### PR TITLE
Update driver code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ colored = "2.0.0"
 bitvec = "1.0.1"
 inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm14-0"] }
 unicode-ident = "1.0.5"
+walkdir = "2"
 
 [lib]
 name = "cobalt"

--- a/src/cobalt/ast.rs
+++ b/src/cobalt/ast.rs
@@ -19,7 +19,7 @@ pub trait AST {
     fn loc(&self) -> Location;
     fn is_const(&self) -> bool {false}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type;
-    fn codegen<'ctx>(&'ctx self, ctx: &'ctx CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>);
+    fn codegen<'ctx>(& self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>);
     fn to_code(&self) -> String;
     fn print_impl(&self, f: &mut Formatter, pre: &mut TreePrefix) -> Result;
 }

--- a/src/cobalt/ast/groups.rs
+++ b/src/cobalt/ast/groups.rs
@@ -6,7 +6,7 @@ pub struct BlockAST {
 impl AST for BlockAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.vals.last().map(|x| x.res_type(ctx)).unwrap_or(Type::Null)}
-    fn codegen<'ctx>(&'ctx self, ctx: &'ctx CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
         ctx.map_vars(|v| Box::new(VarMap::new(Some(v))));
         let mut out = Variable::metaval(InterData::Null, Type::Null);
         let mut errs = vec![];
@@ -48,7 +48,7 @@ pub struct GroupAST {
 impl AST for GroupAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.vals.last().map(|x| x.res_type(ctx)).unwrap_or(Type::Null)}
-    fn codegen<'ctx>(&'ctx self, ctx: &'ctx CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
         let mut out = Variable::metaval(InterData::Null, Type::Null);
         let mut errs = vec![];
         for val in self.vals.iter() {
@@ -88,7 +88,7 @@ pub struct TopLevelAST {
 impl AST for TopLevelAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> Type {Type::Null}
-    fn codegen<'ctx>(&'ctx self, ctx: &'ctx CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
         let mut errs = vec![];
         for val in self.vals.iter() {
             let mut es = val.codegen(ctx).1;

--- a/src/cobalt/ast/literals.rs
+++ b/src/cobalt/ast/literals.rs
@@ -21,7 +21,7 @@ impl AST for IntLiteralAST {
             _ => Type::Null
         }
     }
-    fn codegen<'ctx>(&'ctx self, ctx: &'ctx CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
         match self.suffix.as_ref().map(|x| x.as_str()) {
             None | Some("") => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val), Type::IntLiteral), vec![]),
             Some("isize") => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(64, false)), vec![]),
@@ -71,7 +71,7 @@ impl AST for FloatLiteralAST {
             _ => Type::Null
         }
     }
-    fn codegen<'ctx>(&'ctx self, ctx: &'ctx CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
         match self.suffix.as_ref().map(|x| x.as_str()) {
             None | Some("f64") => (Variable::interpreted(FloatValue(ctx.context.f64_type().const_float(self.val)), InterData::Float(self.val), Type::Float64), vec![]),
             Some("f16") => (Variable::interpreted(FloatValue(ctx.context.f16_type().const_float(self.val)), InterData::Float(self.val), Type::Float16), vec![]),
@@ -115,7 +115,7 @@ impl AST for CharLiteralAST {
             _ => Type::Null
         }
     }
-    fn codegen<'ctx>(&'ctx self, ctx: &'ctx CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
         match self.suffix.as_ref().map(|x| x.as_str()) {
             None | Some("") => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Char), vec![]),
             Some("isize") => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(64, false)), vec![]),
@@ -162,7 +162,7 @@ impl AST for StringLiteralAST {
             Some(_) => Type::Null
         }
     }
-    fn codegen<'ctx>(&'ctx self, ctx: &'ctx CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
         match self.suffix {
             None => (Variable::interpreted(PointerValue(ctx.builder.build_global_string_ptr(self.val.as_str(), "__internals.str").as_pointer_value()), InterData::Str(self.val.clone()), Type::Pointer(Box::new(Type::Char))), vec![]),
             Some(ref x) => (Variable::error(), vec![Error::new(self.loc.clone(), 390, format!("unknown suffix {x} for string literal"))])

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -10,7 +10,7 @@ pub struct VarDefAST {
 impl AST for VarDefAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.val.res_type(ctx)}
-    fn codegen<'ctx>(&'ctx self, ctx: &'ctx CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
         if self.global {
             if self.val.is_const() {
                 let (val, mut errs) = self.val.codegen(ctx);
@@ -111,7 +111,7 @@ pub struct MutDefAST {
 impl AST for MutDefAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.val.res_type(ctx)}
-    fn codegen<'ctx>(&'ctx self, ctx: &'ctx CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
         if self.global {
             if self.val.is_const() {
                 let (val, mut errs) = self.val.codegen(ctx);

--- a/src/cobalt/types.rs
+++ b/src/cobalt/types.rs
@@ -62,7 +62,7 @@ impl Type {
             Borrow(b) => b.align()
         }
     }
-    pub fn llvm_type<'ctx>(&self, ctx: &'ctx CompCtx<'ctx>) -> Option<BasicTypeEnum<'ctx>> {
+    pub fn llvm_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Option<BasicTypeEnum<'ctx>> {
         match self {
             IntLiteral => Some(IntType(ctx.context.i64_type())),
             Int(size, _) => Some(IntType(ctx.context.custom_width_int_type(*size as u32))),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,53 @@
 use colored::Colorize;
+use inkwell::targets::*;
+use std::process::{Command, exit};
+use std::io::Write;
+use std::ffi::OsString;
+use std::path::PathBuf;
 const HELP: &str = "co- Cobalt compiler and build system
 A program can be compiled using the `co aot' subcommand, or JIT compiled using the `co jit' subcommand";
 static mut FILENAME: String = String::new();
+#[derive(Debug, PartialEq, Eq)]
+enum OutputType {
+    Executable,
+    Library,
+    Object,
+    Assembly,
+    LLVM,
+    Bitcode
+}
+const INIT_NEEDED: InitializationConfig = InitializationConfig {
+    asm_parser: false,
+    asm_printer: true,
+    base: true,
+    disassembler: false,
+    info: true,
+    machine_code: true
+};
+fn find_libs<'a>(mut libs: Vec<&'a str>, dirs: Vec<&str>) -> (Vec<PathBuf>, Vec<&'a str>) {
+    let mut outs = vec![];
+    let it = dirs.into_iter().flat_map(|dir| walkdir::WalkDir::new(dir).follow_links(true).into_iter()).filter_map(|x| x.ok()).filter(|x| x.file_type().is_file());
+    it.for_each(|x| {
+        let path = x.into_path();
+        match path.extension().and_then(std::ffi::OsStr::to_str) {
+            Some("a") | Some("so") | Some("dylib") | Some("colib") | Some("dll") | Some("lib") => {},
+            _ => return
+        }
+        if let Some(stem) = path.file_stem().and_then(|x| x.to_str()) {
+            for lib in libs.iter_mut().filter(|x| x.len() > 0) {
+                if lib == &stem || (stem.starts_with("lib") && lib == &&stem[3..]) {
+                    outs.push(path.clone());
+                    *lib = "";
+                }
+            }
+        }
+    });
+    (outs, libs.into_iter().filter(|x| x.len() > 0).collect())
+}
+#[allow(non_snake_case)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ERROR = &"error".bright_red();
+    let WARNING = &"warning".bright_yellow();
     let args: Vec<String> = std::env::args().collect();
     if args.len() == 1 {
         println!("{}", HELP);
@@ -25,17 +70,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         match c {
                             'c' => {
                                 if nfcl {
-                                    eprintln!("{}: reuse of -c flag", "warning".yellow().bold())
+                                    eprintln!("{WARNING}: reuse of -c flag");
                                 }
                                 nfcl = true;
                             }
                             'l' => {
                                 if loc {
-                                    eprintln!("{}: reuse of -l flag", "warning".yellow().bold())
+                                    eprintln!("{WARNING}: reuse of -l flag");
                                 }
                                 loc = true;
                             },
-                            x => eprintln!("{}: unknown flag -{}", "warning".yellow().bold(), x)
+                            x => eprintln!("{WARNING}: unknown flag -{x}")
                         }
                     }
                 }
@@ -44,7 +89,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     nfcl = false;
                     let (toks, errs) = cobalt::parser::lex(arg.as_str(), cobalt::Location::from_name("<command line>"), &flags);
                     for err in errs {
-                        eprintln!("{}: {:#}: {}", if err.code < 100 {"warning".yellow().bold()} else {"error".red().bold()}, err.loc, err.message);
+                        eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {ERROR}, err.loc, err.message);
                         for note in err.notes {
                             eprintln!("\t{}: {:#}: {}", "note".bold(), note.loc, note.message);
                         }
@@ -64,7 +109,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     *fname = arg;
                     let (toks, errs) = cobalt::parser::lex(std::fs::read_to_string(fname.clone())?.as_str(), cobalt::Location::from_name(fname.as_str()), &flags);
                     for err in errs {
-                        eprintln!("{}: {:#}: {}", if err.code < 100 {"warning".yellow().bold()} else {"error".red().bold()}, err.loc, err.message);
+                        eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {ERROR}, err.loc, err.message);
                         for note in err.notes {
                             eprintln!("\t{}: {:#}: {}", "note".bold(), note.loc, note.message);
                         }
@@ -80,7 +125,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             if nfcl {
-                eprintln!("{}: -c switch must be followed by code", "error".red().bold());
+                eprintln!("{ERROR}: -c switch must be followed by code");
             }
         },
         "parse" if cfg!(debug_assertions) => {
@@ -93,17 +138,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         match c {
                             'c' => {
                                 if nfcl {
-                                    eprintln!("{}: reuse of -c flag", "warning".yellow().bold())
+                                    eprintln!("{WARNING}: reuse of -c flag");
                                 }
                                 nfcl = true;
                             }
                             'l' => {
                                 if loc {
-                                    eprintln!("{}: reuse of -l flag", "warning".yellow().bold())
+                                    eprintln!("{WARNING}: reuse of -l flag");
                                 }
                                 loc = true;
                             },
-                            x => eprintln!("{}: unknown flag -{}", "warning".yellow().bold(), x)
+                            x => eprintln!("{WARNING}: unknown flag -{}", x)
                         }
                     }
                 }
@@ -114,7 +159,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let (ast, mut es) = cobalt::parser::parse(toks.as_slice(), &flags);
                     errs.append(&mut es);
                     for err in errs {
-                        eprintln!("{}: {:#}: {}", if err.code < 100 {"warning".yellow().bold()} else {"error".red().bold()}, err.loc, err.message);
+                        eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {ERROR}, err.loc, err.message);
                         for note in err.notes {
                             eprintln!("\t{}: {:#}: {}", "note".bold(), note.loc, note.message);
                         }
@@ -134,7 +179,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let (ast, mut es) = cobalt::parser::parse(toks.as_slice(), &flags);
                     errs.append(&mut es);
                     for err in errs {
-                        eprintln!("{}: {:#}: {}", if err.code < 100 {"warning".yellow().bold()} else {"error".red().bold()}, err.loc, err.message);
+                        eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {ERROR}, err.loc, err.message);
                         for note in err.notes {
                             eprintln!("\t{}: {:#}: {}", "note".bold(), note.loc, note.message);
                         }
@@ -148,7 +193,228 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             if nfcl {
-                eprintln!("{}: -c switch must be followed by code", "error".red().bold());
+                eprintln!("{ERROR}: -c switch must be followed by code");
+            }
+        }
+        "aot" => {
+            let mut output_type: Option<OutputType> = None;
+            let mut in_file: Option<&str> = None;
+            let mut out_file: Option<&str> = None;
+            let mut linked: Vec<&str> = vec![];
+            let mut link_dirs: Vec<&str> = vec![];
+            let mut triple: Option<TargetTriple> = None;
+            {
+                let mut it = args.iter().skip(2).skip_while(|x| x.len() == 0);
+                while let Some(arg) = it.next() {
+                    if arg.as_bytes()[0] == ('-' as u8) {
+                        if arg.as_bytes().len() == 1 {
+                            if in_file.is_some() {
+                                eprintln!("{ERROR}: respecification of input file");
+                                return Ok(())
+                            }
+                            in_file = Some("-");
+                        }
+                        if arg.as_bytes()[1] == ('-' as u8) {
+                            match &arg[2..] {
+                                "emit-asm" => {
+                                    if output_type.is_some() {
+                                        eprintln!("{ERROR}: respecification of output type");
+                                        return Ok(())
+                                    }
+                                    output_type = Some(OutputType::Assembly);
+                                },
+                                "emit-obj" => {
+                                    if output_type.is_some() {
+                                        eprintln!("{ERROR}: respecification of output type");
+                                        return Ok(())
+                                    }
+                                    output_type = Some(OutputType::Object);
+                                },
+                                "emit-llvm" | "emit-ir" => {
+                                    if output_type.is_some() {
+                                        eprintln!("{ERROR}: respecification of output type");
+                                        return Ok(())
+                                    }
+                                    output_type = Some(OutputType::LLVM);
+                                },
+                                "emit-bc" | "emit-bitcode" => {
+                                    if output_type.is_some() {
+                                        eprintln!("{ERROR}: respecification of output type");
+                                        return Ok(())
+                                    }
+                                    output_type = Some(OutputType::Bitcode);
+                                },
+                                "lib" | "emit-lib" => {
+                                    if output_type.is_some() {
+                                        eprintln!("{ERROR}: respecification of output type");
+                                        return Ok(())
+                                    }
+                                    output_type = Some(OutputType::Library);
+                                },
+                                "exe" | "executable" | "emit-exe" => {
+                                    if output_type.is_some() {
+                                        eprintln!("{ERROR}: respecification of output type");
+                                        return Ok(())
+                                    }
+                                    output_type = Some(OutputType::Executable);
+                                },
+                                x => {
+                                    eprintln!("{ERROR}: unknown flag --{x}");
+                                    return Ok(())
+                                }
+                            }
+                        }
+                        else {
+                            for c in arg.chars().skip(1) {
+                                match c {
+                                    'o' => {
+                                        if out_file.is_some() {
+                                            eprintln!("{ERROR}: respecification of input file");
+                                            return Ok(())
+                                        }
+                                        if let Some(x) = it.next() {
+                                            out_file = Some(x.as_str());
+                                        }
+                                        else {
+                                            eprintln!("{ERROR}: expected file after -o flag");
+                                            return Ok(())
+                                        }
+                                    },
+                                    'l' => {
+                                        if let Some(x) = it.next() {
+                                            linked.push(x.as_str());
+                                        }
+                                        else {
+                                            eprintln!("{ERROR}: expected library after -l flag");
+                                            return Ok(())
+                                        }
+                                    },
+                                    'L' => {
+                                        if let Some(x) = it.next() {
+                                            link_dirs.push(x.as_str());
+                                        }
+                                        else {
+                                            eprintln!("{ERROR}: expected directory after -L flag");
+                                            return Ok(())
+                                        }
+                                    },
+                                    't' => {
+                                        if triple.is_some() {
+                                            eprintln!("{ERROR}: respecification of target triple");
+                                            return Ok(())
+                                        }
+                                        if let Some(x) = it.next().map(|x| TargetTriple::create(x)) {
+                                            triple = Some(x);
+                                        }
+                                        else {
+                                            eprintln!("{ERROR}: expected target triple after -t flag");
+                                            return Ok(())
+                                        }
+                                    },
+                                    x => {
+                                        eprintln!("{ERROR}: unknown flag -{x}");
+                                        return Ok(())
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else {
+                        if in_file.is_some() {
+                            eprintln!("{ERROR}: respecification of input file");
+                            return Ok(())
+                        }
+                        in_file = Some(arg.as_str());
+                    }
+                }
+            }
+            if in_file.is_none() {
+                eprintln!("{ERROR}: no input file given");
+                return Ok(())
+            }
+            let in_file = in_file.unwrap();
+            let code = std::fs::read_to_string(in_file)?;
+            let output_type = output_type.unwrap_or(OutputType::Executable);
+            let out_file = out_file.map(String::from).unwrap_or_else(|| match output_type {
+                OutputType::Executable => "a.out".to_string(),
+                OutputType::Library => format!("lib{}.colib", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file)),
+                OutputType::Object => format!("{}.o", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file)),
+                OutputType::Assembly => format!("{}.s", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file)),
+                OutputType::LLVM => format!("{}.ll", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file)),
+                OutputType::Bitcode => format!("{}.bc", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file))
+            });
+            let mut out = if out_file == "-" {Box::new(std::io::stdout()) as Box<dyn Write>} else {Box::new(std::fs::File::create(out_file.as_str())?) as Box<dyn Write>};
+            if triple.is_some() {Target::initialize_all(&INIT_NEEDED)}
+            else {Target::initialize_native(&INIT_NEEDED)?}
+            let triple = triple.unwrap_or_else(TargetMachine::get_default_triple);
+            let flags = cobalt::Flags::default();
+            let fname = unsafe {&mut FILENAME};
+            *fname = in_file.to_string();
+            let (toks, mut errs) = cobalt::parser::lexer::lex(code.as_str(), cobalt::Location::from_name(fname.as_str()), &flags);
+            let (ast, mut es) = cobalt::parser::ast::parse(toks.as_slice(), &flags);
+            errs.append(&mut es);
+            let ink_ctx = inkwell::context::Context::create();
+            let mut ctx = cobalt::context::CompCtx::new(&ink_ctx, fname.as_str());
+            let (_, _) = ast.codegen(&mut ctx);
+            match output_type {
+                OutputType::LLVM => write!(out, "{}", ctx.module.print_to_string())?,
+                OutputType::Bitcode => out.write_all(ctx.module.write_bitcode_to_memory().as_slice())?,
+                _ => {
+                    let target_machine = Target::from_triple(&triple).unwrap().create_target_machine(
+                        &triple,
+                        "",
+                        "",
+                        inkwell::OptimizationLevel::Default,
+                        inkwell::targets::RelocMode::Default,
+                        inkwell::targets::CodeModel::Default
+                    ).expect("failed to create target machine");
+                    if output_type == OutputType::Assembly {
+                        out.write_all(target_machine.write_to_memory_buffer(&ctx.module, inkwell::targets::FileType::Assembly).unwrap().as_slice())?;
+                        return Ok(())
+                    }
+                    let mb = target_machine.write_to_memory_buffer(&ctx.module, inkwell::targets::FileType::Object).unwrap();
+                    match output_type {
+                        OutputType::Executable => {
+                            out.write_all(mb.as_slice())?;
+                            let mut args = vec![OsString::from("-o"), OsString::from(out_file)];
+                            let (libs, notfound) = find_libs(linked, link_dirs);
+                            for nf in notfound.iter() {
+                                eprintln!("couldn't find library {nf}");
+                            }
+                            if notfound.len() > 0 {return Ok(())}
+                            for lib in libs {
+                                let parent = lib.parent().unwrap().as_os_str().to_os_string();
+                                args.push(OsString::from("-L"));
+                                args.push(parent.clone());
+                                args.push(OsString::from("-rpath"));
+                                args.push(parent);
+                                args.push(lib.file_name().unwrap().to_os_string());
+                            }
+                            exit(Command::new("ld").args(args).status().ok().and_then(|x| x.code()).unwrap_or(0))
+                        },
+                        OutputType::Library => {
+                            writeln!(out, "!<arch>")?;
+                            writeln!(out, "file.o          0           0     0     644     {: >10}`", mb.get_size())?;
+                            out.write(mb.as_slice())?;
+                            writeln!(out)?;
+                            let mut buff = format!("{in_file}\00.1.0\0");
+                            let (libs, notfound) = find_libs(linked, link_dirs);
+                            for nf in notfound.iter() {
+                                eprintln!("couldn't find library {nf}");
+                            }
+                            if notfound.len() > 0 {return Ok(())}
+                            for lib in libs {
+                                buff += lib.to_str().expect("library path must be valid UTF-8");
+                                buff.push('\0');
+                            }
+                            buff.push('\0');
+                            writeln!(out, ".colib          0           0     0     644     {: >10}`\n{}", buff.as_bytes().len(), buff)?;
+                            exit(Command::new("ranlib").arg(out_file).status().ok().and_then(|x| x.code()).unwrap_or(0));
+                        },
+                        OutputType::Object => out.write_all(mb.as_slice())?,
+                        x => panic!("{x:?} has already been handled")
+                    }
+                }
             }
         }
         x => {


### PR DESCRIPTION
There is now driver code for the AOT compiler. It can be invoked with the `co aot <input> -o <output>` command.
