### PR TITLE
Implement strings and constants

### DIFF
--- a/src/cobalt/context.rs
+++ b/src/cobalt/context.rs
@@ -7,7 +7,8 @@ pub struct CompCtx<'ctx> {
     vars: Cell<MaybeUninit<Box<VarMap<'ctx>>>>,
     pub context: &'ctx Context,
     pub module: Module<'ctx>,
-    pub builder: Builder<'ctx>
+    pub builder: Builder<'ctx>,
+    pub is_const: Cell<bool>
 }
 impl<'ctx> CompCtx<'ctx> {
     pub fn new(ctx: &'ctx Context, name: &str) -> Self {
@@ -16,7 +17,8 @@ impl<'ctx> CompCtx<'ctx> {
             vars: Cell::new(MaybeUninit::new(Box::default())),
             context: ctx,
             module: ctx.create_module(name),
-            builder: ctx.create_builder()
+            builder: ctx.create_builder(),
+            is_const: Cell::new(false)
         }
     }
     pub fn with_flags(ctx: &'ctx Context, name: &str, flags: Flags) -> Self {
@@ -25,7 +27,8 @@ impl<'ctx> CompCtx<'ctx> {
             vars: Cell::new(MaybeUninit::new(Box::default())),
             context: ctx,
             module: ctx.create_module(name),
-            builder: ctx.create_builder()
+            builder: ctx.create_builder(),
+            is_const: Cell::new(false)
         }
     }
     pub fn with_vars<R, F: FnOnce(&'ctx mut VarMap<'ctx>) -> R>(&self, f: F) -> R {

--- a/src/cobalt/parser/lexer.rs
+++ b/src/cobalt/parser/lexer.rs
@@ -223,7 +223,10 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                                         if let Some(c) = it.next() {
                                             step(flags.up, &mut loc, &c);
                                             if c == '\'' {
-                                                outs.push(Token::new(start, Char('\0')));
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap_or_else(|| {
+                                                    errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                                    '\0'
+                                                }))));
                                                 break 'early_exit false;
                                             }
                                             if let Some(v) = c.to_digit(16) {x |= v;}
@@ -236,7 +239,10 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                                         if let Some(c) = it.next() {
                                             step(flags.up, &mut loc, &c);
                                             if c == '\'' {
-                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap_or_else(|| {
+                                                    errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                                    '\0'
+                                                }))));
                                                 break 'early_exit false;
                                             }
                                             if let Some(v) = c.to_digit(16) {
@@ -252,7 +258,10 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                                         if let Some(c) = it.next() {
                                             step(flags.up, &mut loc, &c);
                                             if c == '\'' {
-                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap_or_else(|| {
+                                                    errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                                    '\0'
+                                                }))));
                                                 break 'early_exit false;
                                             }
                                             if let Some(v) = c.to_digit(16) {
@@ -268,7 +277,10 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                                         if let Some(c) = it.next() {
                                             step(flags.up, &mut loc, &c);
                                             if c == '\'' {
-                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap_or_else(|| {
+                                                    errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                                    '\0'
+                                                }))));
                                                 break 'early_exit false;
                                             }
                                             if let Some(v) = c.to_digit(16) {
@@ -281,14 +293,20 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                                             errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
                                             break 'main;
                                         }
-                                        char::from_u32(x).unwrap()
+                                        char::from_u32(x).unwrap_or_else(|| {
+                                            errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                            '\0'
+                                        })
                                     },
                                     'U' => {
                                         let mut x = 0u32;
                                         if let Some(c) = it.next() {
                                             step(flags.up, &mut loc, &c);
                                             if c == '\'' {
-                                                outs.push(Token::new(start, Char('\0')));
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap_or_else(|| {
+                                                    errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                                    '\0'
+                                                }))));
                                                 break 'early_exit false;
                                             }
                                             if let Some(v) = c.to_digit(16) {x |= v;}
@@ -301,7 +319,86 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                                         if let Some(c) = it.next() {
                                             step(flags.up, &mut loc, &c);
                                             if c == '\'' {
-                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap_or_else(|| {
+                                                    errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                                    '\0'
+                                                }))));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap_or_else(|| {
+                                                    errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                                    '\0'
+                                                }))));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap_or_else(|| {
+                                                    errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                                    '\0'
+                                                }))));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap_or_else(|| {
+                                                    errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                                    '\0'
+                                                }))));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap_or_else(|| {
+                                                    errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                                    '\0'
+                                                }))));
                                                 break 'early_exit false;
                                             }
                                             if let Some(v) = c.to_digit(16) {
@@ -333,7 +430,10 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                                         if let Some(c) = it.next() {
                                             step(flags.up, &mut loc, &c);
                                             if c == '\'' {
-                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap_or_else(|| {
+                                                    errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                                    '\0'
+                                                }))));
                                                 break 'early_exit false;
                                             }
                                             if let Some(v) = c.to_digit(16) {
@@ -346,71 +446,10 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                                             errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
                                             break 'main;
                                         }
-                                        if let Some(c) = it.next() {
-                                            step(flags.up, &mut loc, &c);
-                                            if c == '\'' {
-                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
-                                                break 'early_exit false;
-                                            }
-                                            if let Some(v) = c.to_digit(16) {
-                                                x <<= 4;
-                                                x |= v;
-                                            }
-                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
-                                        }
-                                        else {
-                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
-                                            break 'main;
-                                        }
-                                        if let Some(c) = it.next() {
-                                            step(flags.up, &mut loc, &c);
-                                            if c == '\'' {
-                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
-                                                break 'early_exit false;
-                                            }
-                                            if let Some(v) = c.to_digit(16) {
-                                                x <<= 4;
-                                                x |= v;
-                                            }
-                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
-                                        }
-                                        else {
-                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
-                                            break 'main;
-                                        }
-                                        if let Some(c) = it.next() {
-                                            step(flags.up, &mut loc, &c);
-                                            if c == '\'' {
-                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
-                                                break 'early_exit false;
-                                            }
-                                            if let Some(v) = c.to_digit(16) {
-                                                x <<= 4;
-                                                x |= v;
-                                            }
-                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
-                                        }
-                                        else {
-                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
-                                            break 'main;
-                                        }
-                                        if let Some(c) = it.next() {
-                                            step(flags.up, &mut loc, &c);
-                                            if c == '\'' {
-                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
-                                                break 'early_exit false;
-                                            }
-                                            if let Some(v) = c.to_digit(16) {
-                                                x <<= 4;
-                                                x |= v;
-                                            }
-                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
-                                        }
-                                        else {
-                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
-                                            break 'main;
-                                        }
-                                        char::from_u32(x).unwrap()
+                                        char::from_u32(x).unwrap_or_else(|| {
+                                            errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                            '\0'
+                                        })
                                     },
                                     'n' => '\n',
                                     'r' => '\r',
@@ -418,7 +457,7 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                                     'f' => '\x0c',
                                     'v' => '\x0b',
                                     'e' => '\x1b',
-                                    'a' => '\x0a',
+                                    'a' => '\x07',
                                     x => x
                                 })));
                                 true
@@ -462,6 +501,202 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                     errs.push(Error::new(loc.clone(), 110, "unterminated character literal".to_string()));
                 }
             },
+            '"' => {
+                let start = loc.clone();
+                let mut out = String::new();
+                let mut lwbs = false;
+                step(flags.up, &mut loc, &c);
+                while let Some(c) = it.next() {
+                    step(flags.up, &mut loc, &c);
+                    if lwbs {
+                        out.push(match c {
+                            'x' => {
+                                let mut x = 0u32;
+                                if let Some(c) = it.next() {
+                                    if let Some(v) = c.to_digit(16) {x |= v;}
+                                    else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                }
+                                else {
+                                    errs.push(Error::new(start.clone(), 113, "unterminated string literal".to_string()));
+                                    break 'main;
+                                }
+                                if let Some(c) = it.next() {
+                                    if let Some(v) = c.to_digit(16) {
+                                        x <<= 4;
+                                        x |= v;
+                                    }
+                                    else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                }
+                                else {
+                                    errs.push(Error::new(start.clone(), 113, "unterminated string literal".to_string()));
+                                    break 'main;
+                                }
+                                char::from_u32(x).unwrap()
+                            },
+                            'u' => {
+                                let mut x = 0u32;
+                                if let Some(c) = it.next() {
+                                    if let Some(v) = c.to_digit(16) {x |= v;}
+                                    else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                }
+                                else {
+                                    errs.push(Error::new(start.clone(), 113, "unterminated string literal".to_string()));
+                                    break 'main;
+                                }
+                                if let Some(c) = it.next() {
+                                    if let Some(v) = c.to_digit(16) {
+                                        x <<= 4;
+                                        x |= v;
+                                    }
+                                    else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                }
+                                else {
+                                    errs.push(Error::new(start.clone(), 113, "unterminated string literal".to_string()));
+                                    break 'main;
+                                }
+                                if let Some(c) = it.next() {
+                                    if let Some(v) = c.to_digit(16) {
+                                        x <<= 4;
+                                        x |= v;
+                                    }
+                                    else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                }
+                                else {
+                                    errs.push(Error::new(start.clone(), 113, "unterminated string literal".to_string()));
+                                    break 'main;
+                                }
+                                if let Some(c) = it.next() {
+                                    if let Some(v) = c.to_digit(16) {
+                                        x <<= 4;
+                                        x |= v;
+                                    }
+                                    else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                }
+                                else {
+                                    errs.push(Error::new(start.clone(), 113, "unterminated string literal".to_string()));
+                                    break 'main;
+                                }
+                                char::from_u32(x).unwrap_or_else(|| {
+                                    errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                    '\0'
+                                })
+                            },
+                            'U' => {
+                                let mut x = 0u32;
+                                if let Some(c) = it.next() {
+                                    if let Some(v) = c.to_digit(16) {x |= v;}
+                                    else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                }
+                                else {
+                                    errs.push(Error::new(start.clone(), 113, "unterminated string literal".to_string()));
+                                    break 'main;
+                                }
+                                if let Some(c) = it.next() {
+                                    if let Some(v) = c.to_digit(16) {
+                                        x <<= 4;
+                                        x |= v;
+                                    }
+                                    else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                }
+                                else {
+                                    errs.push(Error::new(start.clone(), 113, "unterminated string literal".to_string()));
+                                    break 'main;
+                                }
+                                if let Some(c) = it.next() {
+                                    if let Some(v) = c.to_digit(16) {
+                                        x <<= 4;
+                                        x |= v;
+                                    }
+                                    else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                }
+                                else {
+                                    errs.push(Error::new(start.clone(), 113, "unterminated string literal".to_string()));
+                                    break 'main;
+                                }
+                                if let Some(c) = it.next() {
+                                    if let Some(v) = c.to_digit(16) {
+                                        x <<= 4;
+                                        x |= v;
+                                    }
+                                    else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                }
+                                else {
+                                    errs.push(Error::new(start.clone(), 113, "unterminated string literal".to_string()));
+                                    break 'main;
+                                }
+                                if let Some(c) = it.next() {
+                                    if let Some(v) = c.to_digit(16) {
+                                        x <<= 4;
+                                        x |= v;
+                                    }
+                                    else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                }
+                                else {
+                                    errs.push(Error::new(start.clone(), 113, "unterminated string literal".to_string()));
+                                    break 'main;
+                                }
+                                if let Some(c) = it.next() {
+                                    if let Some(v) = c.to_digit(16) {
+                                        x <<= 4;
+                                        x |= v;
+                                    }
+                                    else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                }
+                                else {
+                                    errs.push(Error::new(start.clone(), 113, "unterminated string literal".to_string()));
+                                    break 'main;
+                                }
+                                if let Some(c) = it.next() {
+                                    if let Some(v) = c.to_digit(16) {
+                                        x <<= 4;
+                                        x |= v;
+                                    }
+                                    else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                }
+                                else {
+                                    errs.push(Error::new(start.clone(), 113, "unterminated string literal".to_string()));
+                                    break 'main;
+                                }
+                                if let Some(c) = it.next() {
+                                    if let Some(v) = c.to_digit(16) {
+                                        x <<= 4;
+                                        x |= v;
+                                    }
+                                    else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                }
+                                else {
+                                    errs.push(Error::new(start.clone(), 113, "unterminated string literal".to_string()));
+                                    break 'main;
+                                }
+                                char::from_u32(x).unwrap_or_else(|| {
+                                    errs.push(Error::new(loc.clone(), 114, format!("invalid hex character U+{x:<04X}")));
+                                    '\0'
+                                })
+                            },
+                            'n' => '\n',
+                            'r' => '\r',
+                            't' => '\r',
+                            'v' => '\x0b',
+                            'f' => '\x0c',
+                            'e' => '\x1b',
+                            'a' => '\x07',
+                            _ => c
+                        });
+                        lwbs = false;
+                    }
+                    else {
+                        match c {
+                            '"' => {
+                                outs.push(Token::new(start, Str(out)));
+                                continue 'main
+                            },
+                            '\\' => lwbs = true,
+                            _ => out.push(c)
+                        }
+                    }
+                }
+                errs.push(Error::new(start, 113, "unterminated string literal".to_string()));
+            }
             '_' | '$' | _ if is_xid_start(c) => {
                 let mut s = c.to_string();
                 let start = loc.clone();

--- a/src/cobalt/parser/lexer.rs
+++ b/src/cobalt/parser/lexer.rs
@@ -176,11 +176,11 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                 }
             },
             ' ' | '\r' | '\n' | '\t' => {},
-            _ if is_xid_start(c) => {
+            '_' | '$' | _ if is_xid_start(c) => {
                 let mut s = c.to_string();
                 let start = loc.clone();
                 while let Some(c) = it.peek() {
-                    if is_xid_continue(*c) {s.push(*c);}
+                    if *c == '_' || *c == '$' || is_xid_continue(*c) {s.push(*c);}
                     else {break;}
                     step(flags.up, &mut loc, &c);
                     it.next();

--- a/src/cobalt/parser/lexer.rs
+++ b/src/cobalt/parser/lexer.rs
@@ -176,6 +176,292 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                 }
             },
             ' ' | '\r' | '\n' | '\t' => {},
+            '\'' => {
+                if let Some(c) = it.next() {
+                    let start = loc.clone();
+                    step(flags.up, &mut loc, &c);
+                    if match c {
+                        '\\' => 'early_exit: {
+                            if let Some(c) = it.next() {
+                                step(flags.up, &mut loc, &c);
+                                outs.push(Token::new(start.clone(), Char(match c {
+                                    'x' => {
+                                        let mut x = 0u32;
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char('\0')));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {x |= v;}
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        char::from_u32(x).unwrap()
+                                    },
+                                    'u' => {
+                                        let mut x = 0u32;
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char('\0')));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {x |= v;}
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        char::from_u32(x).unwrap()
+                                    },
+                                    'U' => {
+                                        let mut x = 0u32;
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char('\0')));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {x |= v;}
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        if let Some(c) = it.next() {
+                                            step(flags.up, &mut loc, &c);
+                                            if c == '\'' {
+                                                outs.push(Token::new(start, Char(char::from_u32(x).unwrap())));
+                                                break 'early_exit false;
+                                            }
+                                            if let Some(v) = c.to_digit(16) {
+                                                x <<= 4;
+                                                x |= v;
+                                            }
+                                            else {errs.push(Error::new(loc.clone(), 111, format!("unexpected character '{c}' in hex escape sequence")));}
+                                        }
+                                        else {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                        char::from_u32(x).unwrap()
+                                    },
+                                    'n' => '\n',
+                                    'r' => '\r',
+                                    't' => '\t',
+                                    'f' => '\x0c',
+                                    'v' => '\x0b',
+                                    'e' => '\x1b',
+                                    'a' => '\x0a',
+                                    x => x
+                                })));
+                                true
+                            }
+                            else {
+                                errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                false
+                            }
+                        },
+                        '\'' => {
+                            outs.push(Token::new(start.clone(), Char('\0')));
+                            errs.push(Error::new(start.clone(), 20, "empty character literal".to_string()));
+                            false
+                        },
+                        x => {
+                            outs.push(Token::new(start.clone(), Char(x)));
+                            true
+                        },
+                    } {
+                        match it.next() {
+                            Some('\'') => if flags.up {loc.col += 1;},
+                            Some(x) => {
+                                step(flags.up, &mut loc, &x);
+                                errs.push(Error::new(loc.clone(), 112, format!("expected end of character literal, got '{x}'")));
+                                loop {
+                                    match it.next() {
+                                        Some('\'') => break,
+                                        Some(_) => {},
+                                        None => {
+                                            errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()));
+                                            break 'main;
+                                        }
+                                    }
+                                }
+                            },
+                            None => errs.push(Error::new(start.clone(), 110, "unterminated character literal".to_string()))
+                        }
+                    }
+                }
+                else {
+                    errs.push(Error::new(loc.clone(), 110, "unterminated character literal".to_string()));
+                }
+            },
             '_' | '$' | _ if is_xid_start(c) => {
                 let mut s = c.to_string();
                 let start = loc.clone();

--- a/src/cobalt/parser/lexer.rs
+++ b/src/cobalt/parser/lexer.rs
@@ -707,7 +707,7 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                     it.next();
                 }
                 outs.push(Token::new(start, match s.as_str() {
-                    "let" | "mut" | "fn" | "cr" | "module" | "import" | "if" | "else" | "while" => Keyword(s),
+                    "let" | "mut" | "const" | "fn" | "cr" | "module" | "import" | "if" | "else" | "while" => Keyword(s),
                     _ if s.starts_with("__builtin_") => Keyword(s),
                     _ => Identifier(s)
                 }));


### PR DESCRIPTION
- String and character literals are now recognized by the lexer and properly parsed
- `const` specifiers are also recognized for variables and function parameters
- `_` and `$` aren't in XID\_Start and XID\_Continue, so they had to be explicitly added to the lexer
