### PR TITLE
Add 'JIT' and 'check' subcommands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 toml = "0.5.9"
 colored = "2.0.0"
 bitvec = "1.0.1"
-inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm14-0"] }
+inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm14-0", "internal-getters"] }
+llvm-sys = "140"
 unicode-ident = "1.0.5"
 walkdir = "2"
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1,0 +1,94 @@
+use llvm_sys::orc2::{*, lljit::*};
+use llvm_sys::error::*;
+use inkwell::LLVMReference;
+use std::ffi::CString;
+use std::rc::Rc;
+pub type JDL = LLVMOrcJITDylibRef;
+#[derive(Clone)]
+pub struct LLJIT<'ctx>(Rc<LLVMOrcLLJITRef>, std::marker::PhantomData<&'ctx inkwell::context::Context>);
+impl LLJIT<'_> {
+    pub fn new() -> Self {
+        unsafe {
+            let mut jit = std::ptr::null_mut();
+            let builder = LLVMOrcCreateLLJITBuilder();
+            LLVMConsumeError(LLVMOrcCreateLLJIT(&mut jit as *mut LLVMOrcLLJITRef, builder));
+            LLVMOrcDisposeLLJITBuilder(builder);
+            let this = LLJIT(Rc::new(jit), std::marker::PhantomData);
+            this
+        }
+    }
+    pub fn add_module(&self, jdl: JDL, module: inkwell::module::Module) {
+        unsafe {
+            LLVMConsumeError(LLVMOrcLLJITAddLLVMIRModule(*self.0, jdl, LLVMOrcCreateNewThreadSafeModule(module.get_ref(), LLVMOrcCreateNewThreadSafeContext())));
+        }
+    }
+    pub fn add_object(&self, jdl: JDL, obj: inkwell::memory_buffer::MemoryBuffer) {
+        unsafe {
+            LLVMConsumeError(LLVMOrcLLJITAddObjectFile(*self.0, jdl, obj.get_ref()));
+        }
+    }
+    pub fn add_static(&self, jdl: JDL, path: &str) {
+        unsafe {
+            let mut gen = std::ptr::null_mut();
+            LLVMConsumeError(LLVMOrcCreateStaticLibrarySearchGeneratorForPath(
+                &mut gen as *mut _,
+                LLVMOrcLLJITGetObjLinkingLayer(*self.0),
+                path.as_ptr() as *mut i8,
+                inkwell::targets::TargetMachine::get_default_triple().as_ptr()
+            ));
+            LLVMOrcJITDylibAddGenerator(jdl, gen);
+        }
+    }
+    pub fn add_shared(&self, jdl: JDL, path: &str) {
+        unsafe {
+            let mut gen = std::ptr::null_mut();
+            LLVMConsumeError(LLVMOrcCreateDynamicLibrarySearchGeneratorForPath(
+                &mut gen as *mut _,
+                path.as_ptr() as *const i8,
+                0, None, std::ptr::null_mut()
+            ));
+            LLVMOrcJITDylibAddGenerator(jdl, gen);
+        }
+    }
+    pub fn main(&self) -> JDL {
+        unsafe {
+            LLVMOrcLLJITGetMainJITDylib(*self.0)
+        }
+    }
+    pub fn lookup_lib(&self, name: &CString) -> Option<JDL> {
+        unsafe {
+            const NULL: *mut LLVMOrcOpaqueJITDylib = 0 as *mut _;
+            let es = LLVMOrcLLJITGetExecutionSession(*self.0);
+            match LLVMOrcExecutionSessionGetJITDylibByName(es, name.as_bytes().as_ptr() as *const i8) {
+                NULL => None,
+                x => Some(x)
+            }
+        }
+    }
+    pub fn lookup_or_insert_lib(&self, name: &CString) -> JDL {
+        unsafe {
+            let es = LLVMOrcLLJITGetExecutionSession(*self.0);
+            let mut jdl = LLVMOrcExecutionSessionGetJITDylibByName(es, name.as_bytes().as_ptr() as *const i8);
+            if jdl.is_null() {
+                jdl = LLVMOrcExecutionSessionCreateBareJITDylib(es, name.as_bytes().as_ptr() as *const i8);
+            }
+            jdl
+        }
+    }
+    pub fn lookup_main<'jit, T>(&'jit self, name: &CString) -> Option<&'jit T> {
+        let mut addr = 0u64;
+        unsafe {
+            LLVMConsumeError(LLVMOrcLLJITLookup(*self.0, &mut addr as *mut u64, name.as_bytes().as_ptr() as *const i8));
+            (addr as *const T).as_ref()
+        }
+    }
+}
+impl Drop for LLJIT<'_> {
+    fn drop(&mut self) {
+        if Rc::strong_count(&self.0) == 1 {
+            unsafe {
+                LLVMConsumeError(LLVMOrcDisposeLLJIT(*self.0));
+            }
+        }
+    }
+}

--- a/src/libs.rs
+++ b/src/libs.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+pub fn find_libs<'a>(mut libs: Vec<&'a str>, dirs: Vec<&str>) -> (Vec<PathBuf>, Vec<&'a str>) {
+    let mut outs = vec![];
+    let it = dirs.into_iter().flat_map(|dir| walkdir::WalkDir::new(dir).follow_links(true).into_iter()).filter_map(|x| x.ok()).filter(|x| x.file_type().is_file());
+    it.for_each(|x| {
+        let path = x.into_path();
+        match path.extension().and_then(std::ffi::OsStr::to_str) {
+            Some("a") | Some("so") | Some("dylib") | Some("colib") | Some("dll") | Some("lib") => {},
+            _ => return
+        }
+        if let Some(stem) = path.file_stem().and_then(|x| x.to_str()) {
+            for lib in libs.iter_mut().filter(|x| x.len() > 0) {
+                if lib == &stem || (stem.starts_with("lib") && lib == &&stem[3..]) {
+                    outs.push(path.clone());
+                    *lib = "";
+                }
+            }
+        }
+    });
+    (outs, libs.into_iter().filter(|x| x.len() > 0).collect())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,7 +364,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             match output_type {
-                OutputType::LLVM => write!(out, "{}", ctx.module.print_to_string())?,
+                OutputType::LLVM => write!(out, "{}", ctx.module.to_string())?,
                 OutputType::Bitcode => out.write_all(ctx.module.write_bitcode_to_memory().as_slice())?,
                 _ => {
                     let target_machine = Target::from_triple(&triple).unwrap().create_target_machine(

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,8 +46,8 @@ fn find_libs<'a>(mut libs: Vec<&'a str>, dirs: Vec<&str>) -> (Vec<PathBuf>, Vec<
 }
 #[allow(non_snake_case)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let ERROR = &"error".bright_red();
-    let WARNING = &"warning".bright_yellow();
+    let ERROR = &"error".bright_red().bold();
+    let WARNING = &"warning".bright_yellow().bold();
     let args: Vec<String> = std::env::args().collect();
     if args.len() == 1 {
         println!("{}", HELP);

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,19 +333,33 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let flags = cobalt::Flags::default();
             let fname = unsafe {&mut FILENAME};
             *fname = in_file.to_string();
-            let (toks, mut errs) = cobalt::parser::lexer::lex(code.as_str(), cobalt::Location::from_name(fname.as_str()), &flags);
-            let (ast, mut es) = cobalt::parser::ast::parse(toks.as_slice(), &flags);
-            errs.append(&mut es);
-            let ink_ctx = inkwell::context::Context::create();
-            let ctx = cobalt::context::CompCtx::new(&ink_ctx, fname.as_str());
-            let (_, mut es) = ast.codegen(&ctx);
-            errs.append(&mut es);
+            let mut fail = false;
+            let (toks, errs) = cobalt::parser::lexer::lex(code.as_str(), cobalt::Location::from_name(fname.as_str()), &flags);
             for err in errs {
-                eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {ERROR}, err.loc, err.message);
+                eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {fail = true; ERROR}, err.loc, err.message);
                 for note in err.notes {
                     eprintln!("\t{}: {:#}: {}", "note".bold(), note.loc, note.message);
                 }
             }
+            if fail {return Ok(())}
+            let (ast, errs) = cobalt::parser::ast::parse(toks.as_slice(), &flags);
+            for err in errs {
+                eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {fail = true; ERROR}, err.loc, err.message);
+                for note in err.notes {
+                    eprintln!("\t{}: {:#}: {}", "note".bold(), note.loc, note.message);
+                }
+            }
+            if fail {return Ok(())}
+            let ink_ctx = inkwell::context::Context::create();
+            let ctx = cobalt::context::CompCtx::new(&ink_ctx, fname.as_str());
+            let (_, errs) = ast.codegen(&ctx);
+            for err in errs {
+                eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {fail = true; ERROR}, err.loc, err.message);
+                for note in err.notes {
+                    eprintln!("\t{}: {:#}: {}", "note".bold(), note.loc, note.message);
+                }
+            }
+            if fail {return Ok(())}
             match output_type {
                 OutputType::LLVM => write!(out, "{}", ctx.module.to_string())?,
                 OutputType::Bitcode => out.write_all(ctx.module.write_bitcode_to_memory().as_slice())?,
@@ -480,19 +494,33 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let flags = cobalt::Flags::default();
             let fname = unsafe {&mut FILENAME};
             *fname = in_file.to_string();
-            let (toks, mut errs) = cobalt::parser::lexer::lex(code.as_str(), cobalt::Location::from_name(fname.as_str()), &flags);
-            let (ast, mut es) = cobalt::parser::ast::parse(toks.as_slice(), &flags);
-            errs.append(&mut es);
-            let ink_ctx = inkwell::context::Context::create();
-            let mut ctx = cobalt::context::CompCtx::new(&ink_ctx, fname.as_str());
-            let (_, mut es) = ast.codegen(&ctx);
-            errs.append(&mut es);
+            let mut fail = false;
+            let (toks, errs) = cobalt::parser::lexer::lex(code.as_str(), cobalt::Location::from_name(fname.as_str()), &flags);
             for err in errs {
-                eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {ERROR}, err.loc, err.message);
+                eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {fail = true; ERROR}, err.loc, err.message);
                 for note in err.notes {
                     eprintln!("\t{}: {:#}: {}", "note".bold(), note.loc, note.message);
                 }
             }
+            if fail {return Ok(())}
+            let (ast, errs) = cobalt::parser::ast::parse(toks.as_slice(), &flags);
+            for err in errs {
+                eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {fail = true; ERROR}, err.loc, err.message);
+                for note in err.notes {
+                    eprintln!("\t{}: {:#}: {}", "note".bold(), note.loc, note.message);
+                }
+            }
+            if fail {return Ok(())}
+            let ink_ctx = inkwell::context::Context::create();
+            let mut ctx = cobalt::context::CompCtx::new(&ink_ctx, fname.as_str());
+            let (_, errs) = ast.codegen(&ctx);
+            for err in errs {
+                eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {fail = true; ERROR}, err.loc, err.message);
+                for note in err.notes {
+                    eprintln!("\t{}: {:#}: {}", "note".bold(), note.loc, note.message);
+                }
+            }
+            if fail {return Ok(())}
             let (libs, notfound) = libs::find_libs(linked, link_dirs);
             for nf in notfound.iter() {
                 eprintln!("couldn't find library {nf}");


### PR DESCRIPTION
- Two new commands have been added:
  - `co jit` JIT compiles a program
  - `co check` checks the syntax without executing
- `co aot --emit-llvm` now properly prints the module rather than the escaped string
- Warning an error messages are bold
