### PR TITLE
Finish code generation

### DIFF
--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -1,4 +1,7 @@
 use crate::*;
+use std::cell::Cell;
+use inkwell::types::{BasicType, BasicMetadataTypeEnum, BasicTypeEnum::*};
+use inkwell::values::BasicValueEnum::*;
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum ParamType {
     Normal,
@@ -17,8 +20,179 @@ impl FnDefAST {
 }
 impl AST for FnDefAST {
     fn loc(&self) -> Location {self.loc.clone()}
-    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {panic!("code generation has not been implemented")}
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {panic!("code generation has not been implemented")}
+    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
+        let (ret, mut errs) = self.ret.into_type(ctx);
+        let ret = match ret {
+            Ok(t) => t,
+            Err(IntoTypeError::NotAnInt(name)) => {
+                errs.push(Error::new(self.loc.clone(), 311, format!("cannot convert value of type {name} to u64")));
+                Type::Null
+            },
+            Err(IntoTypeError::NotCompileTime) => {
+                errs.push(Error::new(self.loc.clone(), 312, format!("array size cannot be determined at compile time")));
+                Type::Null
+            },
+            Err(IntoTypeError::NotAModule(name)) => {
+                errs.push(Error::new(self.loc.clone(), 320, format!("{name} is not a module")));
+                Type::Null
+            },
+            Err(IntoTypeError::DoesNotExist(name)) => {
+                errs.push(Error::new(self.loc.clone(), 321, format!("{name} does not exist")));
+                Type::Null
+            }
+        };
+        Type::Function(Box::new(ret), self.params.iter().map(|(_, pt, ty, _)| ({
+            let (ty, mut es) = ty.into_type(ctx);
+            errs.append(&mut es);
+            match ty {
+                Ok(t) => t,
+                Err(IntoTypeError::NotAnInt(name)) => {
+                    errs.push(Error::new(self.loc.clone(), 311, format!("cannot convert value of type {name} to u64")));
+                    Type::Null
+                },
+                Err(IntoTypeError::NotCompileTime) => {
+                    errs.push(Error::new(self.loc.clone(), 312, format!("array size cannot be determined at compile time")));
+                    Type::Null
+                },
+                Err(IntoTypeError::NotAModule(name)) => {
+                    errs.push(Error::new(self.loc.clone(), 320, format!("{name} is not a module")));
+                    Type::Null
+                },
+                Err(IntoTypeError::DoesNotExist(name)) => {
+                    errs.push(Error::new(self.loc.clone(), 321, format!("{name} does not exist")));
+                    Type::Null
+                }
+            }
+        }, pt == &ParamType::Constant)).collect())
+    }
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+        let (ret, mut errs) = self.ret.into_type(ctx);
+        let ret = match ret {
+            Ok(t) => t,
+            Err(IntoTypeError::NotAnInt(name)) => {
+                errs.push(Error::new(self.loc.clone(), 311, format!("cannot convert value of type {name} to u64")));
+                Type::Null
+            },
+            Err(IntoTypeError::NotCompileTime) => {
+                errs.push(Error::new(self.loc.clone(), 312, format!("array size cannot be determined at compile time")));
+                Type::Null
+            },
+            Err(IntoTypeError::NotAModule(name)) => {
+                errs.push(Error::new(self.loc.clone(), 320, format!("{name} is not a module")));
+                Type::Null
+            },
+            Err(IntoTypeError::DoesNotExist(name)) => {
+                errs.push(Error::new(self.loc.clone(), 321, format!("{name} does not exist")));
+                Type::Null
+            }
+        };
+        let fty = Type::Function(Box::new(ret), self.params.iter().map(|(_, pt, ty, _)| ({
+            let (ty, mut es) = ty.into_type(ctx);
+            errs.append(&mut es);
+            match ty {
+                Ok(t) => t,
+                Err(IntoTypeError::NotAnInt(name)) => {
+                    errs.push(Error::new(self.loc.clone(), 311, format!("cannot convert value of type {name} to u64")));
+                    Type::Null
+                },
+                Err(IntoTypeError::NotCompileTime) => {
+                    errs.push(Error::new(self.loc.clone(), 312, format!("array size cannot be determined at compile time")));
+                    Type::Null
+                },
+                Err(IntoTypeError::NotAModule(name)) => {
+                    errs.push(Error::new(self.loc.clone(), 320, format!("{name} is not a module")));
+                    Type::Null
+                },
+                Err(IntoTypeError::DoesNotExist(name)) => {
+                    errs.push(Error::new(self.loc.clone(), 321, format!("{name} does not exist")));
+                    Type::Null
+                }
+            }
+        }, pt == &ParamType::Constant)).collect());
+        let old_ip = ctx.builder.get_insert_block();
+        let val = if let Type::Function(ref ret, ref params) = fty {
+            match if let Some(llt) = ret.llvm_type(ctx) {
+                let mut good = true;
+                let ps = params.iter().filter_map(|(x, c)| if *c {None} else {Some(BasicMetadataTypeEnum::from(x.llvm_type(ctx).unwrap_or_else(|| {good = false; IntType(ctx.context.i8_type())})))}).collect::<Vec<_>>();
+                if good && !ctx.is_const.get() {
+                    let ft = llt.fn_type(ps.as_slice(), false);
+                    let f = ctx.module.add_function(format!("{}", self.name).as_str(), ft, None);
+                    let entry = ctx.context.append_basic_block(f, "entry");
+                    ctx.builder.position_at_end(entry);
+                    let (body, mut es) = self.body.codegen(ctx);
+                    errs.append(&mut es);
+                    let err = format!("cannot convert value of type {} to {}", body.data_type, *ret);
+                    ctx.builder.build_return(Some(&types::utils::impl_convert(body, (&**ret).clone(), ctx).and_then(|v| v.comp_val).unwrap_or_else(|| {
+                        errs.push(Error::new(self.loc.clone(), 311, err));
+                        llt.const_zero()
+                    })));
+                    ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
+                        comp_val: Some(PointerValue(f.as_global_value().as_pointer_value())),
+                        inter_val: None, // TODO: constant functions
+                        data_type: fty,
+                        good: Cell::new(true)
+                    })))
+                }
+                else {
+                    ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
+                        comp_val: None,
+                        inter_val: None, // TODO: constant functions
+                        data_type: fty,
+                        good: Cell::new(true)
+                    })))
+                }
+            }
+            else if **ret == Type::Null {
+                let mut good = true;
+                let ps = params.iter().filter_map(|(x, c)| if *c {None} else {Some(BasicMetadataTypeEnum::from(x.llvm_type(ctx).unwrap_or_else(|| {good = false; IntType(ctx.context.i8_type())})))}).collect::<Vec<_>>();
+                if good && !ctx.is_const.get() {
+                    let ft = ctx.context.void_type().fn_type(ps.as_slice(), false);
+                    let f = ctx.module.add_function(format!("{}", self.name).as_str(), ft, None);
+                    let entry = ctx.context.append_basic_block(f, "entry");
+                    ctx.builder.position_at_end(entry);
+                    let (body, mut es) = self.body.codegen(ctx);
+                    errs.append(&mut es);
+                    ctx.builder.build_return(None);
+                    ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
+                        comp_val: Some(PointerValue(f.as_global_value().as_pointer_value())),
+                        inter_val: None, // TODO: constant functions
+                        data_type: fty,
+                        good: Cell::new(true)
+                    })))
+                }
+                else {
+                    ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
+                        comp_val: None,
+                        inter_val: None, // TODO: constant functions
+                        data_type: fty,
+                        good: Cell::new(true)
+                    })))
+                }
+            }
+            else {
+                ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
+                    comp_val: None,
+                    inter_val: None, // TODO: constant functions
+                    data_type: fty,
+                    good: Cell::new(true)
+                })))
+            } {
+                Ok(x) => (x.as_var().unwrap().clone(), errs),
+                Err(RedefVariable::NotAModule(x, _)) => {
+                    errs.push(Error::new(self.loc.clone(), 320, format!("{} is not a module", self.name.start(x))));
+                    (Variable::error(), errs)
+                },
+                Err(RedefVariable::AlreadyExists(x, _)) => {
+                    errs.push(Error::new(self.loc.clone(), 321, format!("{} has already been defined", self.name.start(x))));
+                    (Variable::error(), errs)
+                },
+                Err(RedefVariable::MergeConflict(_, _)) => panic!("merge conflicts shouldn't be reachable when inserting a variable")
+            }
+        } else {panic!("In order for this to be reachable, fty would have to somehow be mutated, which is impossible")}.clone();
+        if let Some(bb) = old_ip {ctx.builder.position_at_end(bb);}
+        else {ctx.builder.clear_insertion_position();}
+        val
+    }
     fn to_code(&self) -> String {
         let mut out = format!("fn {}(", self.name);
         let mut len = self.params.len();

--- a/src/cobalt/ast/literals.rs
+++ b/src/cobalt/ast/literals.rs
@@ -158,13 +158,13 @@ impl AST for StringLiteralAST {
     fn is_const(&self) -> bool {true}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
         match self.suffix {
-            None => Type::Pointer(Box::new(Type::Char)),
+            None => Type::Pointer(Box::new(Type::Char), false),
             Some(_) => Type::Null
         }
     }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
         match self.suffix {
-            None => (Variable::interpreted(PointerValue(ctx.builder.build_global_string_ptr(self.val.as_str(), "__internals.str").as_pointer_value()), InterData::Str(self.val.clone()), Type::Pointer(Box::new(Type::Char))), vec![]),
+            None => (Variable::interpreted(PointerValue(ctx.builder.build_global_string_ptr(self.val.as_str(), "__internals.str").as_pointer_value()), InterData::Str(self.val.clone()), Type::Pointer(Box::new(Type::Char), false)), vec![]),
             Some(ref x) => (Variable::error(), vec![Error::new(self.loc.clone(), 390, format!("unknown suffix {x} for string literal"))])
         }
     }

--- a/src/cobalt/ast/misc.rs
+++ b/src/cobalt/ast/misc.rs
@@ -9,8 +9,37 @@ impl CastAST {
 }
 impl AST for CastAST {
     fn loc(&self) -> Location {self.loc.clone()}
-    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {panic!("code generation has not been implemented")}
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {panic!("code generation has not been implemented")}
+    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.target.into_type(ctx).0.unwrap_or(Type::Null)}
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+        let (val, mut errs) = self.val.codegen(ctx);
+        let (t, mut es) = self.target.into_type(ctx);
+        errs.append(&mut es);
+        let t = match t {
+            Ok(t) => t,
+            Err(IntoTypeError::NotAnInt(name)) => {
+                errs.push(Error::new(self.loc.clone(), 311, format!("cannot convert value of type {name} to u64")));
+                Type::Null
+            },
+            Err(IntoTypeError::NotCompileTime) => {
+                errs.push(Error::new(self.loc.clone(), 312, format!("array size cannot be determined at compile time")));
+                Type::Null
+            },
+            Err(IntoTypeError::NotAModule(name)) => {
+                errs.push(Error::new(self.loc.clone(), 320, format!("{name} is not a module")));
+                Type::Null
+            },
+            Err(IntoTypeError::DoesNotExist(name)) => {
+                errs.push(Error::new(self.loc.clone(), 321, format!("{name} does not exist")));
+                Type::Null
+            }
+        };
+        let err = format!("cannot convert value of type {} to {t}", val.data_type);
+        if let Some(val) = types::utils::expl_convert(val, t, ctx) {(val, errs)}
+        else {
+            errs.push(Error::new(self.loc.clone(), 311, err));
+            (Variable::error(), errs)
+        }
+    }
     fn to_code(&self) -> String {
         format!("{}: {}", self.val.to_code(), self.target)
     }
@@ -27,8 +56,8 @@ impl NullAST {
 }
 impl AST for NullAST {
     fn loc(&self) -> Location {self.loc.clone()}
-    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {panic!("code generation has not been implemented")}
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {panic!("code generation has not been implemented")}
+    fn res_type<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> Type {Type::Null}
+    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {(Variable::metaval(InterData::Null, Type::Null), vec![])}
     fn to_code(&self) -> String {
         "null".to_string()
     }

--- a/src/cobalt/ast/ops.rs
+++ b/src/cobalt/ast/ops.rs
@@ -10,8 +10,27 @@ impl BinOpAST {
 }
 impl AST for BinOpAST {
     fn loc(&self) -> Location {self.loc.clone()}
-    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {panic!("code generation has not been implemented")}
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {panic!("code generation has not been implemented")}
+    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
+        if self.op == "&&" || self.op == "||" {self.rhs.res_type(ctx)}
+        else {types::utils::bin_type(self.lhs.res_type(ctx), self.rhs.res_type(ctx), self.op.as_str())}
+    }
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+        match self.op.as_str() {
+            "&&" => todo!("short-circuiting operators aren't implemented"),
+            "||" => todo!("short-circuiting operators aren't implemented"),
+            x => {
+                let (lhs, mut errs) = self.lhs.codegen(ctx);
+                let (rhs, mut es) = self.rhs.codegen(ctx);
+                errs.append(&mut es);
+                let err = format!("binary operator {} isn't defined for values of {} and {}", self.op, lhs.data_type, rhs.data_type);
+                let val = types::utils::bin_op(lhs, rhs, x, ctx);
+                if val.is_none() {
+                    errs.push(Error::new(self.loc.clone(), 310, err));
+                }
+                (val.unwrap_or_else(Variable::error), errs)
+            }
+        }
+    }
     fn to_code(&self) -> String {
         format!("({} {} {})", self.lhs.to_code(), self.op, self.rhs.to_code())
     }
@@ -31,8 +50,18 @@ impl PostfixAST {
 }
 impl AST for PostfixAST {
     fn loc(&self) -> Location {self.loc.clone()}
-    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {panic!("code generation has not been implemented")}
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {panic!("code generation has not been implemented")}
+    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
+        types::utils::post_type(self.val.res_type(ctx), self.op.as_str())
+    }
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+        let (v, mut errs) = self.val.codegen(ctx);
+        let err = format!("postfix operator {} isn't defined for value of {}", self.op, v.data_type);
+        let val = types::utils::post_op(v, self.op.as_str(), ctx);
+        if val.is_none() {
+            errs.push(Error::new(self.loc.clone(), 310, err));
+        }
+        (val.unwrap_or_else(Variable::error), errs)
+    }
     fn to_code(&self) -> String {
         format!("{}{}", self.val.to_code(), self.op)
     }
@@ -51,8 +80,18 @@ impl PrefixAST {
 }
 impl AST for PrefixAST {
     fn loc(&self) -> Location {self.loc.clone()}
-    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {panic!("code generation has not been implemented")}
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {panic!("code generation has not been implemented")}
+    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
+        types::utils::pre_type(self.val.res_type(ctx), self.op.as_str())
+    }
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+        let (v, mut errs) = self.val.codegen(ctx);
+        let err = format!("prefix operator {} isn't defined for value of {}", self.op, v.data_type);
+        let val = types::utils::pre_op(v, self.op.as_str(), ctx);
+        if val.is_none() {
+            errs.push(Error::new(self.loc.clone(), 310, err));
+        }
+        (val.unwrap_or_else(Variable::error), errs)
+    }
     fn to_code(&self) -> String {
         format!("{}{}", self.op, self.val.to_code())
     }

--- a/src/cobalt/ast/scope.rs
+++ b/src/cobalt/ast/scope.rs
@@ -6,8 +6,8 @@ pub struct ModuleAST {
 }
 impl AST for ModuleAST {
     fn loc(&self) -> Location {self.loc.clone()}
-    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {panic!("code generation has not been implemented")}
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {panic!("code generation has not been implemented")}
+    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {todo!("code generation has not been implemented for module definitions")}
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {todo!("code generation has not been implemented for module definitions")}
     fn to_code(&self) -> String {
         let mut out = format!("module {} {{", self.name);
         let mut count = self.vals.len();
@@ -38,8 +38,8 @@ pub struct ImportAST {
 }
 impl AST for ImportAST {
     fn loc(&self) -> Location {self.loc.clone()}
-    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {panic!("code generation has not been implemented")}
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {panic!("code generation has not been implemented")}
+    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {todo!("code generation has not been implemented for imports")}
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {todo!("code generation has not been implemented for imports")}
     fn to_code(&self) -> String {
         format!("import {}", self.name)
     }

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -5,6 +5,7 @@ pub struct VarDefAST {
     loc: Location,
     pub name: DottedName,
     pub val: Box<dyn AST>,
+    pub type_: Option<ParsedType>,
     pub global: bool
 }
 impl AST for VarDefAST {
@@ -14,15 +15,40 @@ impl AST for VarDefAST {
         if self.global {
             if self.val.is_const() {
                 let (val, mut errs) = self.val.codegen(ctx);
+                let t2 = val.data_type.clone();
+                let (dt, err) = if let Some(t) = self.type_.as_ref().and_then(|t| {
+                    let (t, mut es) = t.into_type(ctx);
+                    errs.append(&mut es);
+                    let t = match t {
+                        Ok(t) => Some(t),
+                        Err(IntoTypeError::NotAnInt(name)) => {
+                            errs.push(Error::new(self.loc.clone(), 311, format!("cannot convert value of type {name} to u64")));
+                            None
+                        },
+                        Err(IntoTypeError::NotCompileTime) => {
+                            errs.push(Error::new(self.loc.clone(), 312, format!("array size cannot be determined at compile time")));
+                            None
+                        },
+                        Err(IntoTypeError::NotAModule(name)) => {
+                            errs.push(Error::new(self.loc.clone(), 320, format!("{name} is not a module")));
+                            None
+                        },
+                        Err(IntoTypeError::DoesNotExist(name)) => {
+                            errs.push(Error::new(self.loc.clone(), 321, format!("{name} does not exist")));
+                            None
+                        }
+                    };
+                    t.map(|x| (x.clone(), format!("cannot convert value of type {} to {x}", t2)))
+                }) {t} else if let Type::Reference(b, _) = t2 {(*b, "INFALLIBLE".to_string())} else {(t2, "INFALLIBLE".to_string())};
                 match if let Some(v) = val.comp_val {
-                    let t = val.data_type.llvm_type(ctx).unwrap();
+                    let t = dt.llvm_type(ctx).unwrap();
                     let gv = ctx.module.add_global(t, None, format!("{}", self.name).as_str());
                     gv.set_constant(true);
                     gv.set_initializer(&v);
                     ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
                         comp_val: Some(PointerValue(gv.as_pointer_value())),
                         inter_val: val.inter_val,
-                        data_type: val.data_type,
+                        data_type: Type::Reference(Box::new(dt), false),
                         good: Cell::new(true)
                     })))
                 }
@@ -46,13 +72,42 @@ impl AST for VarDefAST {
                 let mut errs;
                 match if let Some(t) = t.llvm_type(ctx) {
                     let gv = ctx.module.add_global(t, None, format!("{}", self.name).as_str());
-                    gv.set_constant(true);
+                    gv.set_constant(false);
                     let f = ctx.module.add_function(format!("__internals.init.{}", self.name).as_str(), ctx.context.void_type().fn_type(&[], false), Some(inkwell::module::Linkage::Private));
                     let entry = ctx.context.append_basic_block(f, "entry");
                     let old_ip = ctx.builder.get_insert_block();
                     ctx.builder.position_at_end(entry);
                     let (val, es) = self.val.codegen(ctx);
                     errs = es;
+                    let t2 = val.data_type.clone();
+                    let (dt, err) = if let Some(t) = self.type_.as_ref().and_then(|t| {
+                        let (t, mut es) = t.into_type(ctx);
+                        errs.append(&mut es);
+                        let t = match t {
+                            Ok(t) => Some(t),
+                            Err(IntoTypeError::NotAnInt(name)) => {
+                                errs.push(Error::new(self.loc.clone(), 311, format!("cannot convert value of type {name} to u64")));
+                                None
+                            },
+                            Err(IntoTypeError::NotCompileTime) => {
+                                errs.push(Error::new(self.loc.clone(), 312, format!("array size cannot be determined at compile time")));
+                                None
+                            },
+                            Err(IntoTypeError::NotAModule(name)) => {
+                                errs.push(Error::new(self.loc.clone(), 320, format!("{name} is not a module")));
+                                None
+                            },
+                            Err(IntoTypeError::DoesNotExist(name)) => {
+                                errs.push(Error::new(self.loc.clone(), 321, format!("{name} does not exist")));
+                                None
+                            }
+                        };
+                        t.map(|x| (x.clone(), format!("cannot convert value of type {} to {x}", t2)))
+                    }) {t} else if let Type::Reference(b, _) = t2 {(*b, "INFALLIBLE".to_string())} else {(t2, "INFALLIBLE".to_string())};
+                    let val = types::utils::impl_convert(val, dt.clone(), ctx).unwrap_or_else(|| {
+                        errs.push(Error::new(self.loc.clone(), 311, err));
+                        Variable::error()
+                    });
                     if let Some(v) = val.comp_val {
                         ctx.builder.build_store(gv.as_pointer_value(), v);
                         ctx.builder.build_return(None);
@@ -61,7 +116,7 @@ impl AST for VarDefAST {
                         ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
                             comp_val: Some(PointerValue(gv.as_pointer_value())),
                             inter_val: val.inter_val,
-                            data_type: val.data_type,
+                            data_type: Type::Reference(Box::new(dt), false),
                             good: Cell::new(true)
                         })))
                     }
@@ -96,7 +151,7 @@ impl AST for VarDefAST {
         }
     }
     fn to_code(&self) -> String {
-        format!("let {} = {}", self.name, self.val.to_code())
+        format!("let {}{} = {}", self.name, self.type_.as_ref().map_or("".to_string(), |t| format!(": {t}")), self.val.to_code())
     }
     fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix) -> std::fmt::Result {
         writeln!(f, "vardef: {}", self.name)?;
@@ -104,12 +159,13 @@ impl AST for VarDefAST {
     }
 }
 impl VarDefAST {
-    pub fn new(loc: Location, name: DottedName, val: Box<dyn AST>, global: bool) -> Self {VarDefAST {loc, name, val, global}}
+    pub fn new(loc: Location, name: DottedName, val: Box<dyn AST>, type_: Option<ParsedType>, global: bool) -> Self {VarDefAST {loc, name, val, type_, global}}
 }
 pub struct MutDefAST {
     loc: Location,
     pub name: DottedName,
     pub val: Box<dyn AST>,
+    pub type_: Option<ParsedType>,
     pub global: bool
 }
 impl AST for MutDefAST {
@@ -119,15 +175,40 @@ impl AST for MutDefAST {
         if self.global {
             if self.val.is_const() {
                 let (val, mut errs) = self.val.codegen(ctx);
+                let t2 = val.data_type.clone();
+                let (dt, err) = if let Some(t) = self.type_.as_ref().and_then(|t| {
+                    let (t, mut es) = t.into_type(ctx);
+                    errs.append(&mut es);
+                    let t = match t {
+                        Ok(t) => Some(t),
+                        Err(IntoTypeError::NotAnInt(name)) => {
+                            errs.push(Error::new(self.loc.clone(), 311, format!("cannot convert value of type {name} to u64")));
+                            None
+                        },
+                        Err(IntoTypeError::NotCompileTime) => {
+                            errs.push(Error::new(self.loc.clone(), 312, format!("array size cannot be determined at compile time")));
+                            None
+                        },
+                        Err(IntoTypeError::NotAModule(name)) => {
+                            errs.push(Error::new(self.loc.clone(), 320, format!("{name} is not a module")));
+                            None
+                        },
+                        Err(IntoTypeError::DoesNotExist(name)) => {
+                            errs.push(Error::new(self.loc.clone(), 321, format!("{name} does not exist")));
+                            None
+                        }
+                    };
+                    t.map(|x| (x.clone(), format!("cannot convert value of type {} to {x}", t2)))
+                }) {t} else if let Type::Reference(b, _) = t2 {(*b, "INFALLIBLE".to_string())} else {(t2, "INFALLIBLE".to_string())};
                 match if let Some(v) = val.comp_val {
-                    let t = val.data_type.llvm_type(ctx).unwrap();
+                    let t = dt.llvm_type(ctx).unwrap();
                     let gv = ctx.module.add_global(t, None, format!("{}", self.name).as_str());
                     gv.set_constant(false);
                     gv.set_initializer(&v);
                     ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
                         comp_val: Some(PointerValue(gv.as_pointer_value())),
                         inter_val: val.inter_val,
-                        data_type: val.data_type,
+                        data_type: Type::Reference(Box::new(dt), true),
                         good: Cell::new(true)
                     })))
                 }
@@ -158,6 +239,35 @@ impl AST for MutDefAST {
                     ctx.builder.position_at_end(entry);
                     let (val, es) = self.val.codegen(ctx);
                     errs = es;
+                    let t2 = val.data_type.clone();
+                    let (dt, err) = if let Some(t) = self.type_.as_ref().and_then(|t| {
+                        let (t, mut es) = t.into_type(ctx);
+                        errs.append(&mut es);
+                        let t = match t {
+                            Ok(t) => Some(t),
+                            Err(IntoTypeError::NotAnInt(name)) => {
+                                errs.push(Error::new(self.loc.clone(), 311, format!("cannot convert value of type {name} to u64")));
+                                None
+                            },
+                            Err(IntoTypeError::NotCompileTime) => {
+                                errs.push(Error::new(self.loc.clone(), 312, format!("array size cannot be determined at compile time")));
+                                None
+                            },
+                            Err(IntoTypeError::NotAModule(name)) => {
+                                errs.push(Error::new(self.loc.clone(), 320, format!("{name} is not a module")));
+                                None
+                            },
+                            Err(IntoTypeError::DoesNotExist(name)) => {
+                                errs.push(Error::new(self.loc.clone(), 321, format!("{name} does not exist")));
+                                None
+                            }
+                        };
+                        t.map(|x| (x.clone(), format!("cannot convert value of type {} to {x}", t2)))
+                    }) {t} else if let Type::Reference(b, _) = t2 {(*b, "INFALLIBLE".to_string())} else {(t2, "INFALLIBLE".to_string())};
+                    let val = types::utils::impl_convert(val, dt.clone(), ctx).unwrap_or_else(|| {
+                        errs.push(Error::new(self.loc.clone(), 311, err));
+                        Variable::error()
+                    });
                     if let Some(v) = val.comp_val {
                         ctx.builder.build_store(gv.as_pointer_value(), v);
                         ctx.builder.build_return(None);
@@ -166,7 +276,7 @@ impl AST for MutDefAST {
                         ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
                             comp_val: Some(PointerValue(gv.as_pointer_value())),
                             inter_val: val.inter_val,
-                            data_type: val.data_type,
+                            data_type: Type::Reference(Box::new(dt), true),
                             good: Cell::new(true)
                         })))
                     }
@@ -201,7 +311,7 @@ impl AST for MutDefAST {
         }
     }
     fn to_code(&self) -> String {
-        format!("mut {} = {}", self.name, self.val.to_code())
+        format!("mut {}{} = {}", self.name, self.type_.as_ref().map_or("".to_string(), |t| format!(": {t}")), self.val.to_code())
     }
     fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix) -> std::fmt::Result {
         writeln!(f, "mutdef: {}", self.name)?;
@@ -209,7 +319,7 @@ impl AST for MutDefAST {
     }
 }
 impl MutDefAST {
-    pub fn new(loc: Location, name: DottedName, val: Box<dyn AST>, global: bool) -> Self {MutDefAST {loc, name, val, global}}
+    pub fn new(loc: Location, name: DottedName, val: Box<dyn AST>, type_: Option<ParsedType>, global: bool) -> Self {MutDefAST {loc, name, val, type_, global}}
 }
 pub struct VarGetAST {
     loc: Location,
@@ -245,6 +355,7 @@ pub struct ConstDefAST {
     loc: Location,
     pub name: DottedName,
     pub val: Box<dyn AST>,
+    pub type_: Option<ParsedType>
 }
 impl AST for ConstDefAST {
     fn loc(&self) -> Location {self.loc.clone()}
@@ -252,6 +363,35 @@ impl AST for ConstDefAST {
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
         let old_is_const = ctx.is_const.replace(true);
         let (val, mut errs) = self.val.codegen(ctx);
+        let t2 = val.data_type.clone();
+        let (dt, err) = if let Some(t) = self.type_.as_ref().and_then(|t| {
+            let (t, mut es) = t.into_type(ctx);
+            errs.append(&mut es);
+            let t = match t {
+                Ok(t) => Some(t),
+                Err(IntoTypeError::NotAnInt(name)) => {
+                    errs.push(Error::new(self.loc.clone(), 311, format!("cannot convert value of type {name} to u64")));
+                    None
+                },
+                Err(IntoTypeError::NotCompileTime) => {
+                    errs.push(Error::new(self.loc.clone(), 312, format!("array size cannot be determined at compile time")));
+                    None
+                },
+                Err(IntoTypeError::NotAModule(name)) => {
+                    errs.push(Error::new(self.loc.clone(), 320, format!("{name} is not a module")));
+                    None
+                },
+                Err(IntoTypeError::DoesNotExist(name)) => {
+                    errs.push(Error::new(self.loc.clone(), 321, format!("{name} does not exist")));
+                    None
+                }
+            };
+            t.map(|x| (x.clone(), format!("cannot convert value of type {} to {x}", t2)))
+        }) {t} else if let Type::Reference(b, _) = t2 {(*b, "INFALLIBLE".to_string())} else {(t2, "INFALLIBLE".to_string())};
+        let val = types::utils::impl_convert(val, dt.clone(), ctx).unwrap_or_else(|| {
+            errs.push(Error::new(self.loc.clone(), 311, err));
+            Variable::error()
+        });
         ctx.is_const.set(old_is_const);
         match ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(val))) {
             Ok(x) => (x.as_var().unwrap().clone(), errs),
@@ -267,7 +407,7 @@ impl AST for ConstDefAST {
         }
     }
     fn to_code(&self) -> String {
-        format!("const {} = {}", self.name, self.val.to_code())
+        format!("const {}{} = {}", self.name, self.type_.as_ref().map_or("".to_string(), |t| format!(": {t}")), self.val.to_code())
     }
     fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix) -> std::fmt::Result {
         writeln!(f, "constdef: {}", self.name)?;
@@ -275,5 +415,5 @@ impl AST for ConstDefAST {
     }
 }
 impl ConstDefAST {
-    pub fn new(loc: Location, name: DottedName, val: Box<dyn AST>) -> Self {ConstDefAST {loc, name, val}}
+    pub fn new(loc: Location, name: DottedName, val: Box<dyn AST>, type_: Option<ParsedType>) -> Self {ConstDefAST {loc, name, val, type_}}
 }

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use inkwell::values::BasicValueEnum::*;
-use std::{cell::Cell, rc::Rc};
+use std::cell::Cell;
 pub struct VarDefAST {
     loc: Location,
     pub name: DottedName,
@@ -23,7 +23,7 @@ impl AST for VarDefAST {
                         comp_val: Some(PointerValue(gv.as_pointer_value())),
                         inter_val: val.inter_val,
                         data_type: val.data_type,
-                        good: Rc::new(Cell::new(true))
+                        good: Cell::new(true)
                     })))
                 }
                 else {
@@ -58,7 +58,7 @@ impl AST for VarDefAST {
                             comp_val: Some(PointerValue(gv.as_pointer_value())),
                             inter_val: val.inter_val,
                             data_type: val.data_type,
-                            good: Rc::new(Cell::new(true))
+                            good: Cell::new(true)
                         })))
                     }
                     else {
@@ -124,7 +124,7 @@ impl AST for MutDefAST {
                         comp_val: Some(PointerValue(gv.as_pointer_value())),
                         inter_val: val.inter_val,
                         data_type: val.data_type,
-                        good: Rc::new(Cell::new(true))
+                        good: Cell::new(true)
                     })))
                 }
                 else {
@@ -159,7 +159,7 @@ impl AST for MutDefAST {
                             comp_val: Some(PointerValue(gv.as_pointer_value())),
                             inter_val: val.inter_val,
                             data_type: val.data_type,
-                            good: Rc::new(Cell::new(true))
+                            good: Cell::new(true)
                         })))
                     }
                     else {

--- a/src/cobalt/lib.rs
+++ b/src/cobalt/lib.rs
@@ -15,7 +15,7 @@ pub use error::*;
 pub use misc::*;
 pub use context::*;
 pub use ast::AST;
-pub use types::Type;
+pub use types::{Type, SizeType};
 pub use varmap::*;
 pub(crate) use ast::*;
 pub(crate) use parsed_type::ParsedType;

--- a/src/cobalt/lib.rs
+++ b/src/cobalt/lib.rs
@@ -9,7 +9,7 @@ pub mod dottedname;
 pub mod parsed_type;
 pub mod varmap;
 
-pub use parser::lexer::{lex, Token, TokenData, TokenData::*};
+pub use parser::lexer::{lex, Token, TokenData};
 pub use dottedname::*;
 pub use error::*;
 pub use misc::*;
@@ -18,4 +18,4 @@ pub use ast::AST;
 pub use types::{Type, SizeType};
 pub use varmap::*;
 pub(crate) use ast::*;
-pub(crate) use parsed_type::ParsedType;
+pub(crate) use parsed_type::*;

--- a/src/cobalt/types.rs
+++ b/src/cobalt/types.rs
@@ -51,7 +51,7 @@ impl Display for Type {
                 let len = args.len();
                 for (arg, ty) in args.iter() {
                     write!(f, "{}{}", match ty {
-                        true => "mut ",
+                        true => "const ",
                         false => ""
                     }, arg)?;
                     if len > 1 {write!(f, ", ")?}

--- a/src/cobalt/types.rs
+++ b/src/cobalt/types.rs
@@ -111,7 +111,7 @@ impl Type {
             Null | Function(..) | Module | TypeData => None,
             Array(_, Some(_)) => todo!("arrays aren't implemented yet"),
             Array(_, None) => todo!("arrays aren't implemented yet"),
-            Pointer(b, _) | Reference(b, _) => Some(PointerType(b.llvm_type(ctx)?.ptr_type(inkwell::AddressSpace::Generic))),
+            Pointer(b, _) | Reference(b, _) => Some(PointerType(b.llvm_type(ctx)?.ptr_type(inkwell::AddressSpace::from(0u16)))),
             Borrow(b) => b.llvm_type(ctx)
         }
     }

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -1,0 +1,1435 @@
+use crate::*;
+use std::cmp::{min, max};
+use std::cell::Cell;
+use inkwell::values::BasicValueEnum::*;
+use inkwell::types::BasicType;
+pub fn bin_type(lhs: Type, rhs: Type, op: &str) -> Type {
+    match (lhs, rhs) {
+        (l, Type::Reference(x, _) | Type::Borrow(x)) => bin_type(l, *x, op),
+        (Type::Int(ls, lu), Type::Int(rs, ru)) => match op {
+            "+" | "-" | "*" | "/" | "%" | "&" | "|" | "^" | "<<" | ">>" | "^^" => Type::Int(max(ls, rs), lu && ru),
+            _ => Type::Null
+        },
+        (x @ Type::Int(..), Type::IntLiteral) | (Type::IntLiteral, x @ Type::Int(..)) => match op {
+            "+" | "-" | "*" | "/" | "%" | "&" | "|" | "^" | "<<" | ">>" | "^^" => x,
+            _ => Type::Null
+        },
+        (Type::IntLiteral, Type::IntLiteral) => match op {
+            "+" | "-" | "*" | "/" | "%" | "&" | "|" | "^" | "<<" | ">>" | "^^" => Type::IntLiteral,
+            _ => Type::Null
+        },
+        (Type::Int(..) | Type::IntLiteral, x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128)) | (x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128), Type::Int(..) | Type::IntLiteral) => match op {
+            "+" | "-" | "*" | "/" | "%" => x,
+            _ => Type::Null
+        },
+        (Type::Float16, Type::Float16) => match op {
+            "+" | "-" | "*" | "/" | "%" => Type::Float16,
+            _ => Type::Null
+        },
+        (Type::Float32, Type::Float16 | Type::Float32) | (Type::Float16, Type::Float32) => match op {
+            "+" | "-" | "*" | "/" | "%" => Type::Float32,
+            _ => Type::Null
+        },
+        (Type::Float64, Type::Float16 | Type::Float32 | Type::Float64) | (Type::Float16 | Type::Float32, Type::Float64) => match op {
+            "+" | "-" | "*" | "/" | "%" => Type::Float64,
+            _ => Type::Null
+        },
+        (Type::Float128, Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) | (Type::Float16 | Type::Float32 | Type::Float64, Type::Float128) => match op {
+            "+" | "-" | "*" | "/" | "%" => Type::Float128,
+            _ => Type::Null
+        },
+        (x @ Type::Pointer(..), Type::IntLiteral | Type::Int(..)) | (Type::IntLiteral | Type::Int(..), x @ Type::Pointer(..)) => match op {
+            "+" | "-" => x,
+            _ => Type::Null
+        }
+        (Type::Reference(x, true), r) => match (*x, r) {
+            (Type::IntLiteral, _) => panic!("There shouldn't be a reference to an integer literal"),
+            (x @ Type::Int(..), r @ (Type::IntLiteral | Type::Int(..))) => match op {
+                "=" | "+=" | "-=" | "*=" | "/=" | "%=" | "&=" | "|=" | "^=" | "<<=" | ">>=" | "^^=" => Type::Reference(Box::new(x), true),
+                _ => bin_type(x, r, op)
+            },
+            (x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128), r @ (Type::IntLiteral | Type::Int(..) | Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128)) => match op {
+                "=" | "+=" | "-=" | "*=" | "/=" | "%=" | "^^=" => Type::Reference(Box::new(x), true),
+                _ => bin_type(x, r, op)
+            },
+            (x @ Type::Pointer(..), r @ (Type::IntLiteral | Type::Int(..))) => match op {
+                "+=" | "-=" => Type::Reference(Box::new(x), true),
+                _ => bin_type(x, r, op)
+            },
+            (x @ Type::Pointer(..), y @ Type::Pointer(..)) if x == y => match op {
+                "=" => Type::Reference(Box::new(x), true),
+                _ => bin_type(x, y, op)
+            },
+            (x, r) => bin_type(x, r, op)
+        },
+        (Type::Reference(x, false) | Type::Borrow(x), r) => bin_type(*x, r, op),
+        _ => Type::Null
+    }
+}
+pub fn pre_type(val: Type, op: &str) -> Type {
+    match val {
+        Type::Reference(x, true) => match *x {
+            Type::IntLiteral => panic!("There shouldn't be a reference to an integer literal"),
+            x @ (Type::Int(..) | Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128 | Type::Pointer(..)) => match op {
+                "++" | "--" => Type::Reference(Box::new(x), true),
+                _ => Type::Null
+            }
+            x => pre_type(x, op)
+        }
+        Type::Reference(x, false) | Type::Borrow(x) => pre_type(*x, op),
+        x @ (Type::IntLiteral | Type::Int(..)) => match op {
+            "+" | "-" | "~" => x,
+            _ => Type::Null
+        },
+        x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => match op {
+            "+" | "-" => x,
+            _ => Type::Null
+        }
+        Type::Pointer(b, c) => match op {
+            "+" | "-" => Type::Pointer(b, c),
+            "*" => Type::Reference(b, c),
+            _ => Type::Null
+        }
+        _ => Type::Null
+    }
+}
+pub fn post_type(val: Type, op: &str) -> Type {
+    match val {
+        Type::Reference(x, _) | Type::Borrow(x) => post_type(*x, op),
+        _ => Type::Null
+    }
+}
+pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> Option<Variable<'ctx>> {
+    match (lhs.data_type, rhs.data_type) {
+        (Type::Borrow(l), r) => {
+            lhs.data_type = *l;
+            rhs.data_type = r;
+            bin_op(lhs, rhs, op, ctx)
+        },
+        (l, Type::Borrow(r)) => {
+            lhs.data_type = l;
+            rhs.data_type = *r;
+            bin_op(lhs, rhs, op, ctx)
+        },
+        (Type::Reference(l, false), r) => {
+            lhs.data_type = *l;
+            rhs.data_type = r;
+            if lhs.data_type.register() {
+                if let Some(v) = lhs.comp_val {
+                    lhs.comp_val = Some(ctx.builder.build_load(v.into_pointer_value(), ""));
+                }
+            }
+            bin_op(lhs, rhs, op, ctx)
+        },
+        (l, Type::Reference(r, _)) => {
+            lhs.data_type = l;
+            rhs.data_type = *r;
+            if rhs.data_type.register() {
+                if let Some(v) = rhs.comp_val {
+                    rhs.comp_val = Some(ctx.builder.build_load(v.into_pointer_value(), ""));
+                }
+            }
+            bin_op(lhs, rhs, op, ctx)
+        },
+        (Type::Reference(l, true), r) => match (*l, r) {
+            (Type::IntLiteral, _) => panic!("There shouldn't be a reference to an integer literal"),
+            (l @ Type::Int(..), r @ (Type::IntLiteral | Type::Int(..))) => match op {
+                "=" => {
+                    lhs.data_type = Type::Reference(Box::new(l), true);
+                    rhs.data_type = r;
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(r)) => {ctx.builder.build_store(l, r);}
+                        _ => {}
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    Some(lhs)
+                },
+                "+=" => {
+                    lhs.data_type = Type::Reference(Box::new(l), true);
+                    rhs.data_type = r;
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(r)) => {
+                            let v1 = ctx.builder.build_load(l, "").into_int_value();
+                            let v2 = ctx.builder.build_int_add(v1, r.into_int_value(), "");
+                            ctx.builder.build_store(l, v2);
+                        },
+                        _ => {}
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    Some(lhs)
+                },
+                "-=" => {
+                    lhs.data_type = Type::Reference(Box::new(l), true);
+                    rhs.data_type = r;
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(r)) => {
+                            let v1 = ctx.builder.build_load(l, "").into_int_value();
+                            let v2 = ctx.builder.build_int_sub(v1, r.into_int_value(), "");
+                            ctx.builder.build_store(l, v2);
+                        },
+                        _ => {}
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    Some(lhs)
+                },
+                "*=" => {
+                    lhs.data_type = Type::Reference(Box::new(l), true);
+                    rhs.data_type = r;
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(r)) => {
+                            let v1 = ctx.builder.build_load(l, "").into_int_value();
+                            let v2 = ctx.builder.build_int_mul(v1, r.into_int_value(), "");
+                            ctx.builder.build_store(l, v2);
+                        },
+                        _ => {}
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    Some(lhs)
+                },
+                "/=" => {
+                    lhs.data_type = Type::Reference(Box::new(l), true);
+                    let unsigned = if let Type::Int(s, true) = r {rhs.data_type = Type::Int(s, true); true}
+                    else {rhs.data_type = r; false};
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(r)) => {
+                            let v1 = ctx.builder.build_load(l, "").into_int_value();
+                            let v2 = if unsigned {ctx.builder.build_int_unsigned_div(v1, r.into_int_value(), "")} else {ctx.builder.build_int_signed_div(v1, r.into_int_value(), "")};
+                            ctx.builder.build_store(l, v2);
+                        },
+                        _ => {}
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    Some(lhs)
+                },
+                "%=" => {
+                    lhs.data_type = Type::Reference(Box::new(l), true);
+                    let unsigned = if let Type::Int(s, true) = r {rhs.data_type = Type::Int(s, true); true}
+                    else {rhs.data_type = r; false};
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(r)) => {
+                            let v1 = ctx.builder.build_load(l, "").into_int_value();
+                            let v2 = if unsigned {ctx.builder.build_int_unsigned_rem(v1, r.into_int_value(), "")} else {ctx.builder.build_int_signed_rem(v1, r.into_int_value(), "")};
+                            ctx.builder.build_store(l, v2);
+                        },
+                        _ => {}
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    Some(lhs)
+                },
+                "&=" => {
+                    lhs.data_type = Type::Reference(Box::new(l), true);
+                    rhs.data_type = r;
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(r)) => {
+                            let v1 = ctx.builder.build_load(l, "").into_int_value();
+                            let v2 = ctx.builder.build_and(v1, r.into_int_value(), "");
+                            ctx.builder.build_store(l, v2);
+                        },
+                        _ => {}
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    Some(lhs)
+                },
+                "|=" => {
+                    lhs.data_type = Type::Reference(Box::new(l), true);
+                    rhs.data_type = r;
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(r)) => {
+                            let v1 = ctx.builder.build_load(l, "").into_int_value();
+                            let v2 = ctx.builder.build_or(v1, r.into_int_value(), "");
+                            ctx.builder.build_store(l, v2);
+                        },
+                        _ => {}
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    Some(lhs)
+                },
+                "^=" => {
+                    lhs.data_type = Type::Reference(Box::new(l), true);
+                    rhs.data_type = r;
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(r)) => {
+                            let v1 = ctx.builder.build_load(l, "").into_int_value();
+                            let v2 = ctx.builder.build_xor(v1, r.into_int_value(), "");
+                            ctx.builder.build_store(l, v2);
+                        },
+                        _ => {}
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    Some(lhs)
+                },
+                "<<=" => {
+                    lhs.data_type = Type::Reference(Box::new(l), true);
+                    rhs.data_type = r;
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(r)) => {
+                            let v1 = ctx.builder.build_load(l, "").into_int_value();
+                            let v2 = ctx.builder.build_left_shift(v1, r.into_int_value(), "");
+                            ctx.builder.build_store(l, v2);
+                        },
+                        _ => {}
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    Some(lhs)
+                },
+                ">>=" => {
+                    lhs.data_type = Type::Reference(Box::new(l), true);
+                    rhs.data_type = r;
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(r)) => {
+                            let v1 = ctx.builder.build_load(l, "").into_int_value();
+                            let v2 = ctx.builder.build_right_shift(v1, r.into_int_value(), false, "");
+                            ctx.builder.build_store(l, v2);
+                        },
+                        _ => {}
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    Some(lhs)
+                },
+                "^^=" => {
+                    return None;
+                    // TODO: implement exponents
+                },
+                _ => {
+                    lhs.data_type = l;
+                    rhs.data_type = r;
+                    if lhs.data_type.register() {
+                        if let Some(v) = lhs.comp_val {
+                            lhs.comp_val = Some(ctx.builder.build_load(v.into_pointer_value(), ""));
+                        }
+                    }
+                    bin_op(lhs, rhs, op, ctx)
+                }
+            },
+            (x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128), r @ (Type::IntLiteral | Type::Int(..))) => match op {
+                "=" => {
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(IntValue(rv))) => {
+                            let v1 = match r {
+                                Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), ""),
+                                _ => ctx.builder.build_unsigned_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), "")
+                            };
+                            ctx.builder.build_store(l, v1);
+                        },
+                        _ => {},
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    lhs.data_type = Type::Reference(Box::new(x), true);
+                    Some(lhs)
+                },
+                "+=" => {
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(IntValue(rv))) => {
+                            let v1 = match r {
+                                Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), ""),
+                                _ => ctx.builder.build_unsigned_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), "")
+                            };
+                            let v2 = ctx.builder.build_load(l, "").into_float_value();
+                            let v3 = ctx.builder.build_float_add(v1, v2, "");
+                            ctx.builder.build_store(l, v3);
+                        },
+                        _ => {},
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    lhs.data_type = Type::Reference(Box::new(x), true);
+                    Some(lhs)
+                },
+                "-=" => {
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(IntValue(rv))) => {
+                            let v1 = match r {
+                                Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), ""),
+                                _ => ctx.builder.build_unsigned_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), "")
+                            };
+                            let v2 = ctx.builder.build_load(l, "").into_float_value();
+                            let v3 = ctx.builder.build_float_sub(v1, v2, "");
+                            ctx.builder.build_store(l, v3);
+                        },
+                        _ => {},
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    lhs.data_type = Type::Reference(Box::new(x), true);
+                    Some(lhs)
+                },
+                "*=" => {
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(IntValue(rv))) => {
+                            let v1 = match r {
+                                Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), ""),
+                                _ => ctx.builder.build_unsigned_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), "")
+                            };
+                            let v2 = ctx.builder.build_load(l, "").into_float_value();
+                            let v3 = ctx.builder.build_float_mul(v1, v2, "");
+                            ctx.builder.build_store(l, v3);
+                        },
+                        _ => {},
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    lhs.data_type = Type::Reference(Box::new(x), true);
+                    Some(lhs)
+                },
+                "/=" => {
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(IntValue(rv))) => {
+                            let v1 = match r {
+                                Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), ""),
+                                _ => ctx.builder.build_unsigned_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), "")
+                            };
+                            let v2 = ctx.builder.build_load(l, "").into_float_value();
+                            let v3 = ctx.builder.build_float_div(v1, v2, "");
+                            ctx.builder.build_store(l, v3);
+                        },
+                        _ => {},
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    lhs.data_type = Type::Reference(Box::new(x), true);
+                    Some(lhs)
+                },
+                "%=" => None, // TODO: implement fmod
+                "^^=" => None, // TODO: implement powf
+                _ => None
+            },
+            (x @ Type::Pointer(..), y) if x == y => match op {
+                "=" => {
+                    lhs.data_type = x;
+                    rhs.data_type = y;
+                    match (lhs.comp_val, rhs.comp_val) {
+                        (Some(PointerValue(l)), Some(r)) => {
+                            ctx.builder.build_store(l, r);
+                        }
+                        _ => {},
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    Some(lhs)
+                },
+                _ => {
+                    lhs.data_type = x;
+                    rhs.data_type = y;
+                    if lhs.data_type.register() {
+                        if let Some(v) = lhs.comp_val {
+                            lhs.comp_val = Some(ctx.builder.build_load(v.into_pointer_value(), ""));
+                        }
+                    }
+                    bin_op(lhs, rhs, op, ctx)
+                }
+            }
+            (Type::Pointer(b, m), r @ (Type::IntLiteral | Type::Int(..))) => match op {
+                "+=" => {
+                    match (lhs.comp_val, rhs.comp_val, b.size()) {
+                        (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(x)) => {
+                            let pt = ctx.context.i64_type();
+                            let v1 = ctx.builder.build_load(l, "").into_pointer_value();
+                            let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
+                            let v3 = ctx.builder.build_ptr_to_int(v1, pt, "");
+                            let v4 = ctx.builder.build_int_add(v3, v2, "");
+                            let v5 = ctx.builder.build_int_to_ptr(v4, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::Generic), "");
+                            ctx.builder.build_store(l, v5);
+                        }
+                        _ => {},
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    lhs.data_type = Type::Pointer(b, m);
+                    Some(lhs)
+                },
+                "-=" => {
+                    match (lhs.comp_val, rhs.comp_val, b.size()) {
+                        (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(x)) => {
+                            let pt = ctx.context.i64_type();
+                            let v1 = ctx.builder.build_load(l, "").into_pointer_value();
+                            let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
+                            let v3 = ctx.builder.build_ptr_to_int(v1, pt, "");
+                            let v4 = ctx.builder.build_int_sub(v3, v2, "");
+                            let v5 = ctx.builder.build_int_to_ptr(v4, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::Generic), "");
+                            ctx.builder.build_store(l, v5);
+                        }
+                        _ => {},
+                    }
+                    if let Some(v) = lhs.inter_val {
+                        lhs.inter_val = None;
+                    }
+                    lhs.data_type = Type::Pointer(b, m);
+                    Some(lhs)
+                },
+                _ => {
+                    lhs.data_type = Type::Pointer(b, m);
+                    rhs.data_type = r;
+                    if lhs.data_type.register() {
+                        if let Some(v) = lhs.comp_val {
+                            lhs.comp_val = Some(ctx.builder.build_load(v.into_pointer_value(), ""));
+                        }
+                    }
+                    bin_op(lhs, rhs, op, ctx)
+                }
+            },
+            (l, r) => {
+                lhs.data_type = l;
+                rhs.data_type = r;
+                if lhs.data_type.register() {
+                    if let Some(v) = lhs.comp_val {
+                        lhs.comp_val = Some(ctx.builder.build_load(v.into_pointer_value(), ""));
+                    }
+                }
+                bin_op(lhs, rhs, op, ctx)
+            }
+        },
+        (Type::Int(ls, lu), Type::Int(rs, ru)) => match op {
+            "+" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_int_add(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l + r)),
+                    _ => None
+                },
+                data_type: Type::Int(max(ls, rs), lu && ru),
+                good: Cell::new(true)
+            }),
+            "-" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_int_sub(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l - r)),
+                    _ => None
+                },
+                data_type: Type::Int(max(ls, rs), lu && ru),
+                good: Cell::new(true)
+            }),
+            "*" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_int_mul(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l * r)),
+                    _ => None
+                },
+                data_type: Type::Int(max(ls, rs), lu && ru),
+                good: Cell::new(true)
+            }),
+            "/" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(if ru {ctx.builder.build_int_unsigned_div(l, r, "")} else {ctx.builder.build_int_signed_div(l, r, "")})),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l / r)),
+                    _ => None
+                },
+                data_type: Type::Int(max(ls, rs), ru),
+                good: Cell::new(true)
+            }),
+            "%" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(if ru {ctx.builder.build_int_unsigned_rem(l, r, "")} else {ctx.builder.build_int_signed_rem(l, r, "")})),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l % r)),
+                    _ => None
+                },
+                data_type: Type::Int(max(ls, rs), ru),
+                good: Cell::new(true)
+            }),
+            "&" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_and(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l & r)),
+                    _ => None
+                },
+                data_type: Type::Int(min(ls, rs), lu || ru),
+                good: Cell::new(true)
+            }),
+            "|" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_or(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l | r)),
+                    _ => None
+                },
+                data_type: Type::Int(max(ls, rs), lu || ru),
+                good: Cell::new(true)
+            }),
+            "^" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_xor(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l ^ r)),
+                    _ => None
+                },
+                data_type: Type::Int(max(ls, rs), lu || ru),
+                good: Cell::new(true)
+            }),
+            ">>" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_left_shift(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l << r)),
+                    _ => None
+                },
+                data_type: Type::Int(max(ls, rs), lu || ru),
+                good: Cell::new(true)
+            }),
+            "<<" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_right_shift(l, r, false, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l >> r)),
+                    _ => None
+                },
+                data_type: Type::Int(max(ls, rs), lu || ru),
+                good: Cell::new(true)
+            }),
+            "^^" => None, // TODO: implement exponents
+            _ => None
+        },
+        (Type::Int(s, u), Type::IntLiteral) | (Type::IntLiteral, Type::Int(s, u)) => match op {
+            "+" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_int_add(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l + r)),
+                    _ => None
+                },
+                data_type: Type::Int(s, u),
+                good: Cell::new(true)
+            }),
+            "-" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_int_sub(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l - r)),
+                    _ => None
+                },
+                data_type: Type::Int(s, u),
+                good: Cell::new(true)
+            }),
+            "*" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_int_mul(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l * r)),
+                    _ => None
+                },
+                data_type: Type::Int(s, u),
+                good: Cell::new(true)
+            }),
+            "/" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(if u {ctx.builder.build_int_unsigned_div(l, r, "")} else {ctx.builder.build_int_signed_div(l, r, "")})),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l / r)),
+                    _ => None
+                },
+                data_type: Type::Int(s, u),
+                good: Cell::new(true)
+            }),
+            "%" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(if u {ctx.builder.build_int_unsigned_rem(l, r, "")} else {ctx.builder.build_int_signed_rem(l, r, "")})),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l % r)),
+                    _ => None
+                },
+                data_type: Type::Int(s, u),
+                good: Cell::new(true)
+            }),
+            "&" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_and(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l & r)),
+                    _ => None
+                },
+                data_type: Type::Int(s, u),
+                good: Cell::new(true)
+            }),
+            "|" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_or(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l | r)),
+                    _ => None
+                },
+                data_type: Type::Int(s, u),
+                good: Cell::new(true)
+            }),
+            "^" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_xor(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l ^ r)),
+                    _ => None
+                },
+                data_type: Type::Int(s, u),
+                good: Cell::new(true)
+            }),
+            ">>" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_left_shift(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l << r)),
+                    _ => None
+                },
+                data_type: Type::Int(s, u),
+                good: Cell::new(true)
+            }),
+            "<<" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_right_shift(l, r, false, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l >> r)),
+                    _ => None
+                },
+                data_type: Type::Int(s, u),
+                good: Cell::new(true)
+            }),
+            "^^" => None, // TODO: implement exponents
+            _ => None
+        },
+        (Type::IntLiteral, Type::IntLiteral) => match op {
+            "+" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_int_add(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l + r)),
+                    _ => None
+                },
+                data_type: Type::IntLiteral,
+                good: Cell::new(true)
+            }),
+            "-" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_int_sub(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l - r)),
+                    _ => None
+                },
+                data_type: Type::IntLiteral,
+                good: Cell::new(true)
+            }),
+            "*" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_int_mul(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l * r)),
+                    _ => None
+                },
+                data_type: Type::IntLiteral,
+                good: Cell::new(true)
+            }),
+            "/" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_int_signed_div(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l / r)),
+                    _ => None
+                },
+                data_type: Type::IntLiteral,
+                good: Cell::new(true)
+            }),
+            "%" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_int_signed_rem(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l % r)),
+                    _ => None
+                },
+                data_type: Type::IntLiteral,
+                good: Cell::new(true)
+            }),
+            "&" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_and(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l & r)),
+                    _ => None
+                },
+                data_type: Type::IntLiteral,
+                good: Cell::new(true)
+            }),
+            "|" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_or(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l | r)),
+                    _ => None
+                },
+                data_type: Type::IntLiteral,
+                good: Cell::new(true)
+            }),
+            "^" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_xor(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l ^ r)),
+                    _ => None
+                },
+                data_type: Type::IntLiteral,
+                good: Cell::new(true)
+            }),
+            ">>" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_left_shift(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l << r)),
+                    _ => None
+                },
+                data_type: Type::IntLiteral,
+                good: Cell::new(true)
+            }),
+            "<<" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(l)), Some(IntValue(r))) => Some(IntValue(ctx.builder.build_right_shift(l, r, false, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l >> r)),
+                    _ => None
+                },
+                data_type: Type::IntLiteral,
+                good: Cell::new(true)
+            }),
+            "^^" => None, // TODO: implement exponents
+            _ => None
+        },
+        (Type::Pointer(b, s), Type::Int(..) | Type::IntLiteral) => match op {
+            "+" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val, b.size()) {
+                    (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(x)) => Some({
+                        let pt = ctx.context.i64_type();
+                        let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
+                        let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
+                        let v3 = ctx.builder.build_int_add(v1, v2, "");
+                        PointerValue(ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::Generic), ""))
+                    }),
+                    _ => None
+                },
+                inter_val: None,
+                data_type: Type::Pointer(b, s),
+                good: Cell::new(true)
+            }),
+            "-" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val, b.size()) {
+                    (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(x)) => Some({
+                        let pt = ctx.context.i64_type();
+                        let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
+                        let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
+                        let v3 = ctx.builder.build_int_sub(v1, v2, "");
+                        PointerValue(ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::Generic), ""))
+                    }),
+                    _ => None
+                },
+                inter_val: None,
+                data_type: Type::Pointer(b, s),
+                good: Cell::new(true)
+            }),
+            _ => None
+        },
+        (Type::Int(..) | Type::IntLiteral, Type::Pointer(b, s)) => match op {
+            "+" => Some(Variable {
+                comp_val: match (rhs.comp_val, lhs.comp_val, b.size()) { // I just swapped the sides here
+                    (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(x)) => Some({
+                        let pt = ctx.context.i64_type();
+                        let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
+                        let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
+                        let v3 = ctx.builder.build_int_add(v1, v2, "");
+                        PointerValue(ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::Generic), ""))
+                    }),
+                    _ => None
+                },
+                inter_val: None,
+                data_type: Type::Pointer(b, s),
+                good: Cell::new(true)
+            }),
+            _ => None
+        },
+        (l @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128), r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128)) => match op {
+            "+" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(FloatValue(l)), Some(FloatValue(r))) => Some(FloatValue(ctx.builder.build_float_add(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l + r)),
+                    _ => None
+                },
+                data_type: bin_type(l, r, op),
+                good: Cell::new(true)
+            }),
+            "-" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(FloatValue(l)), Some(FloatValue(r))) => Some(FloatValue(ctx.builder.build_float_sub(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l - r)),
+                    _ => None
+                },
+                data_type: bin_type(l, r, op),
+                good: Cell::new(true)
+            }),
+            "*" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(FloatValue(l)), Some(FloatValue(r))) => Some(FloatValue(ctx.builder.build_float_mul(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l * r)),
+                    _ => None
+                },
+                data_type: bin_type(l, r, op),
+                good: Cell::new(true)
+            }),
+            "/" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(FloatValue(l)), Some(FloatValue(r))) => Some(FloatValue(ctx.builder.build_float_div(l, r, ""))),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l / r)),
+                    _ => None
+                },
+                data_type: bin_type(l, r, op),
+                good: Cell::new(true)
+            }),
+            "%" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(FloatValue(l)), Some(FloatValue(r))) => None, // TODO: implement fmod
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l.rem_euclid(r))),
+                    _ => None
+                },
+                data_type: bin_type(l, r, op),
+                good: Cell::new(true)
+            }),
+            "^^" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(FloatValue(l)), Some(FloatValue(r))) => None, // TODO: implement powf
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l.powf(r))),
+                    _ => None
+                },
+                data_type: bin_type(l, r, op),
+                good: Cell::new(true)
+            }),
+            _ => None
+        },
+        (l @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128), r @ (Type::IntLiteral | Type::Int(..))) => match op {
+            "+" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(FloatValue(lv)), Some(IntValue(rv))) => Some({
+                        let v1 = match &r {
+                            Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(rv, l.llvm_type(ctx).unwrap().into_float_type(), ""),
+                            _ => ctx.builder.build_unsigned_int_to_float(rv, l.llvm_type(ctx).unwrap().into_float_type(), "")
+                        };
+                        FloatValue(ctx.builder.build_float_add(lv, v1, ""))
+                    }),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Float(l)), Some(InterData::Int(r))) => Some(InterData::Float(l / (r as f64))),
+                    _ => None
+                },
+                data_type: l,
+                good: Cell::new(true)
+            }),
+            "-" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(FloatValue(lv)), Some(IntValue(rv))) => Some({
+                        let v1 = match &r {
+                            Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(rv, l.llvm_type(ctx).unwrap().into_float_type(), ""),
+                            _ => ctx.builder.build_unsigned_int_to_float(rv, l.llvm_type(ctx).unwrap().into_float_type(), "")
+                        };
+                        FloatValue(ctx.builder.build_float_sub(lv, v1, ""))
+                    }),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Float(l)), Some(InterData::Int(r))) => Some(InterData::Float(l / (r as f64))),
+                    _ => None
+                },
+                data_type: l,
+                good: Cell::new(true)
+            }),
+            "*" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(FloatValue(lv)), Some(IntValue(rv))) => Some({
+                        let v1 = match &r {
+                            Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(rv, l.llvm_type(ctx).unwrap().into_float_type(), ""),
+                            _ => ctx.builder.build_unsigned_int_to_float(rv, l.llvm_type(ctx).unwrap().into_float_type(), "")
+                        };
+                        FloatValue(ctx.builder.build_float_mul(lv, v1, ""))
+                    }),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Float(l)), Some(InterData::Int(r))) => Some(InterData::Float(l / (r as f64))),
+                    _ => None
+                },
+                data_type: l,
+                good: Cell::new(true)
+            }),
+            "/" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(FloatValue(lv)), Some(IntValue(rv))) => Some({
+                        let v1 = match &r {
+                            Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(rv, l.llvm_type(ctx).unwrap().into_float_type(), ""),
+                            _ => ctx.builder.build_unsigned_int_to_float(rv, l.llvm_type(ctx).unwrap().into_float_type(), "")
+                        };
+                        FloatValue(ctx.builder.build_float_div(lv, v1, ""))
+                    }),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Float(l)), Some(InterData::Int(r))) => Some(InterData::Float(l / (r as f64))),
+                    _ => None
+                },
+                data_type: l,
+                good: Cell::new(true)
+            }),
+            "%" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(FloatValue(lv)), Some(IntValue(rv))) => None, // TODO: implement fmod
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Float(l)), Some(InterData::Int(r))) => Some(InterData::Float(l.rem_euclid(r as f64))),
+                    _ => None
+                },
+                data_type: l,
+                good: Cell::new(true)
+            }),
+            "^^" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(FloatValue(lv)), Some(IntValue(rv))) => None, // TODO: implement powf
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Float(l)), Some(InterData::Int(r))) => Some(InterData::Float(l.powf(r as f64))),
+                    _ => None
+                },
+                data_type: l,
+                good: Cell::new(true)
+            }),
+            _ => None
+        },
+        (l @ (Type::IntLiteral | Type::Int(..)), r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128)) => match op {
+            "+" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(lv)), Some(FloatValue(rv))) => Some({
+                        let v1 = match &l {
+                            Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(lv, r.llvm_type(ctx).unwrap().into_float_type(), ""),
+                            _ => ctx.builder.build_unsigned_int_to_float(lv, r.llvm_type(ctx).unwrap().into_float_type(), "")
+                        };
+                        FloatValue(ctx.builder.build_float_add(v1, rv, ""))
+                    }),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Float(r))) => Some(InterData::Float((l as f64) + r)),
+                    _ => None
+                },
+                data_type: r,
+                good: Cell::new(true)
+            }),
+            "-" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(lv)), Some(FloatValue(rv))) => Some({
+                        let v1 = match &l {
+                            Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(lv, r.llvm_type(ctx).unwrap().into_float_type(), ""),
+                            _ => ctx.builder.build_unsigned_int_to_float(lv, r.llvm_type(ctx).unwrap().into_float_type(), "")
+                        };
+                        FloatValue(ctx.builder.build_float_sub(v1, rv, ""))
+                    }),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Float(r))) => Some(InterData::Float((l as f64) - r)),
+                    _ => None
+                },
+                data_type: r,
+                good: Cell::new(true)
+            }),
+            "*" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(lv)), Some(FloatValue(rv))) => Some({
+                        let v1 = match &l {
+                            Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(lv, r.llvm_type(ctx).unwrap().into_float_type(), ""),
+                            _ => ctx.builder.build_unsigned_int_to_float(lv, r.llvm_type(ctx).unwrap().into_float_type(), "")
+                        };
+                        FloatValue(ctx.builder.build_float_mul(v1, rv, ""))
+                    }),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Float(r))) => Some(InterData::Float((l as f64) * r)),
+                    _ => None
+                },
+                data_type: r,
+                good: Cell::new(true)
+            }),
+            "/" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(lv)), Some(FloatValue(rv))) => Some({
+                        let v1 = match &l {
+                            Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(lv, r.llvm_type(ctx).unwrap().into_float_type(), ""),
+                            _ => ctx.builder.build_unsigned_int_to_float(lv, r.llvm_type(ctx).unwrap().into_float_type(), "")
+                        };
+                        FloatValue(ctx.builder.build_float_div(v1, rv, ""))
+                    }),
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Float(r))) => Some(InterData::Float((l as f64) / r)),
+                    _ => None
+                },
+                data_type: r,
+                good: Cell::new(true)
+            }),
+            "%" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(lv)), Some(FloatValue(rv))) => None, // TODO: implement fmod
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Float(r))) => Some(InterData::Float((l as f64).rem_euclid(r))),
+                    _ => None
+                },
+                data_type: r,
+                good: Cell::new(true)
+            }),
+            "^^" => Some(Variable {
+                comp_val: match (lhs.comp_val, rhs.comp_val) {
+                    (Some(IntValue(lv)), Some(FloatValue(rv))) => None, // TODO: implement powf
+                    _ => None
+                },
+                inter_val: match (lhs.inter_val, rhs.inter_val) {
+                    (Some(InterData::Int(l)), Some(InterData::Float(r))) => Some(InterData::Float((l as f64).powf(r))),
+                    _ => None
+                },
+                data_type: r,
+                good: Cell::new(true)
+            }),
+            _ => None
+        },
+        _ => None
+    }
+}
+pub fn pre_op<'ctx>(mut val: Variable<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> Option<Variable<'ctx>> {
+    match val.data_type {
+        Type::Borrow(x) => {
+            val.data_type = *x;
+            pre_op(val, op, ctx)
+        },
+        Type::Reference(x, false) => if op == "&" {
+            val.data_type = Type::Pointer(x, false);
+            Some(val)
+        }
+        else if op == "&&" {
+            val.data_type = Type::Pointer(x, false);
+            pre_op(val, "&", ctx)
+        }
+        else {
+            val.data_type = *x;
+            if val.data_type.register() {
+                if let Some(v) = val.comp_val {
+                    val.comp_val = Some(ctx.builder.build_load(v.into_pointer_value(), ""));
+                }
+            }
+            pre_op(val, op, ctx)
+        },
+        Type::Reference(x, true) => if op == "&" {
+            val.data_type = Type::Pointer(x, true);
+            Some(val)
+        }
+        else if op == "&&" {
+            val.data_type = Type::Pointer(x, true);
+            pre_op(val, "&", ctx)
+        }
+        else {
+            match *x {
+                Type::IntLiteral => panic!("There shouldn't be a reference to an integer literal"),
+                x @ Type::Int(..) => match op {
+                    "++" => {
+                        if let Some(PointerValue(v)) = val.comp_val {
+                            let v1 = ctx.builder.build_load(v, "").into_int_value();
+                            let v2 = ctx.builder.build_int_add(v1, ctx.context.i8_type().const_int(1, false), "");
+                            ctx.builder.build_store(v, v2);
+                        }
+                        if let Some(v) = val.inter_val {
+                            val.inter_val = None;
+                        }
+                        val.data_type = x;
+                        Some(val)
+                    },
+                    "--" => {
+                        if let Some(PointerValue(v)) = val.comp_val {
+                            let v1 = ctx.builder.build_load(v, "").into_int_value();
+                            let v2 = ctx.builder.build_int_sub(v1, ctx.context.i8_type().const_int(1, false), "");
+                            ctx.builder.build_store(v, v2);
+                        }
+                        if let Some(v) = val.inter_val {
+                            val.inter_val = None;
+                        }
+                        val.data_type = x;
+                        Some(val)
+                    },
+                    _ => {
+                        val.data_type = x;
+                        if val.data_type.register() {
+                            if let Some(v) = val.comp_val {
+                                val.comp_val = Some(ctx.builder.build_load(v.into_pointer_value(), ""));
+                            }
+                        }
+                        pre_op(val, op, ctx)
+                    }
+                },
+                x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => match op {
+                    "++" => {
+                        val.data_type = x;
+                        if let Some(PointerValue(v)) = val.comp_val {
+                            let v1 = ctx.builder.build_load(v, "").into_float_value();
+                            let v2 = ctx.builder.build_float_add(v1, ctx.context.f64_type().const_float(1.0), "");
+                            ctx.builder.build_store(v, v2);
+                        }
+                        if let Some(v) = val.inter_val {
+                            val.inter_val = None;
+                        }
+                        Some(val)
+                    },
+                    "--" => {
+                        val.data_type = x;
+                        if let Some(PointerValue(v)) = val.comp_val {
+                            let v1 = ctx.builder.build_load(v, "").into_float_value();
+                            let v2 = ctx.builder.build_float_sub(v1, ctx.context.f64_type().const_float(1.0), "");
+                            ctx.builder.build_store(v, v2);
+                        }
+                        if let Some(v) = val.inter_val {
+                            val.inter_val = None;
+                        }
+                        Some(val)
+                    },
+                    _ => {
+                        val.data_type = x;
+                        if val.data_type.register() {
+                            if let Some(v) = val.comp_val {
+                                val.comp_val = Some(ctx.builder.build_load(v.into_pointer_value(), ""));
+                            }
+                        }
+                        pre_op(val, op, ctx)
+                    }
+                },
+                Type::Pointer(b, m) => match op {
+                    "++" => {
+                        if let (Some(PointerValue(v)), SizeType::Static(x)) = (val.comp_val, b.size()) {
+                            let x = if let SizeType::Static(x) = b.size() {x} else {return None};
+                            let pt = ctx.context.i64_type();
+                            let v1 = ctx.builder.build_load(v, "").into_pointer_value();
+                            let v2 = ctx.builder.build_ptr_to_int(v1, pt, "");
+                            let v3 = ctx.builder.build_int_sub(v2, pt.const_int(x, false), "");
+                            let v4 = ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::Generic), "");
+                            ctx.builder.build_store(v, v4);
+                        }
+                        if let Some(v) = val.inter_val {
+                            val.inter_val = None;
+                        }
+                        val.data_type = Type::Pointer(b, m);
+                        Some(val)
+                    },
+                    "--" => {
+                        if let Some(PointerValue(v)) = val.comp_val {
+                            let x = if let SizeType::Static(x) = b.size() {x} else {return None};
+                            let pt = ctx.context.i64_type();
+                            let v1 = ctx.builder.build_load(v, "").into_pointer_value();
+                            let v2 = ctx.builder.build_ptr_to_int(v1, pt, "");
+                            let v3 = ctx.builder.build_int_sub(v2, pt.const_int(x, false), "");
+                            let v4 = ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::Generic), "");
+                            ctx.builder.build_store(v, v4);
+                        }
+                        if let Some(v) = val.inter_val {
+                            val.inter_val = None;
+                        }
+                        val.data_type = Type::Pointer(b, m);
+                        Some(val)
+                    },
+                    _ => {
+                        val.data_type = Type::Pointer(b, m);
+                        if val.data_type.register() {
+                            if let Some(v) = val.comp_val {
+                                val.comp_val = Some(ctx.builder.build_load(v.into_pointer_value(), ""));
+                            }
+                        }
+                        pre_op(val, op, ctx)
+                    }
+                },
+                x => {
+                    val.data_type = x;
+                    if val.data_type.register() {
+                        if let Some(v) = val.comp_val {
+                            val.comp_val = Some(ctx.builder.build_load(v.into_pointer_value(), ""));
+                        }
+                    }
+                    pre_op(val, op, ctx)
+                }
+            }
+        },
+        Type::IntLiteral => match op {
+            "+" => {
+                val.data_type = Type::IntLiteral;
+                Some(val)
+            },
+            "-" => Some(Variable {
+                comp_val: if let Some(IntValue(v)) = val.comp_val {Some(IntValue(ctx.builder.build_int_neg(v, "")))} else {None},
+                inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(-v))} else {None},
+                data_type: Type::IntLiteral,
+                good: Cell::new(true)
+            }),
+            "~" => Some(Variable {
+                comp_val: if let Some(IntValue(v)) = val.comp_val {Some(IntValue(ctx.builder.build_xor(v, ctx.context.i64_type().const_all_ones(), "")))} else {None},
+                inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(!v))} else {None},
+                data_type: Type::IntLiteral,
+                good: Cell::new(true)
+            }),
+            _ => None
+        },
+        Type::Int(s, u) => match op {
+            "+" => {
+                val.data_type = Type::Int(s, u);
+                Some(val)
+            },
+            "-" => Some(Variable {
+                comp_val: if let Some(IntValue(v)) = val.comp_val {Some(IntValue(ctx.builder.build_int_neg(v, "")))} else {None},
+                inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(-v))} else {None},
+                data_type: Type::Int(s, u),
+                good: Cell::new(true)
+            }),
+            "~" => Some(Variable {
+                comp_val: if let Some(IntValue(v)) = val.comp_val {Some(IntValue(ctx.builder.build_xor(v, ctx.context.custom_width_int_type(s as u32).const_all_ones(), "")))} else {None},
+                inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(!v))} else {None},
+                data_type: Type::Int(s, u),
+                good: Cell::new(true)
+            }),
+            _ => None
+        },
+        x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => match op {
+            "+" => {
+                val.data_type = x;
+                Some(val)
+            },
+            "-" => Some(Variable {
+                comp_val: if let Some(FloatValue(v)) = val.comp_val {Some(FloatValue(ctx.builder.build_float_neg(v, "")))} else {None},
+                inter_val: if let Some(InterData::Float(v)) = val.inter_val {Some(InterData::Float(-v))} else {None},
+                data_type: x,
+                good: Cell::new(true)
+            }),
+            _ => None
+        }
+        Type::Pointer(b, m) => match op {
+            "*" => {
+                val.data_type = Type::Reference(b, m);
+                Some(val)
+            },
+            _ => None
+        },
+        _ => None
+    }
+}
+pub fn post_op<'ctx>(val: Variable<'ctx>, _op: &str, _ctx: &CompCtx<'ctx>) -> Option<Variable<'ctx>> {
+    match val.data_type { // The only posfix operators are ? and !, and they're for error handling
+        _ => None
+    }
+}
+pub fn impl_convert<'ctx>(val: Variable<'ctx>, target: Type, ctx: &CompCtx<'ctx>) -> Option<Variable<'ctx>> {todo!("variable conversions aren't implemented")}
+pub fn expl_convert<'ctx>(val: Variable<'ctx>, target: Type, ctx: &CompCtx<'ctx>) -> Option<Variable<'ctx>> {todo!("variable conversions aren't implemented")}

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -456,7 +456,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                             let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
                             let v3 = ctx.builder.build_ptr_to_int(v1, pt, "");
                             let v4 = ctx.builder.build_int_add(v3, v2, "");
-                            let v5 = ctx.builder.build_int_to_ptr(v4, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::Generic), "");
+                            let v5 = ctx.builder.build_int_to_ptr(v4, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::from(0u16)), "");
                             ctx.builder.build_store(l, v5);
                         }
                         _ => {},
@@ -475,7 +475,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                             let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
                             let v3 = ctx.builder.build_ptr_to_int(v1, pt, "");
                             let v4 = ctx.builder.build_int_sub(v3, v2, "");
-                            let v5 = ctx.builder.build_int_to_ptr(v4, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::Generic), "");
+                            let v5 = ctx.builder.build_int_to_ptr(v4, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::from(0u16)), "");
                             ctx.builder.build_store(l, v5);
                         }
                         _ => {},
@@ -888,7 +888,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
                         let v3 = ctx.builder.build_int_add(v1, v2, "");
-                        PointerValue(ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::Generic), ""))
+                        PointerValue(ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::from(0u16)), ""))
                     }),
                     _ => None
                 },
@@ -903,7 +903,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
                         let v3 = ctx.builder.build_int_sub(v1, v2, "");
-                        PointerValue(ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::Generic), ""))
+                        PointerValue(ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::from(0u16)), ""))
                     }),
                     _ => None
                 },
@@ -921,7 +921,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
                         let v3 = ctx.builder.build_int_add(v1, v2, "");
-                        PointerValue(ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::Generic), ""))
+                        PointerValue(ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::from(0u16)), ""))
                     }),
                     _ => None
                 },
@@ -1318,7 +1318,7 @@ pub fn pre_op<'ctx>(mut val: Variable<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> O
                             let v1 = ctx.builder.build_load(v, "").into_pointer_value();
                             let v2 = ctx.builder.build_ptr_to_int(v1, pt, "");
                             let v3 = ctx.builder.build_int_add(v2, pt.const_int(x, false), "");
-                            let v4 = ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::Generic), "");
+                            let v4 = ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::from(0u16)), "");
                             ctx.builder.build_store(v, v4);
                         }
                         if let Some(v) = val.inter_val {
@@ -1333,7 +1333,7 @@ pub fn pre_op<'ctx>(mut val: Variable<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> O
                             let v1 = ctx.builder.build_load(v, "").into_pointer_value();
                             let v2 = ctx.builder.build_ptr_to_int(v1, pt, "");
                             let v3 = ctx.builder.build_int_sub(v2, pt.const_int(x, false), "");
-                            let v4 = ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::Generic), "");
+                            let v4 = ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::from(0u16)), "");
                             ctx.builder.build_store(v, v4);
                         }
                         if let Some(v) = val.inter_val {

--- a/src/cobalt/varmap.rs
+++ b/src/cobalt/varmap.rs
@@ -1,7 +1,7 @@
 use crate::*;
 use inkwell::values::BasicValueEnum;
 use std::collections::hash_map::{HashMap, Entry};
-use std::{cell::Cell, rc::Rc};
+use std::cell::Cell;
 pub enum UndefVariable {
     NotAModule(usize),
     DoesNotExist(usize)
@@ -17,20 +17,20 @@ pub enum InterData {
     Int(i128),
     Float(f64),
     Str(String),
-    Array(Vec<InterData>)
+    Array(Vec<InterData>),
 }
 #[derive(Clone)]
 pub struct Variable<'ctx> {
     pub comp_val: Option<BasicValueEnum<'ctx>>,
     pub inter_val: Option<InterData>,
     pub data_type: Type,
-    pub good: Rc<Cell<bool>>
+    pub good: Cell<bool>
 }
 impl<'ctx> Variable<'ctx> {
-    pub fn error() -> Self {Variable {comp_val: None, inter_val: None, data_type: Type::Null, good: Rc::new(Cell::new(false))}}
-    pub fn compiled(comp_val: BasicValueEnum<'ctx>, data_type: Type) -> Self {Variable {comp_val: Some(comp_val), inter_val: None, data_type, good: Rc::new(Cell::new(true))}}
-    pub fn interpreted(comp_val: BasicValueEnum<'ctx>, inter_val: InterData, data_type: Type) -> Self {Variable {comp_val: Some(comp_val), inter_val: Some(inter_val), data_type, good: Rc::new(Cell::new(true))}}
-    pub fn metaval(inter_val: InterData, data_type: Type) -> Self {Variable {comp_val: None, inter_val: Some(inter_val), data_type, good: Rc::new(Cell::new(true))}}
+    pub fn error() -> Self {Variable {comp_val: None, inter_val: None, data_type: Type::Null, good: Cell::new(false)}}
+    pub fn compiled(comp_val: BasicValueEnum<'ctx>, data_type: Type) -> Self {Variable {comp_val: Some(comp_val), inter_val: None, data_type, good: Cell::new(true)}}
+    pub fn interpreted(comp_val: BasicValueEnum<'ctx>, inter_val: InterData, data_type: Type) -> Self {Variable {comp_val: Some(comp_val), inter_val: Some(inter_val), data_type, good: Cell::new(true)}}
+    pub fn metaval(inter_val: InterData, data_type: Type) -> Self {Variable {comp_val: None, inter_val: Some(inter_val), data_type, good: Cell::new(true)}}
 }
 pub enum Symbol<'ctx> {
     Variable(Variable<'ctx>),


### PR DESCRIPTION
Almost all of the code generation has been implemented, leaving only modules. They will most likely be implemented on a branch called `feature.modules` or something similar.
Changes:
- Code generation for operators is implemented
- Code generation for local variables is implemented
- Code generation for implicit conversions is implemented
- When a variable is defined, its type in the `VarMap` is a reference
Commits:
- Implement code generation for operators
- Made operators not emit LLVM code when evaluated in a constant context
- Changed function Type to track constant paramters instead of mutables
- Fixed builder not inserting instructions in a the initializer function
- Fixed variables being defined as references instead of copying
- Updated inkwell::AddressSpace to use struct instead of enum
- Improved code generation for global variables in constant contexts
- Added code generation for local variables
- Implemented code generation for nulls and explicit casts
- Implemented code generation for function definitions
- Fixed type parsing and added more implicit conversions
- Made error messages caused by modules and imports clearer
