### PR TITLE
Add parser support for blocks and local statements

### DIFF
--- a/src/cobalt/misc.rs
+++ b/src/cobalt/misc.rs
@@ -8,6 +8,7 @@ pub struct Location {
     pub offset: u64
 }
 impl Location {
+    pub fn null() -> Self {Location::new("<anonymous>", 0, 0, 0)}
     pub fn new(file: &'static str, line: u64, col: u64, offset: u64) -> Self {Location{file, line, col, offset}}
     pub fn from_name(file: &'static str) -> Self {Location{file, line: 1, col: 1, offset: 0}}
 }

--- a/src/cobalt/parser/lexer.rs
+++ b/src/cobalt/parser/lexer.rs
@@ -708,7 +708,6 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                 }
                 outs.push(Token::new(start, match s.as_str() {
                     "let" | "mut" | "const" | "fn" | "cr" | "module" | "import" | "if" | "else" | "while" => Keyword(s),
-                    _ if s.starts_with("__builtin_") => Keyword(s),
                     _ => Identifier(s)
                 }));
             },


### PR DESCRIPTION
Changes:
- Expressions can be grouped with parentheses, or contain blocks delimited by braces.
  - `let expr = (a; b; c);` where `a`, `b`, and `c` are expressions
  - `let expr = {a; b; c};` where `a`, `b`, and `c` are statements
- Types can contain `mut` and `const` (for pointers and references)
Commits:
- Added parsing for groups, blocks, and local statements
- Added parsing support for mut and const in types
