### PR TITLE
Fix lexer parsing '~' as '?'

### DIFF
--- a/src/cobalt/parser/lexer.rs
+++ b/src/cobalt/parser/lexer.rs
@@ -723,8 +723,8 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                 },
                 _ => outs.push(Token::new(loc.clone(), Special('.')))
             },
-            '?' => { // operator of the from @
-                outs.push(Token::new(loc.clone(), Operator("?".to_string())));
+            '?' | '~' => { // operator of the from @
+                outs.push(Token::new(loc.clone(), Operator(c.to_string())));
             },
             '=' | '!' | '%' | '*' => { // operator of the form @, @=
                 if it.peek() == Some(&'=') {


### PR DESCRIPTION
- Made integer literals implicitly cast to i64 in variable definitions
- Fixed parameters being ignored in function definitions
- Fixed values in binary operators in emitted LLVM IR having different types
- Fixed lexer not allowing '~' as an operator
