### PR TITLE
Add support for function calls

### DIFF
--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -267,3 +267,38 @@ impl AST for FnDefAST {
         print_ast_child(f, pre, &*self.body, true)
     }
 }
+pub struct CallAST {
+    loc: Location,
+    pub target: Box<dyn AST>,
+    pub args: Vec<Box<dyn AST>>
+}
+impl CallAST {
+    pub fn new(loc: Location, target: Box<dyn AST>, args: Vec<Box<dyn AST>>) -> Self {CallAST {loc, target, args}}
+}
+impl AST for CallAST {
+    fn loc(&self) -> Location {self.loc.clone()}
+    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {todo!("function calls haven't been implemented")}
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {todo!("function calls haven't been implemented")}
+    fn to_code(&self) -> String {
+        let mut out = format!("{}(", self.target.to_code());
+        let mut count = self.args.len();
+        for arg in self.args.iter() {
+            out += arg.to_code().as_str();
+            if count > 1 {
+                out += ", ";
+            }
+            count -= 1;
+        }
+        out + ")"
+    }
+    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix) -> std::fmt::Result {
+        writeln!(f, "call")?;
+        let mut count = self.args.len();
+        print_ast_child(f, pre, &*self.target, count == 0)?;
+        for arg in self.args.iter() {
+            print_ast_child(f, pre, &**arg, count <= 1)?;
+            count -= 1;
+        }
+        Ok(())
+    }
+}

--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -158,17 +158,59 @@ impl AST for FnDefAST {
                         errs.push(Error::new(self.loc.clone(), 311, err));
                         llt.const_zero()
                     })));
+                    let cloned = params.clone(); // Rust doesn't like me using params in the following closure
                     ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
                         comp_val: Some(PointerValue(f.as_global_value().as_pointer_value())),
-                        inter_val: None, // TODO: constant functions
+                        inter_val: Some(InterData::Function(FnData {
+                            defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
+                                let old_const = ctx.is_const.replace(true);
+                                let (val, mut es) = a.codegen(ctx);
+                                let err = format!("cannot convert value of type {} to {t}", val.data_type);
+                                let val = types::utils::impl_convert(val, t.clone(), ctx);
+                                ctx.is_const.set(old_const);
+                                errs.append(&mut es);
+                                if let Some(val) = val {
+                                    if let Some(val) = val.inter_val {val}
+                                    else {
+                                        errs.push(Error::new(a.loc(), 312, "function parameter's default value must be constant".to_string()));
+                                        InterData::Null
+                                    }
+                                }
+                                else {
+                                    errs.push(Error::new(a.loc(), 311, err));
+                                    InterData::Null
+                                }
+                            })).collect()
+                        })),
                         data_type: fty,
                         good: Cell::new(true)
                     })))
                 }
                 else {
+                    let cloned = params.clone(); // Rust doesn't like me using params in the following closure
                     ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
                         comp_val: None,
-                        inter_val: None, // TODO: constant functions
+                        inter_val: Some(InterData::Function(FnData {
+                            defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
+                                let old_const = ctx.is_const.replace(true);
+                                let (val, mut es) = a.codegen(ctx);
+                                let err = format!("cannot convert value of type {} to {t}", val.data_type);
+                                let val = types::utils::impl_convert(val, t.clone(), ctx);
+                                ctx.is_const.set(old_const);
+                                errs.append(&mut es);
+                                if let Some(val) = val {
+                                    if let Some(val) = val.inter_val {val}
+                                    else {
+                                        errs.push(Error::new(a.loc(), 312, "function parameter's default value must be constant".to_string()));
+                                        InterData::Null
+                                    }
+                                }
+                                else {
+                                    errs.push(Error::new(a.loc(), 311, err));
+                                    InterData::Null
+                                }
+                            })).collect()
+                        })),
                         data_type: fty,
                         good: Cell::new(true)
                     })))
@@ -185,26 +227,89 @@ impl AST for FnDefAST {
                     let (body, mut es) = self.body.codegen(ctx);
                     errs.append(&mut es);
                     ctx.builder.build_return(None);
+                    let cloned = params.clone(); // Rust doesn't like me using params in the following closure
                     ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
                         comp_val: Some(PointerValue(f.as_global_value().as_pointer_value())),
-                        inter_val: None, // TODO: constant functions
+                        inter_val: Some(InterData::Function(FnData {
+                            defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
+                                let old_const = ctx.is_const.replace(true);
+                                let (val, mut es) = a.codegen(ctx);
+                                let err = format!("cannot convert value of type {} to {t}", val.data_type);
+                                let val = types::utils::impl_convert(val, t.clone(), ctx);
+                                ctx.is_const.set(old_const);
+                                errs.append(&mut es);
+                                if let Some(val) = val {
+                                    if let Some(val) = val.inter_val {val}
+                                    else {
+                                        errs.push(Error::new(a.loc(), 312, "function parameter's default value must be constant".to_string()));
+                                        InterData::Null
+                                    }
+                                }
+                                else {
+                                    errs.push(Error::new(a.loc(), 311, err));
+                                    InterData::Null
+                                }
+                            })).collect()
+                        })),
                         data_type: fty,
                         good: Cell::new(true)
                     })))
                 }
                 else {
+                    let cloned = params.clone(); // Rust doesn't like me using params in the following closure
                     ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
                         comp_val: None,
-                        inter_val: None, // TODO: constant functions
+                        inter_val: Some(InterData::Function(FnData {
+                            defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
+                                let old_const = ctx.is_const.replace(true);
+                                let (val, mut es) = a.codegen(ctx);
+                                let err = format!("cannot convert value of type {} to {t}", val.data_type);
+                                let val = types::utils::impl_convert(val, t.clone(), ctx);
+                                ctx.is_const.set(old_const);
+                                errs.append(&mut es);
+                                if let Some(val) = val {
+                                    if let Some(val) = val.inter_val {val}
+                                    else {
+                                        errs.push(Error::new(a.loc(), 312, "function parameter's default value must be constant".to_string()));
+                                        InterData::Null
+                                    }
+                                }
+                                else {
+                                    errs.push(Error::new(a.loc(), 311, err));
+                                    InterData::Null
+                                }
+                            })).collect()
+                        })),
                         data_type: fty,
                         good: Cell::new(true)
                     })))
                 }
             }
             else {
+                let cloned = params.clone(); // Rust doesn't like me using params in the following closure
                 ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
                     comp_val: None,
-                    inter_val: None, // TODO: constant functions
+                    inter_val: Some(InterData::Function(FnData {
+                        defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
+                            let old_const = ctx.is_const.replace(true);
+                            let (val, mut es) = a.codegen(ctx);
+                            let err = format!("cannot convert value of type {} to {t}", val.data_type);
+                            let val = types::utils::impl_convert(val, t.clone(), ctx);
+                            ctx.is_const.set(old_const);
+                            errs.append(&mut es);
+                            if let Some(val) = val {
+                                if let Some(val) = val.inter_val {val}
+                                else {
+                                    errs.push(Error::new(a.loc(), 312, "function parameter's default value must be constant".to_string()));
+                                    InterData::Null
+                                }
+                            }
+                            else {
+                                errs.push(Error::new(a.loc(), 311, err));
+                                InterData::Null
+                            }
+                        })).collect()
+                    })),
                     data_type: fty,
                     good: Cell::new(true)
                 })))

--- a/src/cobalt/parser/ast.rs
+++ b/src/cobalt/parser/ast.rs
@@ -480,7 +480,7 @@ fn parse_calls(mut toks: &[Token], flags: &Flags) -> (Box<dyn AST>, Vec<Error>) 
                     _ => {}
                 }
             }
-            if idx == 0 || depth > 0{parse_groups(toks, flags)}
+            if idx == 0 || depth > 0 {parse_groups(toks, flags)}
             else {
                 let (target, ts) = toks.split_at(idx);
                 toks = &ts[1..];

--- a/src/cobalt/varmap.rs
+++ b/src/cobalt/varmap.rs
@@ -11,13 +11,28 @@ pub enum RedefVariable<'ctx> {
     AlreadyExists(usize, Symbol<'ctx>),
     MergeConflict(usize, HashMap<DottedName, Symbol<'ctx>>)
 }
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+pub struct FnData {
+    pub defaults: Vec<InterData>
+}
+#[derive(Clone)]
 pub enum InterData {
     Null,
     Int(i128),
     Float(f64),
     Str(String),
     Array(Vec<InterData>),
+    Function(FnData)
+}
+impl InterData {
+    pub fn into_compiled<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Option<BasicValueEnum<'ctx>> {
+        match self {
+            InterData::Int(val) => Some(BasicValueEnum::IntValue(ctx.context.i64_type().const_int(*val as u64, true))),
+            InterData::Float(val) => Some(BasicValueEnum::FloatValue(ctx.context.f64_type().const_float(*val))),
+            InterData::Str(val) => Some(BasicValueEnum::PointerValue(ctx.builder.build_global_string_ptr(val.as_str(), "__internals.str").as_pointer_value())),
+            _ => None
+        }
+    }
 }
 #[derive(Clone)]
 pub struct Variable<'ctx> {
@@ -31,6 +46,7 @@ impl<'ctx> Variable<'ctx> {
     pub fn compiled(comp_val: BasicValueEnum<'ctx>, data_type: Type) -> Self {Variable {comp_val: Some(comp_val), inter_val: None, data_type, good: Cell::new(true)}}
     pub fn interpreted(comp_val: BasicValueEnum<'ctx>, inter_val: InterData, data_type: Type) -> Self {Variable {comp_val: Some(comp_val), inter_val: Some(inter_val), data_type, good: Cell::new(true)}}
     pub fn metaval(inter_val: InterData, data_type: Type) -> Self {Variable {comp_val: None, inter_val: Some(inter_val), data_type, good: Cell::new(true)}}
+    pub fn value(&self, ctx: &CompCtx<'ctx>) -> Option<BasicValueEnum<'ctx>> {self.comp_val.clone().or_else(|| self.inter_val.as_ref().and_then(|v| v.into_compiled(ctx)))}
 }
 pub enum Symbol<'ctx> {
     Variable(Variable<'ctx>),

--- a/src/cobalt/varmap.rs
+++ b/src/cobalt/varmap.rs
@@ -81,7 +81,7 @@ impl<'ctx> VarMap<'ctx> {
     }
     pub fn lookup(&self, name: &DottedName) -> Result<&Symbol<'ctx>, UndefVariable> {
         match mod_lookup(if name.global {&self.root().symbols} else {&self.symbols}, name) {
-            Err(UndefVariable::DoesNotExist(x)) => self.parent.as_ref().map(|p| mod_lookup(&p.symbols, name)).unwrap_or(Err(UndefVariable::DoesNotExist(x))),
+            Err(UndefVariable::DoesNotExist(x)) => self.parent.as_ref().map(|p| p.lookup(name)).unwrap_or(Err(UndefVariable::DoesNotExist(x))),
             x => x
         }
     }


### PR DESCRIPTION
Changes:
- Functions can be called, with syntax similar to that of the C family
- Default parameters are stored in the `inter_val` field of function `Variable`s
- Parsing nested groups no longer breaks things
- Variable lookups properly search recursively instead of just checking the parent
Commits:
- Added dummy AST node for function calls
- Added parsing for function calls
- Added storage of function default parameters
- Implemented code generation for function calls
- Fixed issues from parsing groups and function calls
- Fixed variable lookups not checking grandparent VarMaps
