### PR TITLE
Add support for annotations (and macros and intrinsics)

### DIFF
--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -417,3 +417,33 @@ impl AST for CallAST {
         Ok(())
     }
 }
+pub struct IntrinsicAST {
+    loc: Location,
+    pub name: String,
+    pub args: Option<String>
+}
+impl IntrinsicAST {
+    pub fn new(loc: Location, name: String, args: Option<String>) -> Self {IntrinsicAST {loc, name, args}}
+}
+impl AST for IntrinsicAST {
+    fn loc(&self) -> Location {self.loc.clone()}
+    fn res_type<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> Type {Type::Null}
+    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+        match self.name.as_str() {
+            "asm" => todo!("inline assembly isn't yet implemented"),
+            x => (Variable::error(), vec![Error::new(self.loc.clone(), 391, format!("unknown intrinsic {x:?}"))])
+        }
+    }
+    fn to_code(&self) -> String {self.name.clone() + self.args.as_ref().map(|x| x.as_str()).unwrap_or("")}
+    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix) -> std::fmt::Result {
+        writeln!(f, "intrinsic: {}", self.name)?;
+        let mut is_first = true;
+        if let Some(params) = self.args.as_ref() {
+            for line in params.split('\n') {
+                writeln!(f, "{pre}{}{line}", if is_first {"└── "} else {"    "})?;
+                is_first = false;
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use inkwell::values::BasicValueEnum::*;
+use inkwell::module::Linkage::*;
 use std::cell::Cell;
 pub struct VarDefAST {
     loc: Location,
@@ -13,9 +14,118 @@ impl AST for VarDefAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.val.res_type(ctx)}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
-        if self.global {
-            if self.val.is_const() && self.type_.is_none() {
-                let (val, mut errs) = self.val.codegen(ctx);
+        let mut errs = vec![];
+        let mut is_static = false;
+        let mut link_type = None;
+        let mut linkas = None;
+        let mut is_extern = false;
+        for (ann, arg) in self.annotations.iter() {
+            match ann.as_str() {
+                "static" => {
+                    if let Some(arg) = arg {
+                        errs.push(Error::new(self.loc.clone(), 411, format!("unexpected argument {arg:?} to @static annotation")))
+                    }
+                    if self.global {
+                        errs.push(Error::new(self.loc.clone(), 20, "@static annotation on a global variable is redundant".to_string()))
+                    }
+                    if is_static {
+                        errs.push(Error::new(self.loc.clone(), 21, "specifying the @static annotation multiple times doesn't do anything".to_string()))
+                    }
+                    is_static = true;
+                },
+                "link" => {
+                    if link_type.is_some() {
+                        errs.push(Error::new(self.loc.clone(), 414, "respecification of linkage type".to_string()))
+                    }
+                    link_type = match arg.as_ref().map(|x| x.as_str()) {
+                        None => {errs.push(Error::new(self.loc.clone(), 412, "@link annotation requires an argument".to_string())); None},
+                        Some("extern") | Some("external") => Some(External),
+                        Some("extern-weak") | Some("extern_weak") | Some("external-weak") | Some("external_weak") => Some(ExternalWeak),
+                        Some("intern") | Some("internal") => Some(Internal),
+                        Some("private") => Some(Private),
+                        Some("weak") => Some(WeakAny),
+                        Some("weak-odr") | Some("weak_odr") => Some(WeakODR),
+                        Some("linkonce") | Some("link-once") | Some("link_once") => Some(LinkOnceAny),
+                        Some("linkonce-odr") | Some("linkonce_odr") | Some("link-once-odr") | Some("link_once_odr") => Some(LinkOnceODR),
+                        Some("common") => Some(Common),
+                        Some(x) => {errs.push(Error::new(self.loc.clone(), 413, format!("unknown link type {x:?} for @link annotation"))); None},
+                    }
+                },
+                "linkas" => {
+                    if linkas.is_some() {
+                        errs.push(Error::new(self.loc.clone(), 416, "respecification of @linkas annotation".to_string()))
+                    }
+                    if let Some(arg) = arg {
+                        linkas = Some(arg.clone())
+                    }
+                    else {
+                        errs.push(Error::new(self.loc.clone(), 415, "@linkas annotation requires an argument".to_string()))
+                    }
+                },
+                "extern" => {
+                    if is_extern {
+                        errs.push(Error::new(self.loc.clone(), 22, "specifying the @extern annotation multiple times doesn't do anything".to_string()))
+                    }
+                    is_extern = true;
+                },
+                x => errs.push(Error::new(self.loc.clone(), 410, format!("unknown annotation {x:?} for variable definition")))
+            }
+        }
+        if self.global || is_static {
+            if is_extern {
+                let t2 = self.val.res_type(ctx);
+                let dt = if let Some(t) = self.type_.as_ref().and_then(|t| {
+                    let (t, mut es) = t.into_type(ctx);
+                    errs.append(&mut es);
+                    match t {
+                        Ok(t) => Some(t),
+                        Err(IntoTypeError::NotAnInt(name)) => {
+                            errs.push(Error::new(self.loc.clone(), 311, format!("cannot convert value of type {name} to u64")));
+                            None
+                        },
+                        Err(IntoTypeError::NotCompileTime) => {
+                            errs.push(Error::new(self.loc.clone(), 312, format!("array size cannot be determined at compile time")));
+                            None
+                        },
+                        Err(IntoTypeError::NotAModule(name)) => {
+                            errs.push(Error::new(self.loc.clone(), 320, format!("{name} is not a module")));
+                            None
+                        },
+                        Err(IntoTypeError::DoesNotExist(name)) => {
+                            errs.push(Error::new(self.loc.clone(), 321, format!("{name} does not exist")));
+                            None
+                        }
+                    }
+                }) {t} else if t2 == Type::IntLiteral {Type::Int(64, false)} else if let Type::Reference(b, _) = t2 {*b} else {t2};
+                match ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
+                    comp_val: dt.llvm_type(ctx).map(|t| {
+                        let gv = ctx.module.add_global(t, None, linkas.unwrap_or_else(|| format!("{}", self.name)).as_str());
+                        match link_type {
+                            None => {},
+                            Some(WeakAny) => gv.set_linkage(ExternalWeak),
+                            Some(x) => gv.set_linkage(x)
+                        }
+                        PointerValue(gv.as_pointer_value())
+                    }).or_else(|| {errs.push(Error::new(self.loc.clone(), 23, "externally linked variable has a non-runtime type".to_string())); None}),
+                    inter_val: None,
+                    data_type: dt,
+                    good: Cell::new(true)
+                }))) {
+                    Ok(x) => (x.as_var().unwrap().clone(), errs),
+                    Err(RedefVariable::NotAModule(x, _)) => {
+                        errs.push(Error::new(self.loc.clone(), 320, format!("{} is not a module", self.name.start(x))));
+                        (Variable::error(), errs)
+                    },
+                    Err(RedefVariable::AlreadyExists(x, _)) => {
+                        errs.push(Error::new(self.loc.clone(), 321, format!("{} has already been defined", self.name.start(x))));
+                        (Variable::error(), errs)
+                    },
+                    Err(RedefVariable::MergeConflict(_, _)) => panic!("merge conflicts shouldn't be reachable when inserting a variable")
+                }
+            }
+            else if self.val.is_const() && self.type_.is_none() {
+                let (val, mut es) = self.val.codegen(ctx);
+                errs.append(&mut es);
                 let t2 = val.data_type.clone();
                 let (dt, err) = if let Some(t) = self.type_.as_ref().and_then(|t| {
                     let (t, mut es) = t.into_type(ctx);
@@ -47,9 +157,10 @@ impl AST for VarDefAST {
                     }
                     else {
                         let t = dt.llvm_type(ctx).unwrap();
-                        let gv = ctx.module.add_global(t, None, format!("{}", self.name).as_str());
+                        let gv = ctx.module.add_global(t, None, linkas.unwrap_or_else(|| format!("{}", self.name)).as_str());
                         gv.set_constant(true);
                         gv.set_initializer(&v);
+                        if let Some(link) = link_type {gv.set_linkage(link)}
                         ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
                             comp_val: Some(PointerValue(gv.as_pointer_value())),
                             inter_val: val.inter_val,
@@ -112,8 +223,9 @@ impl AST for VarDefAST {
                         ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {good: Cell::new(true), ..val})))
                     }
                     else {
-                        let gv = ctx.module.add_global(t, None, format!("{}", self.name).as_str());
+                        let gv = ctx.module.add_global(t, None, linkas.unwrap_or_else(|| format!("{}", self.name)).as_str());
                         gv.set_constant(false);
+                        if let Some(link) = link_type {gv.set_linkage(link)}
                         let f = ctx.module.add_function(format!("__internals.init.{}", self.name).as_str(), ctx.context.void_type().fn_type(&[], false), Some(inkwell::module::Linkage::Private));
                         let entry = ctx.context.append_basic_block(f, "entry");
                         let old_ip = ctx.builder.get_insert_block();
@@ -218,7 +330,17 @@ impl AST for VarDefAST {
             }
         }
         else {
-            let (val, mut errs) = self.val.codegen(ctx);
+            if is_extern {
+                errs.push(Error::new(self.loc.clone(), 417, "@extern annotation cannot be used on a variable that isn't global or static".to_string()))
+            }
+            if link_type.is_some() {
+                errs.push(Error::new(self.loc.clone(), 418, "@link annotation cannot be used on a variable that isn't global or static".to_string()))
+            }
+            if linkas.is_some() {
+                errs.push(Error::new(self.loc.clone(), 419, "@linkas annotation cannot be used on a variable that isn't global or static".to_string()))
+            }
+            let (val, mut es) = self.val.codegen(ctx);
+            errs.append(&mut es);
             let t2 = val.data_type.clone();
             let (dt, err) = if let Some(t) = self.type_.as_ref().and_then(|t| {
                 let (t, mut es) = t.into_type(ctx);
@@ -305,9 +427,118 @@ impl AST for MutDefAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.val.res_type(ctx)}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
-        if self.global {
-            if self.val.is_const() && self.type_.is_none() {
-                let (val, mut errs) = self.val.codegen(ctx);
+        let mut errs = vec![];
+        let mut is_static = false;
+        let mut link_type = None;
+        let mut linkas = None;
+        let mut is_extern = false;
+        for (ann, arg) in self.annotations.iter() {
+            match ann.as_str() {
+                "static" => {
+                    if let Some(arg) = arg {
+                        errs.push(Error::new(self.loc.clone(), 411, format!("unexpected argument {arg:?} to @static annotation")))
+                    }
+                    if self.global {
+                        errs.push(Error::new(self.loc.clone(), 20, "@static annotation on a global variable is redundant".to_string()))
+                    }
+                    if is_static {
+                        errs.push(Error::new(self.loc.clone(), 21, "specifying the @static annotation multiple times doesn't do anything".to_string()))
+                    }
+                    is_static = true;
+                },
+                "link" => {
+                    if link_type.is_some() {
+                        errs.push(Error::new(self.loc.clone(), 414, "respecification of linkage type".to_string()))
+                    }
+                    link_type = match arg.as_ref().map(|x| x.as_str()) {
+                        None => {errs.push(Error::new(self.loc.clone(), 412, "@link annotation requires an argument".to_string())); None},
+                        Some("extern") | Some("external") => Some(External),
+                        Some("extern-weak") | Some("extern_weak") | Some("external-weak") | Some("external_weak") => Some(ExternalWeak),
+                        Some("intern") | Some("internal") => Some(Internal),
+                        Some("private") => Some(Private),
+                        Some("weak") => Some(WeakAny),
+                        Some("weak-odr") | Some("weak_odr") => Some(WeakODR),
+                        Some("linkonce") | Some("link-once") | Some("link_once") => Some(LinkOnceAny),
+                        Some("linkonce-odr") | Some("linkonce_odr") | Some("link-once-odr") | Some("link_once_odr") => Some(LinkOnceODR),
+                        Some("common") => Some(Common),
+                        Some(x) => {errs.push(Error::new(self.loc.clone(), 413, format!("unknown link type {x:?} for @link annotation"))); None},
+                    }
+                },
+                "linkas" => {
+                    if linkas.is_some() {
+                        errs.push(Error::new(self.loc.clone(), 416, "respecification of @linkas annotation".to_string()))
+                    }
+                    if let Some(arg) = arg {
+                        linkas = Some(arg.clone())
+                    }
+                    else {
+                        errs.push(Error::new(self.loc.clone(), 415, "@linkas annotation requires an argument".to_string()))
+                    }
+                },
+                "extern" => {
+                    if is_extern {
+                        errs.push(Error::new(self.loc.clone(), 22, "specifying the @extern annotation multiple times doesn't do anything".to_string()))
+                    }
+                    is_extern = true;
+                },
+                x => errs.push(Error::new(self.loc.clone(), 410, format!("unknown annotation {x:?} for variable definition")))
+            }
+        }
+        if self.global || is_static {
+            if is_extern {
+                let t2 = self.val.res_type(ctx);
+                let dt = if let Some(t) = self.type_.as_ref().and_then(|t| {
+                    let (t, mut es) = t.into_type(ctx);
+                    errs.append(&mut es);
+                    match t {
+                        Ok(t) => Some(t),
+                        Err(IntoTypeError::NotAnInt(name)) => {
+                            errs.push(Error::new(self.loc.clone(), 311, format!("cannot convert value of type {name} to u64")));
+                            None
+                        },
+                        Err(IntoTypeError::NotCompileTime) => {
+                            errs.push(Error::new(self.loc.clone(), 312, format!("array size cannot be determined at compile time")));
+                            None
+                        },
+                        Err(IntoTypeError::NotAModule(name)) => {
+                            errs.push(Error::new(self.loc.clone(), 320, format!("{name} is not a module")));
+                            None
+                        },
+                        Err(IntoTypeError::DoesNotExist(name)) => {
+                            errs.push(Error::new(self.loc.clone(), 321, format!("{name} does not exist")));
+                            None
+                        }
+                    }
+                }) {t} else if t2 == Type::IntLiteral {Type::Int(64, false)} else if let Type::Reference(b, _) = t2 {*b} else {t2};
+                match ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
+                    comp_val: dt.llvm_type(ctx).map(|t| {
+                        let gv = ctx.module.add_global(t, None, linkas.unwrap_or_else(|| format!("{}", self.name)).as_str());
+                        match link_type {
+                            None => {},
+                            Some(WeakAny) => gv.set_linkage(ExternalWeak),
+                            Some(x) => gv.set_linkage(x)
+                        }
+                        PointerValue(gv.as_pointer_value())
+                    }).or_else(|| {errs.push(Error::new(self.loc.clone(), 23, "externally linked variable has a non-runtime type".to_string())); None}),
+                    inter_val: None,
+                    data_type: dt,
+                    good: Cell::new(true)
+                }))) {
+                    Ok(x) => (x.as_var().unwrap().clone(), errs),
+                    Err(RedefVariable::NotAModule(x, _)) => {
+                        errs.push(Error::new(self.loc.clone(), 320, format!("{} is not a module", self.name.start(x))));
+                        (Variable::error(), errs)
+                    },
+                    Err(RedefVariable::AlreadyExists(x, _)) => {
+                        errs.push(Error::new(self.loc.clone(), 321, format!("{} has already been defined", self.name.start(x))));
+                        (Variable::error(), errs)
+                    },
+                    Err(RedefVariable::MergeConflict(_, _)) => panic!("merge conflicts shouldn't be reachable when inserting a variable")
+                }
+            }
+            else if self.val.is_const() && self.type_.is_none() {
+                let (val, mut es) = self.val.codegen(ctx);
+                errs.append(&mut es);
                 let t2 = val.data_type.clone();
                 let (dt, err) = if let Some(t) = self.type_.as_ref().and_then(|t| {
                     let (t, mut es) = t.into_type(ctx);
@@ -339,9 +570,10 @@ impl AST for MutDefAST {
                     }
                     else {
                         let t = dt.llvm_type(ctx).unwrap();
-                        let gv = ctx.module.add_global(t, None, format!("{}", self.name).as_str());
-                        gv.set_constant(false);
+                        let gv = ctx.module.add_global(t, None, linkas.unwrap_or_else(|| format!("{}", self.name)).as_str());
+                        gv.set_constant(true);
                         gv.set_initializer(&v);
+                        if let Some(link) = link_type {gv.set_linkage(link)}
                         ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
                             comp_val: Some(PointerValue(gv.as_pointer_value())),
                             inter_val: val.inter_val,
@@ -404,8 +636,9 @@ impl AST for MutDefAST {
                         ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {good: Cell::new(true), ..val})))
                     }
                     else {
-                        let gv = ctx.module.add_global(t, None, format!("{}", self.name).as_str());
+                        let gv = ctx.module.add_global(t, None, linkas.unwrap_or_else(|| format!("{}", self.name)).as_str());
                         gv.set_constant(false);
+                        if let Some(link) = link_type {gv.set_linkage(link)}
                         let f = ctx.module.add_function(format!("__internals.init.{}", self.name).as_str(), ctx.context.void_type().fn_type(&[], false), Some(inkwell::module::Linkage::Private));
                         let entry = ctx.context.append_basic_block(f, "entry");
                         let old_ip = ctx.builder.get_insert_block();
@@ -469,7 +702,6 @@ impl AST for MutDefAST {
                     let (dt, err) = if let Some(t) = self.type_.as_ref().and_then(|t| {
                         let (t, mut es) = t.into_type(ctx);
                         errs.append(&mut es);
-                        let t2 = val.data_type.clone();
                         let t = match t {
                             Ok(t) => Some(t),
                             Err(IntoTypeError::NotAnInt(name)) => {
@@ -511,6 +743,16 @@ impl AST for MutDefAST {
             }
         }
         else {
+            if is_extern {
+                errs.push(Error::new(self.loc.clone(), 417, "@extern annotation cannot be used on a variable that isn't global or static".to_string()))
+            }
+            if link_type.is_some() {
+                errs.push(Error::new(self.loc.clone(), 418, "@link annotation cannot be used on a variable that isn't global or static".to_string()))
+            }
+            if linkas.is_some() {
+                errs.push(Error::new(self.loc.clone(), 419, "@linkas annotation cannot be used on a variable that isn't global or static".to_string()))
+            }
+
             let (val, mut errs) = self.val.codegen(ctx);
             let t2 = val.data_type.clone();
             let (dt, err) = if let Some(t) = self.type_.as_ref().and_then(|t| {
@@ -627,8 +869,10 @@ impl AST for ConstDefAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.val.res_type(ctx)}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+        let mut errs = self.annotations.iter().map(|(x, _)| Error::new(self.loc.clone(), 410, format!("unknown annotation {x:?} for variable definition"))).collect::<Vec<_>>();
         let old_is_const = ctx.is_const.replace(true);
-        let (val, mut errs) = self.val.codegen(ctx);
+        let (val, mut es) = self.val.codegen(ctx);
+        errs.append(&mut es);
         let t2 = val.data_type.clone();
         let (dt, err) = if let Some(t) = self.type_.as_ref().and_then(|t| {
             let (t, mut es) = t.into_type(ctx);

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -6,6 +6,7 @@ pub struct VarDefAST {
     pub name: DottedName,
     pub val: Box<dyn AST>,
     pub type_: Option<ParsedType>,
+    pub annotations: Vec<(String, Option<String>)>,
     pub global: bool
 }
 impl AST for VarDefAST {
@@ -277,21 +278,27 @@ impl AST for VarDefAST {
         }
     }
     fn to_code(&self) -> String {
-        format!("let {}{} = {}", self.name, self.type_.as_ref().map_or("".to_string(), |t| format!(": {t}")), self.val.to_code())
+        let mut out = "".to_string();
+        for s in self.annotations.iter().map(|(name, arg)| ("@".to_string() + name.as_str() + arg.as_ref().map(|x| format!("({x})")).unwrap_or("".to_string()).as_str() + " ").to_string()) {out += s.as_str();}
+        out + format!("let {}{} = {}", self.name, self.type_.as_ref().map_or("".to_string(), |t| format!(": {t}")), self.val.to_code()).as_str()
     }
     fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix) -> std::fmt::Result {
         writeln!(f, "vardef: {}", self.name)?;
+        for (name, arg) in self.annotations.iter() {
+            writeln!(f, "{pre}├── @{name}{}", arg.as_ref().map(|x| format!("({x})")).unwrap_or("".to_string()))?;
+        }
         print_ast_child(f, pre, &*self.val, true)
     }
 }
 impl VarDefAST {
-    pub fn new(loc: Location, name: DottedName, val: Box<dyn AST>, type_: Option<ParsedType>, global: bool) -> Self {VarDefAST {loc, name, val, type_, global}}
+    pub fn new(loc: Location, name: DottedName, val: Box<dyn AST>, type_: Option<ParsedType>, annotations: Vec<(String, Option<String>)>, global: bool) -> Self {VarDefAST {loc, name, val, type_, annotations, global}}
 }
 pub struct MutDefAST {
     loc: Location,
     pub name: DottedName,
     pub val: Box<dyn AST>,
     pub type_: Option<ParsedType>,
+    pub annotations: Vec<(String, Option<String>)>,
     pub global: bool
 }
 impl AST for MutDefAST {
@@ -564,15 +571,20 @@ impl AST for MutDefAST {
         }
     }
     fn to_code(&self) -> String {
-        format!("mut {}{} = {}", self.name, self.type_.as_ref().map_or("".to_string(), |t| format!(": {t}")), self.val.to_code())
+        let mut out = "".to_string();
+        for s in self.annotations.iter().map(|(name, arg)| ("@".to_string() + name.as_str() + arg.as_ref().map(|x| format!("({x})")).unwrap_or("".to_string()).as_str() + " ").to_string()) {out += s.as_str();}
+        out + format!("mut {}{} = {}", self.name, self.type_.as_ref().map_or("".to_string(), |t| format!(": {t}")), self.val.to_code()).as_str()
     }
     fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix) -> std::fmt::Result {
         writeln!(f, "mutdef: {}", self.name)?;
+        for (name, arg) in self.annotations.iter() {
+            writeln!(f, "{pre}├── @{name}{}", arg.as_ref().map(|x| format!("({x})")).unwrap_or("".to_string()))?;
+        }
         print_ast_child(f, pre, &*self.val, true)
     }
 }
 impl MutDefAST {
-    pub fn new(loc: Location, name: DottedName, val: Box<dyn AST>, type_: Option<ParsedType>, global: bool) -> Self {MutDefAST {loc, name, val, type_, global}}
+    pub fn new(loc: Location, name: DottedName, val: Box<dyn AST>, type_: Option<ParsedType>, annotations: Vec<(String, Option<String>)>, global: bool) -> Self {MutDefAST {loc, name, val, type_, annotations, global}}
 }
 pub struct VarGetAST {
     loc: Location,
@@ -608,7 +620,8 @@ pub struct ConstDefAST {
     loc: Location,
     pub name: DottedName,
     pub val: Box<dyn AST>,
-    pub type_: Option<ParsedType>
+    pub type_: Option<ParsedType>,
+    pub annotations: Vec<(String, Option<String>)>
 }
 impl AST for ConstDefAST {
     fn loc(&self) -> Location {self.loc.clone()}
@@ -660,13 +673,18 @@ impl AST for ConstDefAST {
         }
     }
     fn to_code(&self) -> String {
-        format!("const {}{} = {}", self.name, self.type_.as_ref().map_or("".to_string(), |t| format!(": {t}")), self.val.to_code())
+        let mut out = "".to_string();
+        for s in self.annotations.iter().map(|(name, arg)| ("@".to_string() + name.as_str() + arg.as_ref().map(|x| format!("({x})")).unwrap_or("".to_string()).as_str() + " ").to_string()) {out += s.as_str();}
+        out + format!("const {}{} = {}", self.name, self.type_.as_ref().map_or("".to_string(), |t| format!(": {t}")), self.val.to_code()).as_str()
     }
     fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix) -> std::fmt::Result {
-        writeln!(f, "constdef: {}", self.name)?;
+        writeln!(f, "const: {}", self.name)?;
+        for (name, arg) in self.annotations.iter() {
+            writeln!(f, "{pre}├── @{name}{}", arg.as_ref().map(|x| format!("({x})")).unwrap_or("".to_string()))?;
+        }
         print_ast_child(f, pre, &*self.val, true)
     }
 }
 impl ConstDefAST {
-    pub fn new(loc: Location, name: DottedName, val: Box<dyn AST>, type_: Option<ParsedType>) -> Self {ConstDefAST {loc, name, val, type_}}
+    pub fn new(loc: Location, name: DottedName, val: Box<dyn AST>, type_: Option<ParsedType>, annotations: Vec<(String, Option<String>)>) -> Self {ConstDefAST {loc, name, val, type_, annotations}}
 }

--- a/src/cobalt/parser/ast.rs
+++ b/src/cobalt/parser/ast.rs
@@ -307,6 +307,7 @@ fn parse_literals(toks: &[Token]) -> (Box<dyn AST>, Vec<Error>) {
             }
             (Box::new(VarGetAST::new(toks[0].loc.clone(), name)), errs)
         },
+        Macro(name, args) => (Box::new(IntrinsicAST::new(toks[0].loc.clone(), name.clone(), args.clone())), toks.iter().skip(1).map(|tok| Error::new(tok.loc.clone(), 272, format!("unexpected token {:?} after intrinsic", tok.data))).collect()),
         _ => (Box::new(NullAST::new(toks[0].loc.clone())), toks.iter().map(|tok| Error::new(tok.loc.clone(), 272, format!("expected identifier or literal, got {:?}", tok.data))).collect())
     }
 }


### PR DESCRIPTION
Changes:
- Added support for intrinsics, annotations, and macros
  - While they all have the same syntax, they appear in different places:
  - An intrinsic is an expression, with minimal precedence
    - Example:
      ```
      let x = {
        @asm(
          
        ); # imagine some clever assembly here
        0
      };
      ```
    - In this example, the `@asm` intrinsic is used for inline assembly
  - An annotation goes before a variable or function definition
    - Example:
      ```
      @link(private) let x: i32 = 0;
      @extern(C) fn puts(str: i8 const*): null;
      ```
    - Cobalt doesn't have syntactically signifcant whitespace, so this is also valid:
      ```
      @link(private)
      let x: i32 = 0;
      @extern(C)
      fn puts(str: i8 const*): null;
      ```
    - Both are valid, and I'm not brave enough to write a style guide
  - A macro is handled at the lexing phase:
    - Example:
      ```
      let version = @version;
      ```
Commits:
- Added lexing for macros
- Added AST node for intrinsics
- Added parser support for intrinsics
- Added parsing for annotations
- Added annotations for variable definitions
- Added annotations for function definitions
