### PR TITLE
Add support for builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ semver = { version = "1.0", features = ["serde"] }
 either = { version = "1.8.0", features = ["serde"] }
 path-dedot = "3.0.18"
 glob = "0.3.0"
+reqwest = "0.11.13"
+flate2 = "1.0.25"
+git2 = "0.15.0"
+zip-extract = "0.1.1"
 
 [lib]
 name = "cobalt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-toml = "0.5.9"
 colored = "2.0.0"
 bitvec = "1.0.1"
 inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm14-0", "internal-getters"] }
 llvm-sys = { version = "140", features = ["strict-versioning"] }
 unicode-ident = "1.0.5"
 walkdir = "2"
+toml = "0.5.9"
+serde = { version = "1.0", features = ["derive"] }
+semver = { version = "1.0", features = ["serde"] }
+either = { version = "1.8.0", features = ["serde"] }
+path-dedot = "3.0.18"
+glob = "0.3.0"
 
 [lib]
 name = "cobalt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ flate2 = "1.0.25"
 git2 = "0.15.0"
 zip-extract = "0.1.1"
 tar = "0.4.38"
+try-lazy-init = "0.0.2"
+lazy_static = "1.4.0"
 
 [lib]
 name = "cobalt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,11 @@ semver = { version = "1.0", features = ["serde"] }
 either = { version = "1.8.0", features = ["serde"] }
 path-dedot = "3.0.18"
 glob = "0.3.0"
-reqwest = "0.11.13"
+reqwest = { version = "0.11.13", features = ["blocking"] }
 flate2 = "1.0.25"
 git2 = "0.15.0"
 zip-extract = "0.1.1"
+tar = "0.4.38"
 
 [lib]
 name = "cobalt"

--- a/src/build.rs
+++ b/src/build.rs
@@ -11,7 +11,7 @@ use either::Either;
 use semver::{Version, VersionReq};
 use path_dedot::ParseDot;
 use cobalt::context::CompCtx;
-use super::{libs, opt};
+use super::{libs, opt, package};
 #[derive(Debug, Clone, Deserialize)]
 pub struct Project {
     pub name: String,
@@ -63,8 +63,9 @@ pub struct Target {
     pub target_type: TargetType,
     #[serde(with = "either::serde_untagged_optional")]
     pub files: Option<Either<String, Vec<String>>>,
+    #[serde(default)]
     #[serde(alias = "dependencies")]
-    pub deps: Option<HashMap<String, String>>
+    pub deps: HashMap<String, String>
 }
 #[derive(Debug, Clone, Deserialize)]
 struct Executable {
@@ -76,8 +77,9 @@ struct Executable {
     pub needs_crt: bool,
     #[serde(with = "either::serde_untagged_optional")]
     pub files: Option<Either<String, Vec<String>>>,
+    #[serde(default)]
     #[serde(alias = "dependencies")]
-    pub deps: Option<HashMap<String, String>>
+    pub deps: HashMap<String, String>
 }
 #[derive(Debug, Clone, Deserialize)]
 struct Library {
@@ -89,8 +91,9 @@ struct Library {
     pub needs_crt: bool,
     #[serde(with = "either::serde_untagged_optional")]
     pub files: Option<Either<String, Vec<String>>>,
+    #[serde(default)]
     #[serde(alias = "dependencies")]
-    pub deps: Option<HashMap<String, String>>
+    pub deps: HashMap<String, String>
 }
 #[derive(Debug, Clone, Deserialize)]
 struct Meta {
@@ -100,8 +103,9 @@ struct Meta {
     #[serde(alias = "needs_libc")]
     #[serde(alias = "needs-libc")]
     pub needs_crt: bool,
+    #[serde(default)]
     #[serde(alias = "dependencies")]
-    pub deps: Option<HashMap<String, String>>
+    pub deps: HashMap<String, String>
 }
 #[derive(Debug, Clone)]
 pub struct BuildOptions<'a, 'b, 'c, 'd> {
@@ -267,7 +271,7 @@ fn build_target<'ctx>(t: &Target, data: &RefCell<Option<TargetData>>, targets: &
     match t.target_type {
         TargetType::Executable => {
             if t.needs_crt {data.borrow_mut().as_mut().unwrap().needs_crt = true;}
-            for (target, version) in t.deps.as_ref().unwrap_or(&HashMap::new()).iter() {
+            for (target, version) in t.deps.iter() {
                 match version.as_str() {
                     "project" => {
                         let (t, d) = if let Some(t) = targets.get(target.as_str()) {t} else {
@@ -349,7 +353,7 @@ fn build_target<'ctx>(t: &Target, data: &RefCell<Option<TargetData>>, targets: &
         },
         TargetType::Library => {
             if t.needs_crt {data.borrow_mut().as_mut().unwrap().needs_crt = true;}
-            for (target, version) in t.deps.as_ref().unwrap_or(&HashMap::new()).iter() {
+            for (target, version) in t.deps.iter() {
                 match version.as_str() {
                     "project" => {
                         let (t, d) = if let Some(t) = targets.get(target.as_str()) {t} else {
@@ -421,7 +425,7 @@ fn build_target<'ctx>(t: &Target, data: &RefCell<Option<TargetData>>, targets: &
                 return 106;
             }
             if t.needs_crt {data.borrow_mut().as_mut().unwrap().needs_crt = true;}
-            for (target, version) in t.deps.as_ref().unwrap_or(&HashMap::new()).iter() {
+            for (target, version) in t.deps.iter() {
                 match version.as_str() {
                     "project" => {
                         let (t, d) = if let Some(t) = targets.get(target.as_str()) {t} else {

--- a/src/build.rs
+++ b/src/build.rs
@@ -21,14 +21,14 @@ pub struct Project {
     #[serde(alias = "description")]
     pub desc: Option<String>,
     #[serde(alias = "target")]
-    pub targets: Option<Vec<Target>>,
+    targets: Option<Vec<Target>>,
     #[serde(alias = "lib")]
-    pub library: Option<Vec<Library>>,
+    library: Option<Vec<Library>>,
     #[serde(alias = "exe")]
     #[serde(alias = "bin")]
     #[serde(alias = "executable")]
-    pub executable: Option<Vec<Executable>>,
-    pub meta: Option<Vec<Meta>>
+    executable: Option<Vec<Executable>>,
+    meta: Option<Vec<Meta>>
 }
 impl Project {
     pub fn into_targets(self) -> impl Iterator<Item = Target> {
@@ -67,7 +67,7 @@ pub struct Target {
     pub deps: Option<HashMap<String, String>>
 }
 #[derive(Debug, Clone, Deserialize)]
-pub struct Executable {
+struct Executable {
     pub name: String,
     #[serde(default)]
     #[serde(alias = "needs-crt")]
@@ -80,7 +80,7 @@ pub struct Executable {
     pub deps: Option<HashMap<String, String>>
 }
 #[derive(Debug, Clone, Deserialize)]
-pub struct Library {
+struct Library {
     pub name: String,
     #[serde(default)]
     #[serde(alias = "needs-crt")]
@@ -93,7 +93,7 @@ pub struct Library {
     pub deps: Option<HashMap<String, String>>
 }
 #[derive(Debug, Clone, Deserialize)]
-pub struct Meta {
+struct Meta {
     pub name: String,
     #[serde(default)]
     #[serde(alias = "needs-crt")]

--- a/src/build.rs
+++ b/src/build.rs
@@ -289,7 +289,52 @@ fn build_target<'ctx>(t: &Target, data: &RefCell<Option<TargetData>>, targets: &
                         data.borrow_mut().as_mut().unwrap().libs.push(LibInfo::Name(target.clone()));
                     },
                     x => if let Ok(v) = x.parse::<VersionReq>() {
-                        todo!("externally downloaded projects aren't implemented")
+                        if let Some(pkg) = package::Package::registry().get(target) {
+                            match pkg.install(opts.triple.as_str().to_str().unwrap(), Some(v), package::InstallOptions::default()) {
+                                Err(package::InstallError::NoInstallDirectory) => panic!("This would only be reachable if $HOME was deleted in a data race, which may or may not even be possible"),
+                                Err(package::InstallError::DownloadError(e)) => {
+                                    eprintln!("{ERROR}: {e}");
+                                    return 4
+                                },
+                                Err(package::InstallError::StdIoError(e)) => {
+                                    eprintln!("{ERROR}: {e}");
+                                    return 3
+                                },
+                                Err(package::InstallError::GitCloneError(e)) => {
+                                    eprintln!("{ERROR}: {e}");
+                                    return 2
+                                },
+                                Err(package::InstallError::ZipExtractError(e)) => {
+                                    eprintln!("{ERROR}: {e}");
+                                    return 5
+                                },
+                                Err(package::InstallError::BuildFailed(e)) => {
+                                    eprintln!("failed to build package {target}");
+                                    return e
+                                },
+                                Err(package::InstallError::NoMatchesError) => {
+                                    eprintln!("package {target:?} has no releases");
+                                    return 7
+                                },
+                                Err(package::InstallError::CfgFileError(e)) => {
+                                    eprintln!("{ERROR} in {target}'s config file: {e}");
+                                    return 8
+                                },
+                                Err(package::InstallError::InvalidVersionSpec(_, v)) => {
+                                    eprintln!("{ERROR} in {target}'s dependencies: invalid version spec {v}");
+                                    return 9
+                                },
+                                Err(package::InstallError::PkgNotFound(p)) => {
+                                    eprintln!("{ERROR} in {target}'s dependencies: can't find package {p}");
+                                    return 10
+                                },
+                                _ => {}
+                            } // TODO: make library info available through VarMap
+                        }
+                        else {
+                            eprintln!("{ERROR}: can't find package {target}");
+                            return 10
+                        }
                     }
                     else {
                         eprintln!("{ERROR}: unknown version specification {x:?}");
@@ -371,7 +416,52 @@ fn build_target<'ctx>(t: &Target, data: &RefCell<Option<TargetData>>, targets: &
                         data.borrow_mut().as_mut().unwrap().libs.push(LibInfo::Name(target.clone()));
                     },
                     x => if let Ok(v) = x.parse::<VersionReq>() {
-                        todo!("externally downloaded projects aren't implemented")
+                        if let Some(pkg) = package::Package::registry().get(target) {
+                            match pkg.install(opts.triple.as_str().to_str().unwrap(), Some(v), package::InstallOptions::default()) {
+                                Err(package::InstallError::NoInstallDirectory) => panic!("This would only be reachable if $HOME was deleted in a data race, which may or may not even be possible"),
+                                Err(package::InstallError::DownloadError(e)) => {
+                                    eprintln!("{ERROR}: {e}");
+                                    return 4
+                                },
+                                Err(package::InstallError::StdIoError(e)) => {
+                                    eprintln!("{ERROR}: {e}");
+                                    return 3
+                                },
+                                Err(package::InstallError::GitCloneError(e)) => {
+                                    eprintln!("{ERROR}: {e}");
+                                    return 2
+                                },
+                                Err(package::InstallError::ZipExtractError(e)) => {
+                                    eprintln!("{ERROR}: {e}");
+                                    return 5
+                                },
+                                Err(package::InstallError::BuildFailed(e)) => {
+                                    eprintln!("failed to build package {target}");
+                                    return e
+                                },
+                                Err(package::InstallError::NoMatchesError) => {
+                                    eprintln!("package {target:?} has no releases");
+                                    return 7
+                                },
+                                Err(package::InstallError::CfgFileError(e)) => {
+                                    eprintln!("{ERROR} in {target}'s config file: {e}");
+                                    return 8
+                                },
+                                Err(package::InstallError::InvalidVersionSpec(_, v)) => {
+                                    eprintln!("{ERROR} in {target}'s dependencies: invalid version spec {v}");
+                                    return 9
+                                },
+                                Err(package::InstallError::PkgNotFound(p)) => {
+                                    eprintln!("{ERROR} in {target}'s dependencies: can't find package {p}");
+                                    return 10
+                                },
+                                _ => {}
+                            } // TODO: make library info available through VarMap
+                        }
+                        else {
+                            eprintln!("{ERROR}: can't find package {target}");
+                            return 10
+                        }
                     }
                     else {
                         eprintln!("{ERROR}: unknown version specification {x:?}");
@@ -443,7 +533,52 @@ fn build_target<'ctx>(t: &Target, data: &RefCell<Option<TargetData>>, targets: &
                         data.borrow_mut().as_mut().unwrap().libs.push(LibInfo::Name(target.clone()));
                     },
                     x => if let Ok(v) = x.parse::<VersionReq>() {
-                        todo!("externally downloaded projects aren't implemented")
+                        if let Some(pkg) = package::Package::registry().get(target) {
+                            match pkg.install(opts.triple.as_str().to_str().unwrap(), Some(v), package::InstallOptions::default()) {
+                                Err(package::InstallError::NoInstallDirectory) => panic!("This would only be reachable if $HOME was deleted in a data race, which may or may not even be possible"),
+                                Err(package::InstallError::DownloadError(e)) => {
+                                    eprintln!("{ERROR}: {e}");
+                                    return 4
+                                },
+                                Err(package::InstallError::StdIoError(e)) => {
+                                    eprintln!("{ERROR}: {e}");
+                                    return 3
+                                },
+                                Err(package::InstallError::GitCloneError(e)) => {
+                                    eprintln!("{ERROR}: {e}");
+                                    return 2
+                                },
+                                Err(package::InstallError::ZipExtractError(e)) => {
+                                    eprintln!("{ERROR}: {e}");
+                                    return 5
+                                },
+                                Err(package::InstallError::BuildFailed(e)) => {
+                                    eprintln!("failed to build package {target}");
+                                    return e
+                                },
+                                Err(package::InstallError::NoMatchesError) => {
+                                    eprintln!("package {target:?} has no releases");
+                                    return 7
+                                },
+                                Err(package::InstallError::CfgFileError(e)) => {
+                                    eprintln!("{ERROR} in {target}'s config file: {e}");
+                                    return 8
+                                },
+                                Err(package::InstallError::InvalidVersionSpec(_, v)) => {
+                                    eprintln!("{ERROR} in {target}'s dependencies: invalid version spec {v}");
+                                    return 9
+                                },
+                                Err(package::InstallError::PkgNotFound(p)) => {
+                                    eprintln!("{ERROR} in {target}'s dependencies: can't find package {p}");
+                                    return 10
+                                },
+                                _ => {}
+                            } // TODO: make library info available through VarMap
+                        }
+                        else {
+                            eprintln!("{ERROR}: can't find package {target}");
+                            return 10
+                        }
                     }
                     else {
                         eprintln!("{ERROR}: unknown version specification {x:?}");

--- a/src/build.rs
+++ b/src/build.rs
@@ -250,6 +250,7 @@ fn build_file<'ctx>(path: &Path, ctx: &mut CompCtx<'ctx>, opts: &BuildOptions) -
     let mut out_path = opts.build_dir.to_path_buf();
     out_path.push(".artifacts");
     out_path.push(path.strip_prefix(opts.source_dir).unwrap_or(path));
+    out_path.set_extension("o");
     if let Err(e) = if out_path.parent().unwrap().exists() {Ok(())} else {std::fs::create_dir_all(out_path.parent().unwrap())} {
         eprintln!("error when creating directory {}: {e}", out_path.parent().unwrap().display());
         return Err(100)

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,370 @@
+#![allow(non_snake_case)]
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::ffi::OsStr;
+use std::process::Command;
+use std::cell::RefCell;
+use serde::*;
+use colored::Colorize;
+use either::Either;
+use semver::{Version, VersionReq};
+use path_dedot::ParseDot;
+use cobalt::context::CompCtx;
+use super::{libs, opt};
+#[derive(Debug, Clone, Deserialize)]
+pub struct Project {
+    pub name: String,
+    pub version: Version,
+    pub author: Option<String>,
+    pub co_version: Option<VersionReq>,
+    #[serde(alias = "description")]
+    pub desc: Option<String>,
+    #[serde(alias = "target")]
+    pub targets: Option<Vec<Target>>,
+    #[serde(alias = "lib")]
+    pub library: Option<Vec<Library>>,
+    #[serde(alias = "exe")]
+    #[serde(alias = "bin")]
+    #[serde(alias = "executable")]
+    pub executable: Option<Vec<Executable>>,
+    pub meta: Option<Vec<Meta>>
+}
+impl Project {
+    pub fn into_targets(self) -> impl Iterator<Item = Target> {
+        self.targets.unwrap_or(vec![]).into_iter()
+        .chain(self.executable.unwrap_or(vec![]).into_iter().map(|Executable {name, files, deps}| Target {target_type: TargetType::Library, name, files, deps}))
+        .chain(self.library.unwrap_or(vec![]).into_iter().map(|Library {name, files, deps}| Target {target_type: TargetType::Library, name, files, deps}))
+        .chain(self.meta.unwrap_or(vec![]).into_iter().map(|Meta {name, deps}| Target {target_type: TargetType::Library, files: None, name, deps}))
+    }
+}
+#[derive(Debug, Clone, Deserialize)]
+pub enum TargetType {
+    #[serde(rename = "exe")]
+    #[serde(alias = "executable")]
+    #[serde(alias = "bin")]
+    #[serde(alias = "binary")]
+    Executable,
+    #[serde(rename = "lib")]
+    #[serde(alias = "library")]
+    Library,
+    #[serde(rename = "meta")]
+    Meta
+}
+#[derive(Debug, Clone, Deserialize)]
+pub struct Target {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub target_type: TargetType,
+    #[serde(with = "either::serde_untagged_optional")]
+    pub files: Option<Either<String, Vec<String>>>,
+    #[serde(alias = "dependencies")]
+    pub deps: Option<HashMap<String, String>>
+}
+#[derive(Debug, Clone, Deserialize)]
+pub struct Executable {
+    pub name: String,
+    #[serde(with = "either::serde_untagged_optional")]
+    pub files: Option<Either<String, Vec<String>>>,
+    #[serde(alias = "dependencies")]
+    pub deps: Option<HashMap<String, String>>
+}
+#[derive(Debug, Clone, Deserialize)]
+pub struct Library {
+    pub name: String,
+    #[serde(with = "either::serde_untagged_optional")]
+    pub files: Option<Either<String, Vec<String>>>,
+    #[serde(alias = "dependencies")]
+    pub deps: Option<HashMap<String, String>>
+}
+#[derive(Debug, Clone, Deserialize)]
+pub struct Meta {
+    pub name: String,
+    #[serde(alias = "dependencies")]
+    pub deps: Option<HashMap<String, String>>
+}
+#[derive(Debug, Clone)]
+pub struct BuildOptions<'a, 'b, 'c, 'd> {
+    pub source_dir: &'a Path,
+    pub build_dir: &'b Path,
+    pub continue_build: bool,
+    pub continue_comp: bool,
+    pub triple: &'c inkwell::targets::TargetTriple,
+    pub profile: &'d str
+}
+enum LibInfo {
+    Name(String),
+    Path(PathBuf)
+}
+#[derive(Default)]
+struct TargetData {
+    pub libs: Vec<LibInfo>,
+    pub deps: Vec<String>,
+}
+static mut FILENAME: String = String::new();
+fn clear_mod<'ctx>(this: &mut HashMap<String, cobalt::Symbol<'ctx>>, module: &inkwell::module::Module<'ctx>) {
+    for (_, sym) in this.iter_mut() {
+        match sym {
+            cobalt::Symbol::Module(m) => clear_mod(m, module),
+            cobalt::Symbol::Variable(v) => if let Some(inkwell::values::BasicValueEnum::PointerValue(pv)) = v.comp_val {
+                let t = inkwell::types::BasicTypeEnum::try_from(pv.get_type().get_element_type());
+                if let Ok(t) = t {
+                    v.comp_val = Some(inkwell::values::BasicValueEnum::PointerValue(module.add_global(t, None, pv.get_name().to_str().expect("global variable should have a name")).as_pointer_value()));
+                }
+            }
+        }
+    }
+}
+fn build_file<'ctx>(path: &Path, ctx: &mut CompCtx<'ctx>, opts: &BuildOptions) -> Result<PathBuf, i32> {
+    let ERROR = &"error".bright_red().bold();
+    let WARNING = &"warning".bright_yellow().bold();
+    let MODULE = &"module".blue().bold();
+    let name = path.to_str().expect("File name must be valid UTF-8");
+    let flags = cobalt::Flags::default();
+    ctx.module.set_name(name);
+    ctx.module.set_source_file_name(name);
+    let fname = unsafe {&mut FILENAME};
+    let mut fail = false;
+    let mut overall_fail = false;
+    let code = match std::fs::read_to_string(path.parse_dot().unwrap()) {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("error occured when trying to open file: {e}");
+            return Err(100)
+        }
+    };
+    let (toks, errs) = cobalt::parser::lexer::lex(code.as_str(), cobalt::Location::from_name(fname.as_str()), &flags);
+    for err in errs {
+        eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {fail = true; overall_fail = true; ERROR}, err.loc, err.message);
+        for note in err.notes {
+            eprintln!("\t{}: {:#}: {}", "note".bold(), note.loc, note.message);
+        }
+    }
+    if fail && !opts.continue_comp {return Err(101)}
+    let (ast, errs) = cobalt::parser::ast::parse(toks.as_slice(), &flags);
+    fail = false;
+    for err in errs {
+        eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {fail = true; overall_fail = true; ERROR}, err.loc, err.message);
+        for note in err.notes {
+            eprintln!("\t{}: {:#}: {}", "note".bold(), note.loc, note.message);
+        }
+    }
+    if fail && !opts.continue_comp {return Err(101)}
+    let (_, errs) = ast.codegen(&ctx);
+    fail = false;
+    for err in errs {
+        eprintln!("{}: {:#}: {}", if err.code < 100 {WARNING} else {fail = true; overall_fail = true; ERROR}, err.loc, err.message);
+        for note in err.notes {
+            eprintln!("\t{}: {:#}: {}", "note".bold(), note.loc, note.message);
+        }
+    }
+    if fail && !opts.continue_comp {
+        let new = ctx.context.create_module("");
+        new.set_triple(&ctx.module.get_triple());
+        ctx.with_vars(|v| clear_mod(&mut v.symbols, &new));
+        ctx.module = new;
+        return Err(101)
+    }
+    if let Err(msg) = ctx.module.verify() {
+        eprintln!("{ERROR}: {MODULE}: {}", msg.to_string());
+        let new = ctx.context.create_module("");
+        new.set_triple(&ctx.module.get_triple());
+        ctx.with_vars(|v| clear_mod(&mut v.symbols, &new));
+        ctx.module = new;
+        return Err(101)
+    }
+    if overall_fail {
+        let new = ctx.context.create_module("");
+        new.set_triple(&ctx.module.get_triple());
+        ctx.with_vars(|v| clear_mod(&mut v.symbols, &new));
+        ctx.module = new;
+        return Err(101)
+    }
+    let pm = inkwell::passes::PassManager::create(());
+    opt::load_profile(Some(opts.profile), &pm);
+    pm.run_on(&ctx.module);
+    let target_machine = inkwell::targets::Target::from_triple(opts.triple).unwrap().create_target_machine(
+        opts.triple,
+        "",
+        "",
+        inkwell::OptimizationLevel::None,
+        inkwell::targets::RelocMode::PIC,
+        inkwell::targets::CodeModel::Small
+    ).expect("failed to create target machine");
+    let mut out_path = opts.build_dir.to_path_buf();
+    out_path.push(".artifacts");
+    out_path.push(path.strip_prefix(opts.source_dir).unwrap_or(path));
+    if let Err(e) = if out_path.parent().unwrap().exists() {Ok(())} else {std::fs::create_dir_all(out_path.parent().unwrap())} {
+        eprintln!("error when creating directory {}: {e}", out_path.parent().unwrap().display());
+        return Err(100)
+    }
+    target_machine.write_to_file(&ctx.module, inkwell::targets::FileType::Object, out_path.as_path()).unwrap();
+    let new = ctx.context.create_module("");
+    new.set_triple(&ctx.module.get_triple());
+    ctx.with_vars(|v| clear_mod(&mut v.symbols, &new));
+    ctx.module = new;
+    Ok(out_path)
+}
+fn build_target<'ctx>(t: &Target, data: &RefCell<Option<TargetData>>, targets: &HashMap<String, (Target, RefCell<Option<TargetData>>)>, ctx: &mut CompCtx<'ctx>, opts: &BuildOptions) -> i32 {
+    let ERROR = "error".bright_red().bold();
+    match t.target_type {
+        TargetType::Executable => {
+            for (target, version) in t.deps.as_ref().unwrap_or(&HashMap::new()).iter() {
+                match version.as_str() {
+                    "project" => {
+                        let (t, d) = if let Some(t) = targets.get(target.as_str()) {t} else {
+                            eprintln!("{ERROR}: target {target:?} is not a target in this project");
+                            return 105
+                        };
+                        if d.borrow().is_some() {continue}
+                        else {*d.borrow_mut() = Some(TargetData::default())}
+                        let res = build_target(t, d, targets, ctx, opts);
+                        if res != 0 {return res}
+                        data.borrow_mut().as_mut().unwrap().deps.push(target.clone());
+                    },
+                    "system" => {
+                        data.borrow_mut().as_mut().unwrap().libs.push(LibInfo::Name(target.clone()));
+                    },
+                    x => if let Ok(v) = x.parse::<VersionReq>() {
+                        todo!("externally downloaded projects aren't implemented")
+                    }
+                    else {
+                        eprintln!("{ERROR}: unknown version specification {x:?}");
+                        return 107
+                    }
+                }
+            }
+            0
+        },
+        TargetType::Library => {
+            for (target, version) in t.deps.as_ref().unwrap_or(&HashMap::new()).iter() {
+                match version.as_str() {
+                    "project" => {
+                        let (t, d) = if let Some(t) = targets.get(target.as_str()) {t} else {
+                            eprintln!("{ERROR}: target {target:?} is not a target in this project");
+                            return 105
+                        };
+                        if d.borrow().is_some() {continue}
+                        else {*d.borrow_mut() = Some(TargetData::default())}
+                        let res = build_target(t, d, targets, ctx, opts);
+                        if res != 0 {return res}
+                        data.borrow_mut().as_mut().unwrap().deps.push(target.clone());
+                    },
+                    "system" => {
+                        data.borrow_mut().as_mut().unwrap().libs.push(LibInfo::Name(target.clone()));
+                    },
+                    x => if let Ok(v) = x.parse::<VersionReq>() {
+                        todo!("externally downloaded projects aren't implemented")
+                    }
+                    else {
+                        eprintln!("{ERROR}: unknown version specification {x:?}");
+                        return 107
+                    }
+                }
+            }
+            let mut paths = vec![];
+            match t.files.as_ref() {
+                Some(either::Left(files)) => for file in (match glob::glob((opts.source_dir.to_str().unwrap_or("").to_string() + "/" + files).as_str()) {
+                    Ok(f) => f,
+                    Err(e) => {
+                        eprintln!("error in file glob: {e}");
+                        return 108;
+                    }
+                }).filter_map(Result::ok) {
+                    if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {continue}
+                    match build_file(file.as_path(), ctx, opts) {
+                        Ok(path) => paths.push(path),
+                        Err(code) => return code
+                    }
+                },
+                Some(either::Right(files)) => for file in files.iter().filter_map(|f| match glob::glob((opts.source_dir.to_str()?.to_string() + "/" + f).as_str()) {
+                    Ok(f) => Some(f),
+                    Err(e) => {
+                        eprintln!("error in file glob: {e}");
+                        None
+                    }
+                }).flatten().filter_map(Result::ok) {
+                    if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {continue}
+                    match build_file(file.as_path(), ctx, opts) {
+                        Ok(path) => paths.push(path),
+                        Err(code) => return code
+                    }
+                },
+                None => {
+                    eprintln!("{ERROR}: library target must have files");
+                    return 106;
+                }
+            }
+            let mut output = opts.build_dir.to_path_buf();
+            output.push(format!("{}.colib", t.name));
+            Command::new("ar").args([OsStr::new("-rcs"), output.as_os_str()].into_iter().chain(paths.iter().map(|f| f.as_os_str()))).status().ok().and_then(|x| x.code()).unwrap_or_else(|| {
+                eprintln!("{ERROR}: could not invoke ar");
+                109
+            })
+        },
+        TargetType::Meta => {
+            if t.files.is_some() {
+                eprintln!("{ERROR}: meta target cannot have files");
+                return 106;
+            }
+            for (target, version) in t.deps.as_ref().unwrap_or(&HashMap::new()).iter() {
+                match version.as_str() {
+                    "project" => {
+                        let (t, d) = if let Some(t) = targets.get(target.as_str()) {t} else {
+                            eprintln!("{ERROR}: target {target:?} is not a target in this project");
+                            return 105
+                        };
+                        if d.borrow().is_some() {continue}
+                        else {*d.borrow_mut() = Some(TargetData::default())}
+                        let res = build_target(t, d, targets, ctx, opts);
+                        if res != 0 {return res}
+                        data.borrow_mut().as_mut().unwrap().deps.push(target.clone());
+                    },
+                    "system" => {
+                        data.borrow_mut().as_mut().unwrap().libs.push(LibInfo::Name(target.clone()));
+                    },
+                    x => if let Ok(v) = x.parse::<VersionReq>() {
+                        todo!("externally downloaded projects aren't implemented")
+                    }
+                    else {
+                        eprintln!("{ERROR}: unknown version specification {x:?}");
+                        return 107
+                    }
+                }
+            }
+            0
+        }
+    }
+}
+pub fn build(pkg: Project, to_build: Option<Vec<String>>, opts: &BuildOptions) -> i32 {
+    let ERROR = "error".bright_red().bold();
+    if let Some(v) = &pkg.co_version {
+        if !v.matches(&env!("CARGO_PKG_VERSION").parse::<Version>().unwrap()) {
+            eprintln!(r#"{ERROR}: project has Cobalt version requirement "{v}", but Cobalt version is {}"#, env!("CARGO_PKG_VERSION"));
+            return 104;
+        }
+    }
+    let targets = pkg.into_targets().map(|t| (t.name.clone(), (t, RefCell::new(None)))).collect::<HashMap<String, (Target, RefCell<Option<TargetData>>)>>();
+    let ink_ctx = inkwell::context::Context::create();
+    let mut ctx = CompCtx::new(&ink_ctx, "");
+    if let Some(tb) = to_build {
+        for target_name in tb {
+            let (target, data) = if let Some(t) = targets.get(&target_name) {t} else {
+                eprintln!("{ERROR}: target {target_name:?} is not a target in this project");
+                return 105;
+            };
+            if data.borrow().is_some() {continue}
+            else {*data.borrow_mut() = Some(TargetData::default())}
+            let res = build_target(target, data, &targets, &mut ctx, opts);
+            if res != 0 {return res}
+        }
+    }
+    else {
+        for (_, (target, data)) in targets.iter() {
+            if data.borrow().is_some() {continue}
+            else {*data.borrow_mut() = Some(TargetData::default())}
+            let res = build_target(target, data, &targets, &mut ctx, opts);
+            if res != 0 {return res}
+        }
+    }
+    0
+}

--- a/src/build.rs
+++ b/src/build.rs
@@ -33,7 +33,7 @@ pub struct Project {
 impl Project {
     pub fn into_targets(self) -> impl Iterator<Item = Target> {
         self.targets.unwrap_or(vec![]).into_iter()
-        .chain(self.executable.unwrap_or(vec![]).into_iter().map(|Executable {name, files, deps, needs_crt}| Target {target_type: TargetType::Library, name, files, deps, needs_crt}))
+        .chain(self.executable.unwrap_or(vec![]).into_iter().map(|Executable {name, files, deps, needs_crt}| Target {target_type: TargetType::Executable, name, files, deps, needs_crt}))
         .chain(self.library.unwrap_or(vec![]).into_iter().map(|Library {name, files, deps, needs_crt}| Target {target_type: TargetType::Library, name, files, deps, needs_crt}))
         .chain(self.meta.unwrap_or(vec![]).into_iter().map(|Meta {name, deps, needs_crt}| Target {target_type: TargetType::Library, files: None, name, deps, needs_crt}))
     }

--- a/src/libs.rs
+++ b/src/libs.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-pub fn find_libs<'a>(mut libs: Vec<&'a str>, dirs: Vec<&str>) -> (Vec<PathBuf>, Vec<&'a str>) {
+pub fn find_libs<'a>(mut libs: Vec<&'a str>, dirs: Vec<&str>) -> (Vec<(PathBuf, &'a str)>, Vec<&'a str>) {
     let mut outs = vec![];
     let it = dirs.into_iter().flat_map(|dir| walkdir::WalkDir::new(dir).follow_links(true).into_iter()).filter_map(|x| x.ok()).filter(|x| x.file_type().is_file());
     it.for_each(|x| {
@@ -11,7 +11,7 @@ pub fn find_libs<'a>(mut libs: Vec<&'a str>, dirs: Vec<&str>) -> (Vec<PathBuf>, 
         if let Some(stem) = path.file_stem().and_then(|x| x.to_str()) {
             for lib in libs.iter_mut().filter(|x| x.len() > 0) {
                 if lib == &stem || (stem.starts_with("lib") && lib == &&stem[3..]) {
-                    outs.push(path.clone());
+                    outs.push((path.clone(), *lib));
                     *lib = "";
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -532,7 +532,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 eprintln!("couldn't find library {nf}");
                             }
                             if notfound.len() > 0 {exit(102)}
-                            for lib in libs {
+                            for (lib, _) in libs {
                                 let parent = lib.parent().unwrap().as_os_str().to_os_string();
                                 args.push(OsString::from("-L"));
                                 args.push(parent.clone());
@@ -551,7 +551,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 eprintln!("couldn't find library {nf}");
                             }
                             if notfound.len() > 0 {exit(102)}
-                            for lib in libs {
+                            for (lib, _) in libs {
                                 let parent = lib.parent().unwrap().as_os_str().to_os_string();
                                 args.push(OsString::from("-L"));
                                 args.push(parent.clone());
@@ -577,7 +577,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 eprintln!("couldn't find library {nf}");
                             }
                             if notfound.len() > 0 {exit(102)}
-                            for lib in libs {
+                            for (lib, _) in libs {
                                 buff += lib.to_str().expect("library path must be valid UTF-8");
                                 buff.push('\0');
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1033,7 +1033,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             };
             let source_dir: &Path = source_dir.map_or(project_dir.as_path(), Path::new);
-            let build_dir: PathBuf = build_dir.map_or_else(|| project_dir.clone(), PathBuf::from);
+            let build_dir: PathBuf = build_dir.map_or_else(|| format!("{project_dir/build/", PathBuf::from);
             if triple.is_some() {Target::initialize_all(&INIT_NEEDED)}
             else {Target::initialize_native(&INIT_NEEDED)?}
             exit(build::build(project_data, if targets.len() == 0 {None} else {Some(targets.into_iter().map(String::from).collect())}, &build::BuildOptions {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod libs;
 mod jit;
 mod opt;
 mod build;
+mod package;
 const HELP: &str = "co- Cobalt compiler and build system
 A program can be compiled using the `co aot' subcommand, or JIT compiled using the `co jit' subcommand";
 static mut FILENAME: String = String::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1033,7 +1033,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             };
             let source_dir: &Path = source_dir.map_or(project_dir.as_path(), Path::new);
-            let build_dir: PathBuf = build_dir.map_or_else(|| format!("{project_dir/build/", PathBuf::from);
+            let build_dir: PathBuf = build_dir.map_or_else(|| {
+                let mut dir = project_dir.clone();
+                dir.push("build");
+                dir
+            }, PathBuf::from);
             if triple.is_some() {Target::initialize_all(&INIT_NEEDED)}
             else {Target::initialize_native(&INIT_NEEDED)?}
             exit(build::build(project_data, if targets.len() == 0 {None} else {Some(targets.into_iter().map(String::from).collect())}, &build::BuildOptions {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1070,7 +1070,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let registry = package::Package::registry();
             for pkg in args.iter().skip(2).skip_while(|x| x.len() == 0) {
                 if let Some(p) = registry.get(pkg) {
-                    match p.install(TargetMachine::get_default_triple().as_str().to_str().unwrap(), None, package::InstallOptions::default()).map_err(|e| e.unwrap_base()) {
+                    match p.install(TargetMachine::get_default_triple().as_str().to_str().unwrap(), None, package::InstallOptions::default()) {
                         Err(package::InstallError::NoInstallDirectory) => panic!("This would only be reachable if $HOME was deleted in a data race, which may or may not even be possible"),
                         Err(package::InstallError::DownloadError(e)) => {
                             eprintln!("{ERROR}: {e}");
@@ -1103,6 +1103,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         Err(package::InstallError::InvalidVersionSpec(_, v)) => {
                             eprintln!("{ERROR} in {pkg}'s dependencies: invalid version spec {v}");
                             good = 9;
+                        },
+                        Err(package::InstallError::PkgNotFound(p)) => {
+                            eprintln!("{ERROR} in {pkg}'s dependencies: can't find package {p}");
+                            good = 10;
                         },
                         _ => {}
                     }

--- a/src/package.rs
+++ b/src/package.rs
@@ -95,9 +95,8 @@ impl Package {
             else if let Ok(dir) = std::env::var("HOME") {PathBuf::from(format!("{dir}/.cobalt/packages"))}
             else {return Err(InstallError::NoInstallDirectory)};
         install_loc.push(format!("{}-{v}", self.name));
-        if !install_loc.exists() {
-            std::fs::create_dir_all(&install_loc)?;
-        }
+        if install_loc.exists() {return Ok(())}
+        else {std::fs::create_dir_all(&install_loc)?;}
         let install_dir = install_loc.clone();
         if let Some(url) = rel.prebuilt.get(triple) {
             if opts.output.verbose() {eprintln!("\tdownloading prebuilt version from {url}");}

--- a/src/package.rs
+++ b/src/package.rs
@@ -50,7 +50,7 @@ impl Package {
             else if let Ok(dir) = std::env::var("COBALT_DIR") {PathBuf::from(format!("{dir}/packages"))}
             else if let Ok(dir) = std::env::var("HOME") {PathBuf::from(format!("{dir}/.cobalt/packages"))}
             else {return Err(InstallError::NoInstallDirectory)};
-        install_loc.push(&self.name);
+        install_loc.push(format!("{}-{v}", self.name));
         if !install_loc.exists() {
             std::fs::create_dir_all(&install_loc)?;
         }
@@ -198,5 +198,5 @@ pub fn packages() -> Result<HashMap<String, Package>, PackageUpdateError> {
         },
         Err(_) => {Repository::clone("https://github.com/matt-cornell/cobalt-registry.git", &cobalt_path)?;} // eventually, this might be under a cobalt-lang org, or somewhere else
     }
-    Ok(std::fs::read_dir(cobalt_path)?.filter_map(|entry| Some((entry.as_ref().ok()?.file_name().to_str()?.to_string(), toml::from_str::<Package>(&std::fs::read_to_string(entry.as_ref().ok()?.file_name()).ok()?).ok()?))).collect())
+    Ok(std::fs::read_dir(cobalt_path)?.filter_map(|entry| Some(toml::from_str::<Package>(&std::fs::read_to_string(entry.as_ref().ok()?.file_name()).ok()?).ok()?)).map(|pkg| (pkg.name.clone(), pkg)).collect())
 }

--- a/src/package.rs
+++ b/src/package.rs
@@ -83,20 +83,24 @@ impl Package {
                 continue_build: false,
                 triple: &triple
             });
+            if opts.clean {std::fs::remove_all(install_loc)}
             if res == 0 {Ok(())} else {Err(InstallError::BuildFailed(res))}
         }
     }
 }
 #[derive(Debug, Clone, Copy, Default)]
-pub enum OutputLevel {Normal, Quiet Verbose}
+pub enum OutputLevel {Normal, Quiet, Verbose}
 impl OutputLevel {
     pub fn verbose(self) -> bool {self == Verbose}
     pub fn quiet(self) -> bool {self == Quiet}
 }
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub struct InstallOptions {
     pub output: OutputLevel,
     pub clean: bool
+}
+impl Default for InstallOptions {
+    fn default() -> Self {InstallOptions {output: OutputLevel::Normal, clean: true}}
 }
 #[derive(Debug, Clone)]
 pub enum InstallError {

--- a/src/package.rs
+++ b/src/package.rs
@@ -2,6 +2,7 @@ use serde::*;
 use semver::{Version, VersionReq};
 use flate2::write::GzDecoder;
 use super::build::{Project, BuildOptions, build};
+use git2::Repository;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Package {
     name: String,
@@ -38,10 +39,10 @@ impl Package {
             else if let Some(dir) = std::env::get("COBALT_DIR") {PathBuf::from(format!("{dir}/packages"))}
             else if let Some(dir) = std::env::get("HOME") {PathBuf::from(format!("{dir}/.cobalt/packages"))}
             else {return Err(InstallError::NoInstallDirectory)};
+        install_loc.push(self.name);
         if !install_loc.exists() {
             std::fs::create_dir_all(install_loc).map_err(InstallError::StdIoError)?;
         }
-        install_loc.push(self.name);
         let install_dir = install_loc.clone();
         if let Some(url) = rel.prebuilt.get(triple) {
             if opts.output.verbose() {eprintln!("\tdownloading prebuilt version from {url}");}
@@ -50,25 +51,25 @@ impl Package {
             tar::Archive::new(decoded).unpack(install_loc);
         }
         else {
-            if opts.verbose {eprintln!("\tno prebuilt version available, building from source");}
+            if opts.verbose {eprint!("\tno prebuilt version available, building from source... ");}
             install_loc.push(".download");
             let triple = inkwell::targets::TargetTriple::new(triple);
             match rel.src {
                 Git(url) => {
-                    if opts.output.verbose() {eprintln!("\tcloning from git repository from {url}");}
-                    git2::Repository::clone(url, install_loc).map_err(InstallError::GitCloneError);
+                    if opts.output.verbose() {eprintln!("cloning from git repository from {url}");}
+                    Repository::clone(url, install_loc).map_err(InstallError::GitCloneError);
                 },
                 Tarball(url) => {
-                    if opts.output.verbose() {eprintln!("\tdownloading source tarball from {url}");}
+                    if opts.output.verbose() {eprintln!("downloading source tarball from {url}");}
                     let body = reqwest::blocking::get(url).map_err(InstallError::DownloadError)?;
                     let decoded = GzDecoder::new(body);
                     tar::Archive::new(decoded).unpack(install_loc);
                 },
                 Zipball(url) => {
-                    if opts.output.verbose() {eprintln!("\tdownloading source zipball from {url}");}
+                    if opts.output.verbose() {eprintln!("downloading source zipball from {url}");}
                     let body = reqwest::blocking::get(url).map_err(InstallError::DownloadError)?;
                     let reader = std::io::BufReader::new(body);
-                    zip_extract::extract(reader, &install_loc, true).map_err(InstallError::ZipExtractError);
+                    zip_extract::extract(reader, &install_loc, true).map_err(InstallError::ZipExtractError)?;
                 }
             }
             if !opts.output.quiet() {eprintln!("building {}", self.name)}
@@ -105,4 +106,54 @@ pub enum InstallError {
     GitCloneError(git2::Error),
     StdIoError(std::io::Error),
     BuildFailed(i32)
+}
+impl From<zip_extract::ZipError> for InstallError {
+    pub fn from(err: zip_extract::ZipError) -> Self {InstallError::ZipExtractError(err)}
+}
+impl From<reqwest::Error> for InstallError {
+    pub fn from(err: reqwest::Error) -> Self {InstallError::DownloadError(err)}
+}
+impl From<git2::Error> for InstallError {
+    pub fn from(err: git2::Error) -> Self {InstallError::GitError(err)}
+}
+impl From<std::io::::Error> for InstallError {
+    pub fn from(err: std::io::Error) -> Self {InstallError::StdIoError(err)}
+}
+#[derive(Debug, Clone)]
+pub enum PackageUpdateError {
+    NoInstallDirectory,
+    GitError(git2::Error),
+    StdIoError(std::io::Error)
+}
+impl From<git2::Error> for PackageUpdateError {
+    pub fn from(err: git2::Error) -> Self {PackageUpdateError::GitError(err)}
+}
+impl From<std::io::Error> for PackageUpdateError {
+    pub fn from(err: std::io::Error) -> Self {PackageUpdateError::StdIoError(err)}
+}
+pub fn packages() -> Result<HashMap<String, Package>, PackageUpdateError> {
+    let cobalt_path = 
+        if let Some(path) = std::env::get("COBALT_DIR") {format!("{path}/registry")}
+        else if let Some(path) = std::env::get("HOME") {format!("{path}/.cobalt/registry")}
+        else {return Err(PackageUpdateError::NoInstallDirectory)};
+    match Repository::open(&cobalt_path)) {
+        Ok(repo) => { // pull
+            repo.find_remote("origin")?.fetch("main", None, None)?;
+            let fetch_head = repo.find_reference("FETCH_HEAD")?;
+            let fetch_commit = repo.reference_to_annotated_commit(&fetch_head)?;
+            let analysis = repo.merge_analysis(&[&fetch_commit])?;
+            if analysis.0.is_up_to_date() {}
+            else if analysis.0.is_fast_forward() {
+                let mut reference = repo.find_reference("refs/heads/main")?;
+                reference.set_target(fetch_commit.id(), "Fast-Forward")?;
+                repo.set_head("refs/heads/main")?;
+                repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))
+            }
+            else {
+                panic!("Pull from Cobalt package registry is not fast-forward!");
+            }
+        },
+        Err(_) => Repository::clone("https://github.com/matt-cornell/cobalt-registry.git", &cobalt_path) // eventually, this might be under a cobalt-lang org, or somewhere else
+    }?
+    Ok(std::fs::read_dir(cobalt_path)?.filter_map(|entry| Some((entry.file_name(), toml::from_str::<Package>(std::fs::read_to_string(entry.ok()?.file_name()).ok()?).ok()?))).collect())
 }

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,0 +1,108 @@
+use serde::*;
+use semver::{Version, VersionReq};
+use flate2::write::GzDecoder;
+use super::build::{Project, BuildOptions, build};
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Package {
+    name: String,
+    author: String,
+    #[serde(alias = "description")]
+    desc: String,
+    #[serde(alias = "release")]
+    #[serde(default)]
+    releases: HashMap<Version, Release>
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Source {
+    #[serde(rename = "git")]
+    Git(String),
+    #[serde(rename = "tar")]
+    #[serde(alias = "tarball")]
+    Tarball(String),
+    #[serde(rename = "zip")]
+    #[serde(alias = "zipball")]
+    Zipball(String)
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Release {
+    #[serde(flatten)]
+    src: Source,
+    prebuilt: HashMap<String, Source>
+}
+impl Package {
+    pub fn install(&self, triple: String, version: Option<VersionReq>, opts: InstallOptions) -> Result<(), InstallError> {
+        let (v, rel) = self.releases.iter().filter(|(k, _)| if let Some(v) = version {k.matches(v)} else {true}).max_by_key(|x| x.0);
+        if !opts.output.quiet() {eprintln!("installing {} version {v}", self.name);}
+        let mut install_loc = 
+            if let Some(dir) = std::env::get("COBALT_PKG_DIR") {PathBuf::from(dir)} 
+            else if let Some(dir) = std::env::get("COBALT_DIR") {PathBuf::from(format!("{dir}/packages"))}
+            else if let Some(dir) = std::env::get("HOME") {PathBuf::from(format!("{dir}/.cobalt/packages"))}
+            else {return Err(InstallError::NoInstallDirectory)};
+        if !install_loc.exists() {
+            std::fs::create_dir_all(install_loc).map_err(InstallError::StdIoError)?;
+        }
+        install_loc.push(self.name);
+        let install_dir = install_loc.clone();
+        if let Some(url) = rel.prebuilt.get(triple) {
+            if opts.output.verbose() {eprintln!("\tdownloading prebuilt version from {url}");}
+            let body = reqwest::blocking::get(url).map_err(InstallError::DownloadError)?;
+            let decoded = GzDecoder::new(body);
+            tar::Archive::new(decoded).unpack(install_loc);
+        }
+        else {
+            if opts.verbose {eprintln!("\tno prebuilt version available, building from source");}
+            install_loc.push(".download");
+            let triple = inkwell::targets::TargetTriple::new(triple);
+            match rel.src {
+                Git(url) => {
+                    if opts.output.verbose() {eprintln!("\tcloning from git repository from {url}");}
+                    git2::Repository::clone(url, install_loc).map_err(InstallError::GitCloneError);
+                },
+                Tarball(url) => {
+                    if opts.output.verbose() {eprintln!("\tdownloading source tarball from {url}");}
+                    let body = reqwest::blocking::get(url).map_err(InstallError::DownloadError)?;
+                    let decoded = GzDecoder::new(body);
+                    tar::Archive::new(decoded).unpack(install_loc);
+                },
+                Zipball(url) => {
+                    if opts.output.verbose() {eprintln!("\tdownloading source zipball from {url}");}
+                    let body = reqwest::blocking::get(url).map_err(InstallError::DownloadError)?;
+                    let reader = std::io::BufReader::new(body);
+                    zip_extract::extract(reader, &install_loc, true).map_err(InstallError::ZipExtractError);
+                }
+            }
+            if !opts.output.quiet() {eprintln!("building {}", self.name)}
+            install_loc.push("cobalt.toml");
+            let cfg = std::fs::read_to_string(install_loc).map_err(InstallError::StdIoError)?;
+            install_loc.pop();
+            let res = build(toml::from_str(cfg), BuildOptions {
+                source_dir: &install_loc,
+                build_dir: &install_dir,
+                continue_comp: false,
+                continue_build: false,
+                triple: &triple
+            });
+            if res == 0 {Ok(())} else {Err(InstallError::BuildFailed(res))}
+        }
+    }
+}
+#[derive(Debug, Clone, Copy, Default)]
+pub enum OutputLevel {Normal, Quiet Verbose}
+impl OutputLevel {
+    pub fn verbose(self) -> bool {self == Verbose}
+    pub fn quiet(self) -> bool {self == Quiet}
+}
+#[derive(Debug, Clone, Copy, Default)]
+pub struct InstallOptions {
+    pub output: OutputLevel,
+    pub clean: bool
+}
+#[derive(Debug, Clone)]
+pub enum InstallError {
+    NoInstallDirectory,
+    ZipExtractError(zip_extract::ZipError),
+    DownloadError(reqwest::Error),
+    GitCloneError(git2::Error),
+    StdIoError(std::io::Error),
+    BuildFailed(i32)
+}


### PR DESCRIPTION
Changes:
- Added builds:
  - Builds search for `cobalt.toml` in `$PROJECT_DIR` as the configuration file by default. This can be changed by specifying another file or even stdin for the input.
  - Project configuration is a TOML file with the following fields:
    - `name`
    - `author`
    - `version`
    - `co_version` (optional, build fails if Cobalt version doesn't match this)
    - `[[targets]]` | `[[target]]`
      - `type`: build type, options are:
        - "lib" | "library"
        - "exe" | "executable" | "bin" | "binary"
        - "meta" - No files, only dependencies
      - `needs-libc` | `needs-crt` (bool) - Link using a C compiler instead of `ld`
      - `files` - glob pattern or array of glob patterns
      - `deps`- table of dependency name and version. Special version requirements are "project" and "system", which link to other targets and system libraries, respectively
    - `[[lib]]` | `[[library]]` - targets with `type` field autoset to "lib"
    - `[[bin]]` | `[[binary]]` | `[[exe]]` | `[[executable]]` - targets with `type` autoset to "exe"
    - `[[meta]]` - targets with `type` autoset to "exe"
  - `build` subcommand:
    - `-s` to change source directory
    - `-b` to change build directory
    - `-T` to specify targetse
    - `-t` to change build triple
- Added packages:
  - Packages are TOML files with the following fields:
    - `name`
    - `author`
    - `[releases]`
      - `[<version>]`
        - source:
          - `git` - clone a Git repository
          - `tar` | `tarball` - download and extract a tarball (gzipped)
          - `zip` | `zipball` - download and extract a zipball
        - `[prebuilt]` (optional)
          - `<target machine>` - source, specified the same as above
  - Added `install` subcommand, which installs the specified packages
Commits:
- Started work on build system
- Added CLI for builds
- Added support for executable targets
- Changed default build directory to `$PROJECT_DIR/build`
- Fixed executables being parsed as libraries
- Fixed default build directory
- Restricted public build API
- Began work on packages
- Added function to update package registry
- Added cleaning after builds from source
- Fixed various build errors
- Added 'install' subcommand
- Modified `package::packages()` to read package name instead from file instead of relying on file name
- Added static package registry
- Stopped `Package::install` from reinstalling already-installed targets
- Added options to reinstall packages or force build from source
- Added ability to build dependencies
