### PR TITLE
Add metadata for libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ llvm-sys = { version = "140", features = ["strict-versioning"] }
 unicode-ident = "1.0.5"
 walkdir = "2"
 ar = "0.9.0"
+path-dedot = "3.0.18"
 
 [lib]
 name = "cobalt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", feat
 llvm-sys = { version = "140", features = ["strict-versioning"] }
 unicode-ident = "1.0.5"
 walkdir = "2"
+ar = "0.9.0"
 
 [lib]
 name = "cobalt"

--- a/src/build.rs
+++ b/src/build.rs
@@ -2,7 +2,7 @@
 #![allow(unused_variables)]
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::process::Command;
 use std::cell::RefCell;
 use serde::*;
@@ -114,7 +114,8 @@ pub struct BuildOptions<'a, 'b, 'c, 'd> {
     pub continue_build: bool,
     pub continue_comp: bool,
     pub triple: &'c inkwell::targets::TargetTriple,
-    pub profile: &'d str
+    pub profile: &'d str,
+    pub link_dirs: Vec<String>
 }
 enum LibInfo {
     Name(String),
@@ -274,7 +275,8 @@ fn build_file<'ctx>(path: &Path, ctx: &mut CompCtx<'ctx>, opts: &BuildOptions) -
     Ok(out_path)
 }
 fn build_target<'ctx>(t: &Target, data: &RefCell<Option<TargetData>>, targets: &HashMap<String, (Target, RefCell<Option<TargetData>>)>, ctx: &mut CompCtx<'ctx>, opts: &BuildOptions) -> i32 {
-    let ERROR = "error".bright_red().bold();
+    let ERROR = &"error".bright_red().bold();
+    let WARNING = &"warning".bright_yellow().bold();
     match t.target_type {
         TargetType::Executable => {
             if t.needs_crt {data.borrow_mut().as_mut().unwrap().needs_crt = true;}
@@ -336,7 +338,7 @@ fn build_target<'ctx>(t: &Target, data: &RefCell<Option<TargetData>>, targets: &
                                     return 10
                                 },
                                 _ => {}
-                            } // TODO: make library info available through VarMap
+                            }
                         }
                         else {
                             eprintln!("{ERROR}: can't find package {target}");
@@ -351,34 +353,44 @@ fn build_target<'ctx>(t: &Target, data: &RefCell<Option<TargetData>>, targets: &
             }
             let mut paths = vec![];
             match t.files.as_ref() {
-                Some(either::Left(files)) => for file in (match glob::glob((opts.source_dir.to_str().unwrap_or("").to_string() + "/" + files).as_str()) {
-                    Ok(f) => f,
-                    Err(e) => {
-                        eprintln!("error in file glob: {e}");
-                        return 108;
+                Some(either::Left(files)) => {
+                    let mut passed = false;
+                    for file in (match glob::glob((opts.source_dir.to_str().unwrap_or("").to_string() + "/" + files).as_str()) {
+                        Ok(f) => f,
+                        Err(e) => {
+                            eprintln!("error in file glob: {e}");
+                            return 108;
+                        }
+                    }).filter_map(Result::ok) {
+                        if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {continue}
+                        match build_file(file.as_path(), ctx, opts) {
+                            Ok(path) => paths.push(path),
+                            Err(code) => return code
+                        }
+                        passed = true;
                     }
-                }).filter_map(Result::ok) {
-                    if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {continue}
-                    match build_file(file.as_path(), ctx, opts) {
-                        Ok(path) => paths.push(path),
-                        Err(code) => return code
-                    }
+                    if !passed {eprintln!("{WARNING}: no files matching glob {files}")}
                 },
-                Some(either::Right(files)) => for file in files.iter().filter_map(|f| match glob::glob((opts.source_dir.to_str()?.to_string() + "/" + f).as_str()) {
-                    Ok(f) => Some(f),
-                    Err(e) => {
-                        eprintln!("error in file glob: {e}");
-                        None
+                Some(either::Right(files)) => {
+                    let mut failed = false;
+                    for file in files.iter().filter_map(|f| Some(opts.source_dir.to_str()?.to_string() + "/" + f)) {
+                        if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {
+                            eprintln!("{ERROR}: couldn't find file {file}");
+                            if opts.continue_build {
+                                failed = true;
+                                continue
+                            }
+                            else {return 120}
+                        }
+                        match build_file(Path::new(&file), ctx, opts) {
+                            Ok(path) => paths.push(path),
+                            Err(code) => return code
+                        }
                     }
-                }).flatten().filter_map(Result::ok) {
-                    if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {continue}
-                    match build_file(file.as_path(), ctx, opts) {
-                        Ok(path) => paths.push(path),
-                        Err(code) => return code
-                    }
+                    if failed {return 120}
                 },
                 None => {
-                    eprintln!("{ERROR}: executable target must have files");
+                    eprintln!("{ERROR}: library target must have files");
                     return 106;
                 }
             }
@@ -478,31 +490,41 @@ fn build_target<'ctx>(t: &Target, data: &RefCell<Option<TargetData>>, targets: &
             }
             let mut paths = vec![];
             match t.files.as_ref() {
-                Some(either::Left(files)) => for file in (match glob::glob((opts.source_dir.to_str().unwrap_or("").to_string() + "/" + files).as_str()) {
-                    Ok(f) => f,
-                    Err(e) => {
-                        eprintln!("error in file glob: {e}");
-                        return 108;
+                Some(either::Left(files)) => {
+                    let mut passed = false;
+                    for file in (match glob::glob((opts.source_dir.to_str().unwrap_or("").to_string() + "/" + files).as_str()) {
+                        Ok(f) => f,
+                        Err(e) => {
+                            eprintln!("error in file glob: {e}");
+                            return 108;
+                        }
+                    }).filter_map(Result::ok) {
+                        if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {continue}
+                        match build_file(file.as_path(), ctx, opts) {
+                            Ok(path) => paths.push(path),
+                            Err(code) => return code
+                        }
+                        passed = true;
                     }
-                }).filter_map(Result::ok) {
-                    if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {continue}
-                    match build_file(file.as_path(), ctx, opts) {
-                        Ok(path) => paths.push(path),
-                        Err(code) => return code
-                    }
+                    if !passed {eprintln!("{WARNING}: no files matching glob {files}")}
                 },
-                Some(either::Right(files)) => for file in files.iter().filter_map(|f| match glob::glob((opts.source_dir.to_str()?.to_string() + "/" + f).as_str()) {
-                    Ok(f) => Some(f),
-                    Err(e) => {
-                        eprintln!("error in file glob: {e}");
-                        None
+                Some(either::Right(files)) => {
+                    let mut failed = false;
+                    for file in files.iter().filter_map(|f| Some(opts.source_dir.to_str()?.to_string() + "/" + f)) {
+                        if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {
+                            eprintln!("{ERROR}: couldn't find file {file}");
+                            if opts.continue_build {
+                                failed = true;
+                                continue
+                            }
+                            else {return 120}
+                        }
+                        match build_file(Path::new(&file), ctx, opts) {
+                            Ok(path) => paths.push(path),
+                            Err(code) => return code
+                        }
                     }
-                }).flatten().filter_map(Result::ok) {
-                    if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {continue}
-                    match build_file(file.as_path(), ctx, opts) {
-                        Ok(path) => paths.push(path),
-                        Err(code) => return code
-                    }
+                    if failed {return 120}
                 },
                 None => {
                     eprintln!("{ERROR}: library target must have files");
@@ -511,10 +533,43 @@ fn build_target<'ctx>(t: &Target, data: &RefCell<Option<TargetData>>, targets: &
             }
             let mut output = opts.build_dir.to_path_buf();
             output.push(format!("{}.colib", t.name));
-            Command::new("ar").args([OsStr::new("-rcs"), output.as_os_str()].into_iter().chain(paths.iter().map(|f| f.as_os_str()))).status().ok().and_then(|x| x.code()).unwrap_or_else(|| {
-                eprintln!("{ERROR}: could not invoke ar");
-                109
-            })
+            let file = match std::fs::File::open(output) {
+                Ok(f) => f,
+                Err(e) => {
+                    eprintln!("{ERROR} when opening output file: {e}");
+                    return 110
+                }
+            };
+            let mut builder = ar::Builder::new(file);
+            if let Err(e) = paths.iter().try_for_each(|p| builder.append_path(&p)) {
+                eprintln!("{ERROR}: {e}");
+                return 110
+            }
+            {
+                let mut buf = String::new();
+                buf.push('\0');
+                for link_dir in &opts.link_dirs {
+                    buf += &link_dir;
+                    buf.push('\0');
+                }
+                buf.push('\0');
+                if let Err(e) = builder.append(&ar::Header::new(b".libs".to_vec(), buf.len() as u64), buf.as_bytes()) {
+                    eprintln!("{ERROR}: {e}");
+                    return 110
+                }
+            }
+            {
+                let mut buf: Vec<u8> = vec![];
+                if let Err(e) = ctx.with_vars(|v| v.save(&mut buf)) {
+                    eprintln!("{ERROR}: {e}");
+                    return 110
+                }
+                if let Err(e) = builder.append(&ar::Header::new(b".co-syms".to_vec(), buf.len() as u64), buf.as_slice()) {
+                    eprintln!("{ERROR}: {e}");
+                    return 110
+                }
+            }
+            0
         },
         TargetType::Meta => {
             if t.files.is_some() {

--- a/src/cobalt/varmap.rs
+++ b/src/cobalt/varmap.rs
@@ -153,6 +153,7 @@ impl<'ctx> Symbol<'ctx> {
         match c {
             1 => {
                 let mut var = Variable::error();
+                var.good.set(true);
                 let mut name = vec![];
                 buf.read_until(0, &mut name)?;
                 if name.last() == Some(&0) {name.pop();}

--- a/src/libs.rs
+++ b/src/libs.rs
@@ -1,21 +1,90 @@
 use std::path::PathBuf;
-pub fn find_libs<'a>(mut libs: Vec<&'a str>, dirs: Vec<&str>) -> (Vec<PathBuf>, Vec<&'a str>) {
-    let mut outs = vec![];
-    let it = dirs.into_iter().flat_map(|dir| walkdir::WalkDir::new(dir).follow_links(true).into_iter()).filter_map(|x| x.ok()).filter(|x| x.file_type().is_file());
-    it.for_each(|x| {
+use std::ffi::OsStr;
+use std::io::{self, BufReader, BufRead};
+use std::fs::File;
+pub fn find_libs(mut libs: Vec<&str>, dirs: &Vec<&str>, ctx: Option<&cobalt::CompCtx>) -> io::Result<(Vec<PathBuf>, Vec<String>)> {
+    let mut out = vec![];
+    let mut nf = vec![];
+    for x in dirs.iter().flat_map(|dir| walkdir::WalkDir::new(dir).follow_links(true).into_iter()).filter_map(|x| x.ok()).filter(|x| x.file_type().is_file()) {
         let path = x.into_path();
-        match path.extension().and_then(std::ffi::OsStr::to_str) {
-            Some("so") | Some("dylib") | Some("colib") | Some("dll") => {},
-            _ => return
-        }
+        if path.extension().and_then(OsStr::to_str) != Some("colib") {continue}
         if let Some(stem) = path.file_stem().and_then(|x| x.to_str()) {
             for lib in libs.iter_mut().filter(|x| x.len() > 0) {
-                if lib == &stem || (stem.starts_with("lib") && lib == &&stem[3..]) {
-                    outs.push(path.clone());
+                if lib == &stem {
+                    let mut passed_libs = false;
+                    let mut passed_syms = false;
+                    let mut archive = ar::Archive::new(File::open(&path)?);
+                    while let Some(entry) = archive.next_entry() {
+                        let entry = entry?;
+                        let id = entry.header().identifier();
+                        if id == b".co-syms" {
+                            if passed_syms {continue}
+                            let mut buf = BufReader::new(entry);
+                            if let Some(ctx) = ctx {ctx.with_vars(|v| v.load(&mut buf, &ctx))?;}
+                            passed_syms = true;
+                            if passed_libs {break}
+                        }
+                        else if id == b".libs" {
+                            if passed_libs {continue}
+                            let mut libs = vec![];
+                            let mut dirs = vec![];
+                            let mut reader = BufReader::new(entry);
+                            loop {
+                                let mut data = vec![];
+                                reader.read_until(0, &mut data)?;
+                                if data.last() == Some(&0) {data.pop();}
+                                if data.len() == 0 {break}
+                                if let Ok(s) = std::str::from_utf8(&data) {libs.push(s.to_string());}
+                            }
+                            loop {
+                                let mut data = vec![];
+                                reader.read_until(0, &mut data)?;
+                                if data.last() == Some(&0) {data.pop();}
+                                if data.len() == 0 {break}
+                                if let Ok(s) = std::str::from_utf8(&data) {dirs.push(s.to_string());}
+                            }
+                            let mut res = find_libs(libs.iter().map(|x| x.as_str()).collect(), &dirs.iter().map(|x| x.as_str()).collect(), ctx)?;
+                            out.append(&mut res.0);
+                            nf.append(&mut res.1);
+                            passed_libs = true;
+                            if passed_syms {break}
+                        }
+                    }
+                    out.push(path.clone());
                     *lib = "";
                 }
             }
         }
-    });
-    (outs, libs.into_iter().filter(|x| x.len() > 0).collect())
+    }
+    for x in dirs.iter().flat_map(|dir| walkdir::WalkDir::new(dir).follow_links(true).into_iter()).filter_map(|x| x.ok()).filter(|x| x.file_type().is_file()) {
+        let path = x.into_path();
+        match path.extension().and_then(OsStr::to_str) {
+            Some("so") | Some("dylib") | Some("dll") => {},
+            _ => continue
+        }
+        if let Some(stem) = path.file_stem().and_then(|x| x.to_str()) {
+            for lib in libs.iter_mut().filter(|x| x.len() > 0) {
+                if lib == &stem  || (stem.starts_with("lib") && lib == &&stem[3..]){
+                    out.push(path.clone());
+                    *lib = "";
+                }
+            }
+        }
+    }
+    for x in dirs.iter().flat_map(|dir| walkdir::WalkDir::new(dir).follow_links(true).into_iter()).filter_map(|x| x.ok()).filter(|x| x.file_type().is_file()) {
+        let path = x.into_path();
+        match path.extension().and_then(OsStr::to_str) {
+            Some("a") | Some("lib") => {},
+            _ => continue
+        }
+        if let Some(stem) = path.file_stem().and_then(|x| x.to_str()) {
+            for lib in libs.iter_mut().filter(|x| x.len() > 0) {
+                if lib == &stem  || (stem.starts_with("lib") && lib == &&stem[3..]){
+                    out.push(path.clone());
+                    *lib = "";
+                }
+            }
+        }
+    }
+    Ok((out, nf.into_iter().chain(libs.into_iter().filter(|x| x.len() > 0).map(|x| x.to_string())).collect()))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -452,7 +452,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let output_type = output_type.unwrap_or(OutputType::Executable);
             let out_file = out_file.map(String::from).unwrap_or_else(|| match output_type {
                 OutputType::Executable | OutputType::ExeLibc => "a.out".to_string(),
-                OutputType::Library => format!("lib{}.colib", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file)),
+                OutputType::Library => format!("{}.colib", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file)),
                 OutputType::Object => format!("{}.o", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file)),
                 OutputType::Assembly => format!("{}.s", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file)),
                 OutputType::LLVM => format!("{}.ll", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file)),

--- a/src/package.rs
+++ b/src/package.rs
@@ -170,7 +170,9 @@ impl Package {
                 continue_comp: false,
                 continue_build: false,
                 triple: &triple,
-                profile: "default"
+                profile: "default",
+                link_dirs:  if let Ok(home) = std::env::var("HOME") {vec![format!("{home}/.cobalt/packages"), format!("{home}/.local/lib/cobalt"), "/usr/local/lib/cobalt/packages".to_string(), "/usr/lib/cobalt/packages".to_string(), "/lib/cobalt/packages".to_string(), "/usr/local/lib".to_string(), "/usr/lib".to_string(), "/lib".to_string()]}
+                            else {["/usr/local/lib/cobalt/packages", "/usr/lib/cobalt/packages", "/lib/cobalt/packages", "/usr/local/lib", "/usr/lib", "/lib"].into_iter().map(String::from).collect()}
             });
             if opts.clean {std::fs::remove_dir_all(install_loc)?}
             if res == 0 {Ok(())} else {Err(InstallError::BuildFailed(res))}


### PR DESCRIPTION
One of the more annoying thing about C++ libraries is all of the header files. To fix this, Cobalt tries to serialize all of the variable data into a file in the library.
Changes:
- Added serialization for the top-level symbols (functions and variables) so they don't need to be forward-declared in a file that links in a library
- I got annoyed typing `libtest.colib` and decided that `test.colib` looked better
Commits:
- Added serialization for `VarMap`
- Added deserialization for library `VarMap`
- Changed default library name from `libNAME.colib` to `NAME.colib`
- Reworked search and added deserialization
- Fixed function deserialization
- Improved library info in library builds
