### PR TITLE
Add support for if/else expressions

### DIFF
--- a/src/cobalt/ast.rs
+++ b/src/cobalt/ast.rs
@@ -47,6 +47,7 @@ pub mod scope;
 pub mod misc;
 pub mod funcs;
 pub mod ops;
+pub mod flow;
 
 pub use vars::*;
 pub use groups::*;
@@ -55,3 +56,4 @@ pub use scope::*;
 pub use misc::*;
 pub use funcs::*;
 pub use ops::*;
+pub use flow::*;

--- a/src/cobalt/ast/flow.rs
+++ b/src/cobalt/ast/flow.rs
@@ -1,0 +1,109 @@
+use crate::*;
+pub struct IfAST {
+    loc: Location,
+    pub cond: Box<dyn AST>,
+    pub if_true: Box<dyn AST>,
+    pub if_false: Option<Box<dyn AST>>
+}
+impl AST for IfAST {
+    fn loc(&self) -> Location {self.loc.clone()}
+    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
+        if let Some(val) = self.if_false.as_ref() {types::utils::common(&self.if_true.res_type(ctx), &val.res_type(ctx)).unwrap_or(Type::Null)}
+        else {self.if_true.res_type(ctx)}
+    }
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Error>) {
+        if ctx.is_const.get() {return (Variable::null(None), vec![])}
+        let mut errs = vec![];
+        let (cond, mut es) = self.cond.codegen(ctx);
+        errs.append(&mut es);
+        let err = format!("cannot convert value of type {} to i1", cond.data_type);
+        let v = if let Some(v) = types::utils::expl_convert(cond, Type::Int(1, false), ctx) {v} else {
+            errs.push(Error::new(self.cond.loc(), 312, err));
+            Variable::compiled(ctx.context.custom_width_int_type(1).const_int(0, false).into(), Type::Int(1, false))
+        };
+        if let Some(inkwell::values::BasicValueEnum::IntValue(v)) = v.comp_val {
+            (if let Some(if_false) = self.if_false.as_ref() {
+                if let Some(f) = ctx.builder.get_insert_block().and_then(|bb| bb.get_parent()) {
+                    let itb = ctx.context.append_basic_block(f, "if_true");
+                    let ifb = ctx.context.append_basic_block(f, "if_false");
+                    let mb = ctx.context.append_basic_block(f, "merge");
+                    ctx.builder.build_conditional_branch(v, itb, ifb);
+                    ctx.builder.position_at_end(itb);
+                    let (if_true, mut es) = self.if_true.codegen(ctx);
+                    errs.append(&mut es);
+                    ctx.builder.position_at_end(itb);
+                    let (if_false, mut es) = if_false.codegen(ctx);
+                    errs.append(&mut es);
+                    let ty = if let Some(t) = types::utils::common(&if_true.data_type, &if_false.data_type) {t} else {
+                        errs.push(Error::new(self.cond.loc(), 315, format!("no common type for values of types {} and {}", if_true.data_type, if_false.data_type)));
+                        Type::Null
+                    };
+                    if let Some(llt) = ty.llvm_type(ctx) {
+                        ctx.builder.position_at_end(itb);
+                        let err = format!("cannot convert value of type {} to {ty}", if_true.data_type);
+                        let if_true = if let Some(v) = types::utils::impl_convert(if_true, ty.clone(), ctx) {v} else {
+                            errs.push(Error::new(self.cond.loc(), 312, err));
+                            Variable::error()
+                        };
+                        ctx.builder.position_at_end(ifb);
+                        let err = format!("cannot convert value of type {} to {ty}", if_false.data_type);
+                        let if_false= if let Some(v) = types::utils::impl_convert(if_false, ty.clone(), ctx) {v} else {
+                            errs.push(Error::new(self.cond.loc(), 312, err));
+                            Variable::error()
+                        };
+                        ctx.builder.position_at_end(mb);
+                        let phi = ctx.builder.build_phi(llt, "");
+                        if let Some(v) = if_true.value(ctx) {phi.add_incoming(&[(&v, itb)]);}
+                        if let Some(v) = if_false.value(ctx) {phi.add_incoming(&[(&v, ifb)]);}
+                        Variable::compiled(phi.as_basic_value(), ty)
+                    }
+                    else {Variable::error()}
+                }
+                else {Variable::error()}
+            }
+            else {
+                let (cond, mut errs) = self.cond.codegen(ctx);
+                let (if_true, mut es) = self.if_true.codegen(ctx);
+                errs.append(&mut es);
+                if let Some(ip) = ctx.builder.get_insert_block() {
+                    if let Some(f) = ip.get_parent() {
+                        let itb = ctx.context.append_basic_block(f, "if_true");
+                        let mb = ctx.context.append_basic_block(f, "merge");
+                        ctx.builder.build_conditional_branch(v, itb, mb);
+                        ctx.builder.position_at_end(itb);
+                        let (if_true, mut es) = self.if_true.codegen(ctx);
+                        errs.append(&mut es);
+                        ctx.builder.build_unconditional_branch(mb);
+                        if let Some(llt) = if_true.data_type.llvm_type(ctx) {
+                            let phi = ctx.builder.build_phi(llt, "");
+                            if let Some(v) = if_true.value(ctx) {phi.add_incoming(&[(&v, itb)]);}
+                            phi.add_incoming(&[(&llt.const_zero(), ip)]);
+                            Variable::compiled(phi.as_basic_value(), if_true.data_type)
+                        }
+                        else {Variable::error()}
+                    }
+                    else {Variable::error()}
+                }
+                else {Variable::error()}
+            }, errs)
+        }
+        else {(Variable::error(), vec![])}
+    }
+    fn to_code(&self) -> String {
+        if let Some(val) = self.if_false.as_ref() {format!("if ({}) {} else {}", self.cond, self.if_true, val)}
+        else {format!("if ({}) {}", self.cond, self.if_true)}
+    }
+    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix) -> std::fmt::Result {
+        if let Some(val) = self.if_false.as_ref() {
+            writeln!(f, "if/else")?;
+            print_ast_child(f, pre, &*self.cond, false)?;
+            print_ast_child(f, pre, &*self.if_true, false)?;
+            print_ast_child(f, pre, &**val, true)
+        }
+        else {
+            writeln!(f, "if")?;
+            print_ast_child(f, pre, &*self.cond, false)?;
+            print_ast_child(f, pre, &*self.if_true, true)
+        }
+    }
+}

--- a/src/cobalt/ast/flow.rs
+++ b/src/cobalt/ast/flow.rs
@@ -5,6 +5,9 @@ pub struct IfAST {
     pub if_true: Box<dyn AST>,
     pub if_false: Option<Box<dyn AST>>
 }
+impl IfAST {
+    pub fn new(loc: Location, cond: Box<dyn AST>, if_true: Box<dyn AST>, if_false: Option<Box<dyn AST>>) -> Self {IfAST {loc, cond, if_true, if_false}}
+}
 impl AST for IfAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {

--- a/src/cobalt/parser/ast.rs
+++ b/src/cobalt/parser/ast.rs
@@ -566,18 +566,9 @@ fn parse_flow(mut toks: &[Token], flags: &Flags) -> (Box<dyn AST>, Vec<Error>) {
                             _ => i += 1
                         }
                     }
-                    let (mut ast, mut es) = parse_splits(&toks[..i], flags);
+                    let (ast, mut es) = parse_splits(&toks[..i], flags);
                     errs.append(&mut es);
-                    let cont = match toks.get(i).map(|x| &x.data) {
-                        Some(Keyword(x)) if x == "else" => true,
-                        Some(Special(';')) => toks.get(i + 1).map(|x| &x.data) == Some(&Keyword("else".to_string())) && {
-                            let loc = ast.loc().clone();
-                            ast = Box::new(GroupAST::new(loc.clone(), vec![ast, Box::new(NullAST::new(loc))]));
-                            i += 1;
-                            true
-                        },
-                        _ => false
-                    };
+                    let cont = toks.get(i).map(|x| &x.data) == Some(&Keyword("else".to_string()));
                     toks = &toks[i..];
                     (ast, cont)
                 };

--- a/src/cobalt/parser/lexer.rs
+++ b/src/cobalt/parser/lexer.rs
@@ -11,6 +11,7 @@ pub enum TokenData {
     Operator(String),
     Identifier(String),
     Keyword(String),
+    Statement(String),
     Macro(String, Option<String>)
 }
 #[derive(Clone, PartialEq, Debug)]
@@ -778,7 +779,8 @@ pub fn lex(data: &str, mut loc: Location, flags: &Flags) -> (Vec<Token>, Vec<Err
                     it.next();
                 }
                 outs.push(Token::new(start, match s.as_str() {
-                    "let" | "mut" | "const" | "fn" | "cr" | "module" | "import" | "if" | "else" | "while" => Keyword(s),
+                    "let" | "mut" | "const" | "fn" | "cr" | "module" | "import" => Statement(s),
+                    "if" | "else" | "while" => Keyword(s),
                     _ => Identifier(s)
                 }));
             },

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -1620,3 +1620,16 @@ pub fn call<'ctx>(mut target: Variable<'ctx>, loc: Location, mut args: Vec<(Vari
         })))
     }
 }
+pub fn common(lhs: &Type, rhs: &Type) -> Option<Type> {
+    if lhs == rhs {return Some(lhs.clone())}
+    match (lhs, rhs) {
+        (lhs, &Type::Reference(ref base, _) | &Type::Borrow(ref base)) if lhs == &**base => Some(lhs.clone()),
+        (&Type::Reference(ref base, _) | &Type::Borrow(ref base), rhs) if rhs == &**base => Some(rhs.clone()),
+        (Type::IntLiteral, x @ Type::Int(..)) | (x @ Type::Int(..), Type::IntLiteral) => Some(x.clone()),
+        (Type::IntLiteral | Type::Int(..), x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128)) | (x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128), Type::IntLiteral | Type::Int(..)) => Some(x.clone()),
+        (Type::Float32, Type::Float16) | (Type::Float16, Type::Float32) => Some(Type::Float32),
+        (Type::Float64, Type::Float16 | Type::Float32) | (Type::Float16 | Type::Float32, Type::Float64) => Some(Type::Float64),
+        (Type::Float128, Type::Float16 | Type::Float32 | Type::Float64) | (Type::Float16 | Type::Float32 | Type::Float64, Type::Float128) => Some(Type::Float128),
+        _ => None
+    }
+}

--- a/src/cobalt/varmap.rs
+++ b/src/cobalt/varmap.rs
@@ -109,6 +109,7 @@ pub struct Variable<'ctx> {
 }
 impl<'ctx> Variable<'ctx> {
     pub fn error() -> Self {Variable {comp_val: None, inter_val: None, data_type: Type::Null, good: Cell::new(false)}}
+    pub fn null(data_type: Option<Type>) -> Self {Variable {comp_val: None, inter_val: None, data_type: data_type.unwrap_or(Type::Null), good: Cell::new(false)}}
     pub fn compiled(comp_val: BasicValueEnum<'ctx>, data_type: Type) -> Self {Variable {comp_val: Some(comp_val), inter_val: None, data_type, good: Cell::new(true)}}
     pub fn interpreted(comp_val: BasicValueEnum<'ctx>, inter_val: InterData, data_type: Type) -> Self {Variable {comp_val: Some(comp_val), inter_val: Some(inter_val), data_type, good: Cell::new(true)}}
     pub fn metaval(inter_val: InterData, data_type: Type) -> Self {Variable {comp_val: None, inter_val: Some(inter_val), data_type, good: Cell::new(true)}}


### PR DESCRIPTION
There's not much to explain here, here's some example code:
```
fn min(a: i64, b: i64): i64 = if (a < b) a else b; # Note that there isn't a semicolon between the end of the first branch and the "else"!
fn test(mut a, b, c): null {
  if (b < c) (a += b) else (a += c); # if/else has a lower precedence than operators, so in cases like these, you need parentheses around the branches
  if (a + b + c < 0) {
    a = -a;
    b = -b;
    c = -c;
  }
  if { # If condition can also be a block
    let tmp = a;
    c = b;
    b = a;
    a = tmp;
    a * b * c / 10 != 0
  } ();
};
```
Commits:
- Added if/else AST node
- Added parsing for if/else experssions
- Fixed code being inserted into the wrong blocks in IfAST codegen
- Removed code for C-style single-statement if/else expressions
