### PR TITLE
Add support for modules

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -172,7 +172,7 @@ impl TargetData {
 fn clear_mod<'ctx>(this: &mut HashMap<String, cobalt::Symbol<'ctx>>, module: &inkwell::module::Module<'ctx>) {
     for (_, sym) in this.iter_mut() {
         match sym {
-            cobalt::Symbol::Module(m) => clear_mod(m, module),
+            cobalt::Symbol::Module(m, _) => clear_mod(m, module),
             cobalt::Symbol::Variable(v) => if let Some(inkwell::values::BasicValueEnum::PointerValue(pv)) = v.comp_val {
                 let t = inkwell::types::BasicTypeEnum::try_from(pv.get_type().get_element_type());
                 if let Ok(t) = t {

--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -267,7 +267,7 @@ impl AST for FnDefAST {
                 let ps = params.iter().filter_map(|(x, c)| if *c {None} else {Some(BasicMetadataTypeEnum::from(x.llvm_type(ctx).unwrap_or_else(|| {good = false; IntType(ctx.context.i8_type())})))}).collect::<Vec<_>>();
                 if good && !ctx.is_const.get() {
                     let ft = llt.fn_type(ps.as_slice(), false);
-                    let f = ctx.module.add_function(linkas.map_or_else(|| format!("{}", self.name), |v| v.0.clone()).as_str(), ft, None);
+                    let f = ctx.module.add_function(linkas.map_or_else(|| ctx.mangle(&self.name), |v| v.0.clone()).as_str(), ft, None);
                     f.add_attribute(Function, ctx.context.create_enum_attribute(Attribute::get_named_enum_kind_id("nobuiltin"), 0));
                     match inline {
                         Some((true, _)) => f.add_attribute(Function, ctx.context.create_enum_attribute(Attribute::get_named_enum_kind_id("alwaysinline"), 0)),
@@ -385,7 +385,7 @@ impl AST for FnDefAST {
                 let ps = params.iter().filter_map(|(x, c)| if *c {None} else {Some(BasicMetadataTypeEnum::from(x.llvm_type(ctx).unwrap_or_else(|| {good = false; IntType(ctx.context.i8_type())})))}).collect::<Vec<_>>();
                 if good && !ctx.is_const.get() {
                     let ft = ctx.context.void_type().fn_type(ps.as_slice(), false);
-                    let f = ctx.module.add_function(linkas.map_or_else(|| format!("{}", self.name), |v| v.0.clone()).as_str(), ft, None);
+                    let f = ctx.module.add_function(linkas.map_or_else(|| ctx.mangle(&self.name), |v| v.0.clone()).as_str(), ft, None);
                     f.add_attribute(Function, ctx.context.create_enum_attribute(Attribute::get_named_enum_kind_id("nobuiltin"), 0));
                     match inline {
                         Some((true, _)) => f.add_attribute(Function, ctx.context.create_enum_attribute(Attribute::get_named_enum_kind_id("alwaysinline"), 0)),

--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -535,8 +535,7 @@ impl AST for FnDefAST {
                 Err(RedefVariable::AlreadyExists(x, _)) => {
                     errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
                     (Variable::error(), errs)
-                },
-                Err(RedefVariable::MergeConflict(_, _)) => panic!("merge conflicts shouldn't be reachable when inserting a variable")
+                }
             }
         } else {panic!("In order for this to be reachable, fty would have to somehow be mutated, which is impossible")}.clone();
         if is_extern.is_none() {

--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -306,6 +306,7 @@ impl AST for FnDefAST {
                         export: true
                     }))).clone();
                     if is_extern.is_none() {
+                        let old_scope = ctx.push_scope(&self.name);
                         ctx.map_vars(|v| Box::new(VarMap::new(Some(v))));
                         {
                             let mut param_count = 0;
@@ -347,6 +348,7 @@ impl AST for FnDefAST {
                             errs.push(Diagnostic::error(self.body.loc(), 311, Some(err)));
                             llt.const_zero()
                         })));
+                        ctx.restore_scope(old_scope);
                     }
                     var
                 }
@@ -424,6 +426,7 @@ impl AST for FnDefAST {
                         export: true
                     }))).clone();
                     if is_extern.is_none() {
+                        let old_scope = ctx.push_scope(&self.name);
                         ctx.map_vars(|v| Box::new(VarMap::new(Some(v))));
                         {
                             let mut param_count = 0;
@@ -461,6 +464,7 @@ impl AST for FnDefAST {
                         errs.append(&mut es);
                         ctx.builder.build_return(None);
                         ctx.map_vars(|v| v.parent.unwrap());
+                        ctx.restore_scope(old_scope);
                     }
                     var
                 }

--- a/src/cobalt/ast/scope.rs
+++ b/src/cobalt/ast/scope.rs
@@ -1,14 +1,36 @@
 use crate::*;
+use glob::Pattern;
 pub struct ModuleAST {
     loc: Location,
     pub name: DottedName,
-    pub vals: Vec<Box<dyn AST>>
+    pub vals: Vec<Box<dyn AST>>,
+    pub annotations: Vec<(String, Option<String>, Location)>
 }
 impl AST for ModuleAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> Type {Type::Null}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {
         let mut errs = vec![];
+        let mut target_match = 2u8;
+        for (ann, arg, loc) in self.annotations.iter() {
+            match ann.as_str() {
+                "target" => {
+                    if let Some(arg) = arg {
+                        let mut arg = arg.as_str();
+                        let negate = if arg.as_bytes().get(0) == Some(&0x21) {arg = &arg[1..]; true} else {false};
+                        match Pattern::new(arg) {
+                            Ok(pat) => if target_match != 1 {target_match = if negate ^ pat.matches(&ctx.module.get_triple().as_str().to_string_lossy()) {1} else {0}},
+                            Err(err) => errs.push(Diagnostic::error(loc.clone(), 427, Some(format!("error at byte {}: {}", err.pos, err.msg))))
+                        }
+                    }
+                    else {
+                        errs.push(Diagnostic::error(loc.clone(), 426, None));
+                    }
+                },
+                x => errs.push(Diagnostic::error(loc.clone(), 410, Some(format!("unknown annotation {x:?} for variable definition"))))
+            }
+        }
+        if target_match == 0 {return (Variable::error(), errs)}
         ctx.map_vars(|mut v| {
             match v.lookup_mod(&self.name) {
                 Ok((m, i)) => Box::new(VarMap {parent: Some(v), symbols: m, imports: i}),
@@ -51,7 +73,7 @@ impl AST for ModuleAST {
     }
 }
 impl ModuleAST {
-    pub fn new(loc: Location, name: DottedName, vals: Vec<Box<dyn AST>>) -> Self {ModuleAST {loc, name, vals}}
+    pub fn new(loc: Location, name: DottedName, vals: Vec<Box<dyn AST>>, annotations: Vec<(String, Option<String>, Location)>) -> Self {ModuleAST {loc, name, vals, annotations}}
 }
 pub struct ImportAST {
     loc: Location,

--- a/src/cobalt/ast/scope.rs
+++ b/src/cobalt/ast/scope.rs
@@ -59,8 +59,11 @@ pub struct ImportAST {
 }
 impl AST for ImportAST {
     fn loc(&self) -> Location {self.loc.clone()}
-    fn res_type<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> Type {todo!("code generation has not been implemented for imports")}
-    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {todo!("code generation has not been implemented for imports")}
+    fn res_type<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> Type {Type::Null}
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {
+        ctx.with_vars(|v| v.imports.push(self.name.clone()));
+        (Variable::null(None), vec![])
+    }
     fn to_code(&self) -> String {
         format!("import {}", self.name)
     }

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -134,8 +134,7 @@ impl AST for VarDefAST {
                     Err(RedefVariable::AlreadyExists(x, _)) => {
                         errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
                         (Variable::error(), errs)
-                    },
-                    Err(RedefVariable::MergeConflict(_, _)) => panic!("merge conflicts shouldn't be reachable when inserting a variable")
+                    }
                 }
             }
             else if self.val.is_const() && self.type_.is_none() {
@@ -194,8 +193,7 @@ impl AST for VarDefAST {
                     Err(RedefVariable::AlreadyExists(x, _)) => {
                         errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
                         (Variable::error(), errs)
-                    },
-                    Err(RedefVariable::MergeConflict(_, _)) => panic!("merge conflicts shouldn't be reachable when inserting a variable")
+                    }
                 }
             }
             else {
@@ -342,8 +340,7 @@ impl AST for VarDefAST {
                     Err(RedefVariable::AlreadyExists(x, _)) => {
                         errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
                         (Variable::error(), errs)
-                    },
-                    Err(RedefVariable::MergeConflict(_, _)) => panic!("merge conflicts shouldn't be reachable when inserting a variable")
+                    }
                 }
             }
         }
@@ -414,8 +411,7 @@ impl AST for VarDefAST {
                 Err(RedefVariable::AlreadyExists(x, _)) => {
                     errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
                     (Variable::error(), errs)
-                },
-                Err(RedefVariable::MergeConflict(_, _)) => panic!("merge conflicts shouldn't be reachable when inserting a variable")
+                }
             }
         }
     }
@@ -567,8 +563,7 @@ impl AST for MutDefAST {
                     Err(RedefVariable::AlreadyExists(x, _)) => {
                         errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
                         (Variable::error(), errs)
-                    },
-                    Err(RedefVariable::MergeConflict(_, _)) => panic!("merge conflicts shouldn't be reachable when inserting a variable")
+                    }
                 }
             }
             else if self.val.is_const() && self.type_.is_none() {
@@ -629,8 +624,7 @@ impl AST for MutDefAST {
                     Err(RedefVariable::AlreadyExists(x, _)) => {
                         errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
                         (Variable::error(), errs)
-                    },
-                    Err(RedefVariable::MergeConflict(_, _)) => panic!("merge conflicts shouldn't be reachable when inserting a variable")
+                    }
                 }
             }
             else {
@@ -777,8 +771,7 @@ impl AST for MutDefAST {
                     Err(RedefVariable::AlreadyExists(x, _)) => {
                         errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
                         (Variable::error(), errs)
-                    },
-                    Err(RedefVariable::MergeConflict(_, _)) => panic!("merge conflicts shouldn't be reachable when inserting a variable")
+                    }
                 }
             }
         }
@@ -848,8 +841,7 @@ impl AST for MutDefAST {
                 Err(RedefVariable::AlreadyExists(x, _)) => {
                     errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
                     (Variable::error(), errs)
-                },
-                Err(RedefVariable::MergeConflict(_, _)) => panic!("merge conflicts shouldn't be reachable when inserting a variable")
+                }
             }
         }
     }
@@ -925,8 +917,7 @@ impl AST for ConstDefAST {
             Err(RedefVariable::AlreadyExists(x, _)) => {
                 errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
                 (Variable::error(), errs)
-            },
-            Err(RedefVariable::MergeConflict(_, _)) => panic!("merge conflicts shouldn't be reachable when inserting a variable")
+            }
         }
     }
     fn to_code(&self) -> String {

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -952,7 +952,7 @@ impl AST for VarGetAST {
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {
         match ctx.with_vars(|v| v.lookup(&self.name)) {
             Ok(Symbol::Variable(x)) => (x.clone(), vec![]),
-            Ok(Symbol::Module(_)) => (Variable::error(), vec![Diagnostic::error(self.name.ids.last().unwrap().1.clone(), 322, Some(format!("{} is not a variable", self.name)))]),
+            Ok(Symbol::Module(..)) => (Variable::error(), vec![Diagnostic::error(self.name.ids.last().unwrap().1.clone(), 322, Some(format!("{} is not a variable", self.name)))]),
             Err(UndefVariable::NotAModule(idx)) => (Variable::error(), vec![Diagnostic::error(self.name.ids[idx].1.clone(), 321, Some(format!("{} is not a module", self.name.start(idx))))]),
             Err(UndefVariable::DoesNotExist(idx)) => (Variable::error(), vec![Diagnostic::error(self.name.ids[idx].1.clone(), 320, Some(format!("{} does not exist", self.name.start(idx))))])
         }

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -114,7 +114,7 @@ impl AST for VarDefAST {
                 }) {t} else if t2 == Type::IntLiteral {Type::Int(64, false)} else if let Type::Reference(b, _) = t2 {*b} else {t2};
                 match ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
                     comp_val: dt.llvm_type(ctx).map(|t| {
-                        let gv = ctx.module.add_global(t, None, linkas.map_or_else(|| format!("{}", self.name), |(name, _)| name).as_str());
+                        let gv = ctx.module.add_global(t, None, linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name).as_str());
                         match link_type {
                             None => {},
                             Some((WeakAny, _)) => gv.set_linkage(ExternalWeak),
@@ -171,7 +171,7 @@ impl AST for VarDefAST {
                     }
                     else {
                         let t = dt.llvm_type(ctx).unwrap();
-                        let gv = ctx.module.add_global(t, None, linkas.map_or_else(|| format!("{}", self.name), |(name, _)| name).as_str());
+                        let gv = ctx.module.add_global(t, None, linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name).as_str());
                         gv.set_constant(true);
                         gv.set_initializer(&v);
                         if let Some((link, _)) = link_type {gv.set_linkage(link)}
@@ -237,7 +237,7 @@ impl AST for VarDefAST {
                         ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {export: true, ..val})))
                     }
                     else {
-                        let gv = ctx.module.add_global(t, None, linkas.map_or_else(|| format!("{}", self.name), |(name, _)| name).as_str());
+                        let gv = ctx.module.add_global(t, None, linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name).as_str());
                         gv.set_constant(false);
                         if let Some((link, _)) = link_type {gv.set_linkage(link)}
                         let f = ctx.module.add_function(format!("__internals.init.{}", self.name).as_str(), ctx.context.void_type().fn_type(&[], false), Some(inkwell::module::Linkage::Private));
@@ -541,7 +541,7 @@ impl AST for MutDefAST {
                 }) {t} else if t2 == Type::IntLiteral {Type::Int(64, false)} else if let Type::Reference(b, _) = t2 {*b} else {t2};
                 match ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
                     comp_val: dt.llvm_type(ctx).map(|t| {
-                        let gv = ctx.module.add_global(t, None, linkas.map_or_else(|| format!("{}", self.name), |(name, _)| name).as_str());
+                        let gv = ctx.module.add_global(t, None, linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name).as_str());
                         match link_type {
                             None => {},
                             Some((WeakAny, _)) => gv.set_linkage(ExternalWeak),
@@ -598,7 +598,7 @@ impl AST for MutDefAST {
                     }
                     else {
                         let t = dt.llvm_type(ctx).unwrap();
-                        let gv = ctx.module.add_global(t, None, linkas.map_or_else(|| format!("{}", self.name), |(name, _)| name).as_str());
+                        let gv = ctx.module.add_global(t, None, linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name).as_str());
                         gv.set_constant(true);
                         gv.set_initializer(&v);
                         if let Some((link, _)) = link_type {gv.set_linkage(link)}
@@ -664,7 +664,7 @@ impl AST for MutDefAST {
                         ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {export: true, ..val})))
                     }
                     else {
-                        let gv = ctx.module.add_global(t, None, linkas.map_or_else(|| format!("{}", self.name), |(name, _)| name).as_str());
+                        let gv = ctx.module.add_global(t, None, linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name).as_str());
                         gv.set_constant(false);
                         if let Some((link, _)) = link_type {gv.set_linkage(link)}
                         let f = ctx.module.add_function(format!("__internals.init.{}", self.name).as_str(), ctx.context.void_type().fn_type(&[], false), Some(inkwell::module::Linkage::Private));

--- a/src/cobalt/context.rs
+++ b/src/cobalt/context.rs
@@ -46,6 +46,12 @@ impl<'ctx> CompCtx<'ctx> {
         self.vars.set(MaybeUninit::new(unsafe {f(val.assume_init())}));
         self
     }
+    pub fn map_split_vars<R, F: FnOnce(Box<VarMap<'ctx>>) -> (Box<VarMap<'ctx>>, R)>(&self, f: F) -> R {
+        let val = self.vars.replace(MaybeUninit::uninit());
+        let (v, out) = unsafe {f(val.assume_init())};
+        self.vars.set(MaybeUninit::new(v));
+        out
+    }
     pub fn mangle(&self, name: &DottedName) -> String {
         if name.global {format!("{name}")}
         else {

--- a/src/cobalt/context.rs
+++ b/src/cobalt/context.rs
@@ -2,33 +2,37 @@ use inkwell::{context::Context, module::Module, builder::Builder};
 use crate::*;
 use std::mem::MaybeUninit;
 use std::cell::Cell;
+use either::Either::{self, *};
 pub struct CompCtx<'ctx> {
     pub flags: Flags,
-    vars: Cell<MaybeUninit<Box<VarMap<'ctx>>>>,
     pub context: &'ctx Context,
     pub module: Module<'ctx>,
     pub builder: Builder<'ctx>,
-    pub is_const: Cell<bool>
+    pub is_const: Cell<bool>,
+    vars: Cell<MaybeUninit<Box<VarMap<'ctx>>>>,
+    name: Cell<MaybeUninit<String>>
 }
 impl<'ctx> CompCtx<'ctx> {
     pub fn new(ctx: &'ctx Context, name: &str) -> Self {
         CompCtx {
             flags: Flags::default(),
-            vars: Cell::new(MaybeUninit::new(Box::default())),
             context: ctx,
             module: ctx.create_module(name),
             builder: ctx.create_builder(),
-            is_const: Cell::new(false)
+            is_const: Cell::new(false),
+            vars: Cell::new(MaybeUninit::new(Box::default())),
+            name: Cell::new(MaybeUninit::new(".".to_string()))
         }
     }
     pub fn with_flags(ctx: &'ctx Context, name: &str, flags: Flags) -> Self {
         CompCtx {
             flags,
-            vars: Cell::new(MaybeUninit::new(Box::default())),
             context: ctx,
             module: ctx.create_module(name),
             builder: ctx.create_builder(),
-            is_const: Cell::new(false)
+            is_const: Cell::new(false),
+            vars: Cell::new(MaybeUninit::new(Box::default())),
+            name: Cell::new(MaybeUninit::new(".".to_string()))
         }
     }
     pub fn with_vars<R, F: FnOnce(&'ctx mut VarMap<'ctx>) -> R>(&self, f: F) -> R {
@@ -41,6 +45,39 @@ impl<'ctx> CompCtx<'ctx> {
         let val = self.vars.replace(MaybeUninit::uninit());
         self.vars.set(MaybeUninit::new(unsafe {f(val.assume_init())}));
         self
+    }
+    pub fn mangle(&self, name: &DottedName) -> String {
+        if name.global {format!("{name}")}
+        else {
+            unsafe {
+                let base = self.name.replace(MaybeUninit::uninit()).assume_init();
+                let out = format!("{base}{name}");
+                self.name.set(MaybeUninit::new(base.to_string()));
+                out
+            }
+        }
+    }
+    pub fn push_scope(&self, name: &DottedName) -> Either<usize, String> {
+        unsafe {
+            if name.global {Right(self.name.replace(MaybeUninit::new(name.to_string())).assume_init())}
+            else {
+                let mut old = self.name.replace(MaybeUninit::uninit()).assume_init();
+                let len = old.len();
+                old += &format!("{name}.");
+                self.name.set(MaybeUninit::new(old));
+                Left(len)
+            }
+        }
+    }
+    pub fn restore_scope(&self, old: Either<usize, String>) {
+        match old {
+            Left(len) => unsafe {
+                let mut old = self.name.replace(MaybeUninit::uninit()).assume_init();
+                old.truncate(len);
+                self.name.set(MaybeUninit::new(old));
+            },
+            Right(old) => self.name.set(MaybeUninit::new(old))
+        }
     }
 }
 impl<'ctx> Drop for CompCtx<'ctx> {

--- a/src/cobalt/dottedname.rs
+++ b/src/cobalt/dottedname.rs
@@ -28,13 +28,14 @@ impl Display for DottedName {
 #[derive(Clone, Debug)]
 pub enum CompoundDottedNameSegment {
     Identifier(String, Location),
-    Glob(String, Location),
+    Glob(Location),
     Group(Vec<Vec<CompoundDottedNameSegment>>)
 }
 impl Display for CompoundDottedNameSegment {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
-            Self::Identifier(x, _) | Self::Glob(x, _) => write!(f, "{x}"),
+            Self::Identifier(x, _) => write!(f, "{x}"),
+            Self::Glob(_) => write!(f, "*"),
             Self::Group(x) => {
                 write!(f, "{{")?;
                 let mut count = x.len();

--- a/src/cobalt/dottedname.rs
+++ b/src/cobalt/dottedname.rs
@@ -63,6 +63,7 @@ impl CompoundDottedName {
     pub fn absolute(ids: Vec<CompoundDottedNameSegment>) -> Self {Self::new(ids, true)}
     pub fn relative(ids: Vec<CompoundDottedNameSegment>) -> Self {Self::new(ids, false)}
     pub fn local(id: CompoundDottedNameSegment) -> Self {Self::new(vec![id], false)}
+    pub fn matches(name: &DottedName) -> bool {false} // TODO: pattern matching
 }
 impl From<DottedName> for CompoundDottedName {
     fn from(other: DottedName) -> Self {Self::new(other.ids.into_iter().map(|(id, loc)| CompoundDottedNameSegment::Identifier(id, loc)).collect(), other.global)}

--- a/src/cobalt/dottedname.rs
+++ b/src/cobalt/dottedname.rs
@@ -11,6 +11,7 @@ impl DottedName {
     pub fn relative(ids: Vec<(String, Location)>) -> Self {Self::new(ids, false)}
     pub fn local(id: (String, Location)) -> Self {Self::new(vec![id], false)}
     pub fn start(&self, len: usize) -> Self {DottedName {global: self.global, ids: self.ids[..(len + 1)].to_vec()}}
+    pub fn end(&self, len: usize) -> Self {DottedName {global: self.global, ids: self.ids[len..].to_vec()}}
 }
 impl Display for DottedName {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -62,6 +63,7 @@ impl CompoundDottedName {
     pub fn absolute(ids: Vec<CompoundDottedNameSegment>) -> Self {Self::new(ids, true)}
     pub fn relative(ids: Vec<CompoundDottedNameSegment>) -> Self {Self::new(ids, false)}
     pub fn local(id: CompoundDottedNameSegment) -> Self {Self::new(vec![id], false)}
+    pub fn matches(name: &DottedName) -> bool {todo!("Matching of a DottedName against a CompoundDottedName can wait")}
 }
 impl From<DottedName> for CompoundDottedName {
     fn from(other: DottedName) -> Self {Self::new(other.ids.into_iter().map(|(id, loc)| CompoundDottedNameSegment::Identifier(id, loc)).collect(), other.global)}

--- a/src/cobalt/dottedname.rs
+++ b/src/cobalt/dottedname.rs
@@ -63,7 +63,6 @@ impl CompoundDottedName {
     pub fn absolute(ids: Vec<CompoundDottedNameSegment>) -> Self {Self::new(ids, true)}
     pub fn relative(ids: Vec<CompoundDottedNameSegment>) -> Self {Self::new(ids, false)}
     pub fn local(id: CompoundDottedNameSegment) -> Self {Self::new(vec![id], false)}
-    pub fn matches(name: &DottedName) -> bool {todo!("Matching of a DottedName against a CompoundDottedName can wait")}
 }
 impl From<DottedName> for CompoundDottedName {
     fn from(other: DottedName) -> Self {Self::new(other.ids.into_iter().map(|(id, loc)| CompoundDottedNameSegment::Identifier(id, loc)).collect(), other.global)}

--- a/src/cobalt/dottedname.rs
+++ b/src/cobalt/dottedname.rs
@@ -1,5 +1,6 @@
 use crate::Location;
 use std::fmt::*;
+use std::io::{self, Read, Write, BufRead};
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DottedName {
     pub ids: Vec<(String, Location)>,
@@ -30,6 +31,53 @@ pub enum CompoundDottedNameSegment {
     Identifier(String, Location),
     Glob(Location),
     Group(Vec<Vec<CompoundDottedNameSegment>>)
+}
+impl CompoundDottedNameSegment {
+    pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {
+        use CompoundDottedNameSegment::*;
+        match self {
+            Identifier(id, _) => {
+                w.write_all(&[1])?;
+                w.write_all(&id.as_bytes())?;
+                w.write_all(&[0])
+            },
+            Glob(_) => w.write_all(&[2]),
+            Group(groups) => {
+                w.write_all(&[3])?;
+                for group in groups.iter() {
+                    group.iter().try_for_each(|id| id.save(out))?;
+                    out.write_all(&[0])?;
+                }
+                w.write_all(&[0])
+            }
+        }
+    }
+    pub fn load<R: Read + BufRead>(buf: &mut R) -> io::Result<Option<Self>> {
+        use CompoundDottedNameSegment::*;
+        let mut c = 0u8;
+        buf.read_exact(std::slice::from_mut(&mut c))?;
+        match c {
+            0 => Ok(None),
+            1 => {
+                let mut name = vec![];
+                buf.read_until(0, &mut name)?;
+                if name.last() == Some(&0) {name.pop();}
+                Ok(Some(Identifier(std::str::from_utf8(&name).expect("Cobalt symbols should be valid UTF-8").to_string(), (0, 0..0))))
+            },
+            2 => Ok(Some(Glob((0, 0..0)))),
+            3 => {
+                let mut out = vec![];
+                loop {
+                    let mut group = vec![];
+                    while let Some(val) = Self::load(buf)? {group.push(val);}
+                    if group.len() == 0 {break}
+                    else {out.push(group);}
+                }
+                Ok(Some(Group(out)))
+            },
+            x => panic!("read CDN segment expecting 0, 1, 2, or 3, got {x}")
+        }
+    }
 }
 impl Display for CompoundDottedNameSegment {
     fn fmt(&self, f: &mut Formatter) -> Result {
@@ -64,7 +112,24 @@ impl CompoundDottedName {
     pub fn absolute(ids: Vec<CompoundDottedNameSegment>) -> Self {Self::new(ids, true)}
     pub fn relative(ids: Vec<CompoundDottedNameSegment>) -> Self {Self::new(ids, false)}
     pub fn local(id: CompoundDottedNameSegment) -> Self {Self::new(vec![id], false)}
-    pub fn matches(name: &DottedName) -> bool {false} // TODO: pattern matching
+    pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {
+        out.write_all(&[if self.global {2} else {1}])?;
+        self.ids.iter().try_for_each(|i| i.save(out))?;
+        out.write_all(&[0])
+    }
+    pub fn load<R: Read + BufRead>(buf: &mut R) -> io::Result<Option<Self>> {
+        let mut c = 0u8;
+        buf.read_exact(std::slice::from_mut(&mut c))?;
+        match c {
+            0 => Ok(None),
+            1 | 2 => {
+                let mut ids = vec![];
+                while let Some(id) = CompoundDottedNameSegment::load(buf)? {ids.push(id)}
+                Ok(Some(Self::new(ids, c == 2)))
+            },
+            x => panic!("read CDN expecting 0, 1, or 2, got {x}")
+        }
+    }
 }
 impl From<DottedName> for CompoundDottedName {
     fn from(other: DottedName) -> Self {Self::new(other.ids.into_iter().map(|(id, loc)| CompoundDottedNameSegment::Identifier(id, loc)).collect(), other.global)}

--- a/src/cobalt/dottedname.rs
+++ b/src/cobalt/dottedname.rs
@@ -37,18 +37,18 @@ impl CompoundDottedNameSegment {
         use CompoundDottedNameSegment::*;
         match self {
             Identifier(id, _) => {
-                w.write_all(&[1])?;
-                w.write_all(&id.as_bytes())?;
-                w.write_all(&[0])
+                out.write_all(&[1])?;
+                out.write_all(&id.as_bytes())?;
+                out.write_all(&[0])
             },
-            Glob(_) => w.write_all(&[2]),
+            Glob(_) => out.write_all(&[2]),
             Group(groups) => {
-                w.write_all(&[3])?;
+                out.write_all(&[3])?;
                 for group in groups.iter() {
                     group.iter().try_for_each(|id| id.save(out))?;
                     out.write_all(&[0])?;
                 }
-                w.write_all(&[0])
+                out.write_all(&[0])
             }
         }
     }

--- a/src/cobalt/errors/info.rs
+++ b/src/cobalt/errors/info.rs
@@ -40,7 +40,10 @@ pub static ERR_REGISTRY: &[(u64, &[Option<ErrorInfo>])] = &[
     /*210*/ ErrorInfo::new("expected token in identifier", ""),
     /*211*/ ErrorInfo::new("identifier cannot contain consecutive periods", ""),
     /*212*/ ErrorInfo::new("identifier cannot contain consecutive names", ""),
-    /*213*/ ErrorInfo::new("unexpected token in type", "")]),
+    /*213*/ ErrorInfo::new("unexpected token in type", ""),
+    /*214*/ ErrorInfo::new("identifier cannot end in a period", ""),
+    /*215*/ ErrorInfo::new("subimport in group import cannot be global", ""),
+    /*216*/ ErrorInfo::new("unterminated group import", "")]),
     (230, &[
     /*230*/ ErrorInfo::new("expected type specification or value after variable definition", ""),
     /*231*/ ErrorInfo::new("expected semicolon after variable definition", ""),

--- a/src/cobalt/errors/info.rs
+++ b/src/cobalt/errors/info.rs
@@ -103,7 +103,8 @@ pub static ERR_REGISTRY: &[(u64, &[Option<ErrorInfo>])] = &[
     /*321*/ ErrorInfo::new("value is not a module", ""),
     /*322*/ ErrorInfo::new("value is not a variable", ""),
     /*323*/ ErrorInfo::new("redefinition of variable", ""),
-    /*324*/ ErrorInfo::new("value cannot be determined at compile-time", "")]),
+    /*324*/ ErrorInfo::new("value cannot be determined at compile-time", ""),
+    /*325*/ ErrorInfo::new("redefinition of values in module", "")]),
     (390, &[
     /*390*/ ErrorInfo::new("unknown literal suffix", ""),
     /*391*/ ErrorInfo::new("unknown intrinisc", "")]),

--- a/src/cobalt/parser/ast.rs
+++ b/src/cobalt/parser/ast.rs
@@ -177,37 +177,19 @@ fn parse_paths(toks: &[Token], is_nested: bool) -> (CompoundDottedName, usize, V
             Special(';') => break,
             Special(',') | Special('}') if is_nested => break,
             Special('.') => {
-                if lwp {
-                    errs.push(Diagnostic::error(toks[idx].loc.clone(), 211, None))
-                }
+                if lwp {errs.push(Diagnostic::error(toks[idx].loc.clone(), 211, None))}
                 lwp = true;
                 idx += 1;
             }
             Identifier(s) => {
-                if !lwp {
-                    if let Some(CompoundDottedNameSegment::Glob(ref x, l)) = name.ids.last() {
-                        name.ids.push(CompoundDottedNameSegment::Glob(x.to_owned() + s, (l.0, l.1.start..toks[idx].loc.1.end)));
-                    }
-                    else {
-                        errs.push(Diagnostic::error(toks[idx].loc.clone(), 212, None))
-                    }
-                }
+                if !lwp {errs.push(Diagnostic::error(toks[idx].loc.clone(), 212, None))}
                 lwp = false;
                 name.ids.push(CompoundDottedNameSegment::Identifier(s.clone(), toks[idx].loc.clone()));
                 idx += 1;
             }
             Operator(ref x) if x == "*" => {
-                if lwp {
-                    name.ids.push(CompoundDottedNameSegment::Glob('*'.to_string(), toks[idx].loc.clone()));
-                }
-                else {
-                    match name.ids.pop() {
-                        Some(CompoundDottedNameSegment::Identifier(x, l)) |
-                        Some(CompoundDottedNameSegment::Glob(x, l)) => name.ids.push(CompoundDottedNameSegment::Glob(x + "*", (l.0, l.1.start..toks[idx].loc.1.end))),
-                        Some(CompoundDottedNameSegment::Group(_)) => errs.push(Diagnostic::error(toks[idx].loc.clone(), 212, None)),
-                        None => unreachable!("if the last element was not a period, then there is at least one element in name.ids")
-                    }
-                }
+                if !lwp {errs.push(Diagnostic::error(toks[idx].loc.clone(), 212, None))}
+                name.ids.push(CompoundDottedNameSegment::Glob(toks[idx].loc.clone()));
                 lwp = false;
                 idx += 1;
             },
@@ -1321,7 +1303,7 @@ fn parse_tl(mut toks: &[Token], flags: &Flags, is_tl: bool) -> (Vec<Box<dyn AST>
                                 break;
                             }
                             let mut cname: CompoundDottedName = oname.into();
-                            cname.ids.push(CompoundDottedNameSegment::Glob('*'.to_string(), toks[0].loc.clone()));
+                            cname.ids.push(CompoundDottedNameSegment::Glob(toks[0].loc.clone()));
                             outs.push(Box::new(ModuleAST::new(toks[0].loc.clone(), name, vec![Box::new(ImportAST::new(toks[0].loc.clone(), cname))])));
                         },
                         Special(';') => {

--- a/src/cobalt/parser/ast.rs
+++ b/src/cobalt/parser/ast.rs
@@ -1294,10 +1294,8 @@ fn parse_tl(mut toks: &[Token], flags: &Flags, is_tl: bool) -> (Vec<Box<dyn AST>
             } else {break 'main},
             Statement(ref x) => match x.as_str() {
                 "module" => {
-                    if annotations.len() > 0 {
-                        errs.push(Diagnostic::error(val.loc.clone(), 282, None));
-                        annotations = vec![];
-                    }
+                    let mut anns = vec![];
+                    std::mem::swap(&mut annotations, &mut anns);
                     let (name, idx, mut es) = parse_path(&toks[1..], "=;{");
                     i += idx;
                     toks = &toks[idx..];
@@ -1310,7 +1308,7 @@ fn parse_tl(mut toks: &[Token], flags: &Flags, is_tl: bool) -> (Vec<Box<dyn AST>
                         Special('{') => {
                             let (vals, idx, mut e) = parse_tl(&toks[1..], flags, false);
                             if let Some(idx) = idx {
-                                outs.push(Box::new(ModuleAST::new(toks[0].loc.clone(), name, vals)));
+                                outs.push(Box::new(ModuleAST::new(toks[0].loc.clone(), name, vals, anns)));
                                 errs.append(&mut e);
                                 toks = &toks[(idx + 1)..];
                                 i += idx + 1;
@@ -1332,10 +1330,10 @@ fn parse_tl(mut toks: &[Token], flags: &Flags, is_tl: bool) -> (Vec<Box<dyn AST>
                             }
                             let mut cname: CompoundDottedName = oname.into();
                             cname.ids.push(CompoundDottedNameSegment::Glob(toks[0].loc.clone()));
-                            outs.push(Box::new(ModuleAST::new(toks[0].loc.clone(), name, vec![Box::new(ImportAST::new(toks[0].loc.clone(), cname))])));
+                            outs.push(Box::new(ModuleAST::new(toks[0].loc.clone(), name, vec![Box::new(ImportAST::new(toks[0].loc.clone(), cname))], anns)));
                         },
                         Special(';') => {
-                            outs.push(Box::new(ModuleAST::new(toks[0].loc.clone(), name, vec![])));
+                            outs.push(Box::new(ModuleAST::new(toks[0].loc.clone(), name, vec![], anns)));
                         },
                         x => unreachable!("unexpected value after module: {:#}", x)
                     }

--- a/src/cobalt/parser/ast.rs
+++ b/src/cobalt/parser/ast.rs
@@ -575,9 +575,10 @@ fn parse_statement(mut toks: &[Token], flags: &Flags) -> (Box<dyn AST>, Vec<Diag
                 "module" => {errs.push(Diagnostic::error(toks[0].loc.clone(), 275, None)); null()},
                 "import" => {
                     let (name, idx, mut es) = parse_paths(&toks[1..], false);
+                    let loc = toks[0].loc.clone();
                     toks = &toks[idx..];
                     errs.append(&mut es);
-                    Box::new(ImportAST::new(toks[0].loc.clone(), name))
+                    Box::new(ImportAST::new(loc, name))
                 },
                 "fn" => {
                     let annotations = toks.iter().take(start_idx).filter_map(|x| if let Macro(name, args) = &x.data {Some((name.clone(), args.clone(), x.loc.clone()))} else {None}).collect::<Vec<_>>();

--- a/src/cobalt/varmap.rs
+++ b/src/cobalt/varmap.rs
@@ -249,7 +249,7 @@ impl<'ctx> VarMap<'ctx> {
         match pat.get(0)? {
             Identifier(id, _) =>
                 if pat.len() == 1 {
-                    if name.len() == 0 && &name[0].0 == id {symbols.get(id)} else {None}
+                    if name.len() == 1 && &name[0].0 == id {symbols.get(id)} else {None}
                 }
                 else {Self::satisfy(symbols.get(id)?.as_mod()?, root, &name[1..], &pat[1..])},
             Group(ids) => ids.iter().cloned().filter_map(|mut v| {
@@ -258,7 +258,7 @@ impl<'ctx> VarMap<'ctx> {
             }).next(),
             Glob(_) =>
                 if pat.len() == 1 {
-                    if name.len() == 0 {symbols.get(&name[0].0)} else {None}
+                    if name.len() == 1 {symbols.get(&name[0].0)} else {None}
                 }
                 else {symbols.values().filter_map(|v| Self::satisfy(v.as_mod()?, root, &name[1..], &pat[1..])).next()}
         }


### PR DESCRIPTION
Changes:
- Modules! Modules can be imported with the `module` keyword, and all top-level definitions with in them will be placed within their own namespace
  - The `@target` annotation can be specified on modules to simplify target-dependent code
- Import statements
  - They can be a combination of:
    - literal: `import x.y;`
    - group: `import x.{y, z};`
    - glob: `import x.*;`
      - You can't actually glob the symbols *within a module*
        - So this isn't allowed: `import asts.*AST;`
    - They can also be combined, and unlike Rust's, can have more complex patterns:
      - This is fine: `import my_mod.*.{a, b}.c;`
  - Imports don't cause an error if you try to reference something that doesn't exist
  - For now, they cannot be used transitively
Commits:
- Added code to mangle identifiers is `CompCtx`
- Added mangle scope change in variable and function definitions
- Fixed parsing for modules
- Implemented code generation for modules
- Added imports to `VarMap`
- Added import lookup
- Moved module lookup and insertion code into member functions
- Partially implemented matcher for imports
- Simplified import patterns
- Added serialization for `CompoundDottedName`
- Fixed compiler errors
- Fixed a few panics
- Fixed import lookup
- Added parsing for import groups
- Added `@target` annotation for modules
