### PR TITLE
Improve version subcommand

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,19 @@
+use std::process::{Command, Output};
+fn git_info() -> Option<()> {
+    let Output {stdout, status, ..} = Command::new("git").args(&["rev-parse", "HEAD", "--abbrev-ref", "HEAD"]).output().ok()?;
+    if status.success() {
+        let info = std::str::from_utf8(&stdout).ok()?;
+        let (commit, branch) = info.split_once('\n')?;
+        println!("cargo:rustc-env=GIT_BRANCH={branch}");
+        println!("cargo:rustc-env=GIT_COMMIT={commit}");
+    }
+    else {
+        println!("cargo:rustc-env=GIT_BRANCH=<no git>");
+        println!("cargo:rustc-env=GIT_COMMIT=<no git>");
+    }
+    Some(())
+}
+fn main() {
+    println!("cargo:rerun-if-changed=.git");
+    git_info();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         },
         "version" | "--version" | "-v" | "-V" => {
-            println!("Cobalt version {} using LLVM version {}", env!("CARGO_PKG_VERSION"), "14.0.1.6");
+            println!(
+                "Cobalt version {}\n\
+                LLVM version {}\n\
+                Git commit {} on branch {}{}", env!("CARGO_PKG_VERSION"), "14.0.1.6", env!("GIT_COMMIT"), env!("GIT_BRANCH"), if cfg!(debug_assertions) {"\nDebug Build"} else {""});
         }
         "lex" if cfg!(debug_assertions) => {
             let mut nfcl = false;


### PR DESCRIPTION
The new `co version` subcommand (and its aliases) gives better version info.
New output:
```
Cobalt version {version}
LLVM version {llvm version}
Git commit {hash} on branch {branch}
[Debug build]
```
