### PR TITLE
Improve libraries

### DIFF
--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -198,8 +198,31 @@ impl AST for VarDefAST {
             }
             else {
                 let t = self.val.res_type(ctx);
+                let dt = if let Some(t) = self.type_.as_ref().and_then(|t| {
+                    let (t, mut es) = t.into_type(ctx);
+                    errs.append(&mut es);
+                    match t {
+                        Ok(t) => Some(t),
+                        Err(IntoTypeError::NotAnInt(name, loc)) => {
+                            errs.push(Diagnostic::error(loc, 311, Some(format!("cannot convert value of type {name} to u64"))));
+                            None
+                        },
+                        Err(IntoTypeError::NotCompileTime(loc)) => {
+                            errs.push(Diagnostic::error(loc, 324, None));
+                            None
+                        },
+                        Err(IntoTypeError::NotAModule(name, loc)) => {
+                            errs.push(Diagnostic::error(loc, 321, Some(format!("{name} is not a module"))));
+                            None
+                        },
+                        Err(IntoTypeError::DoesNotExist(name, loc)) => {
+                            errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                            None
+                        }
+                    }
+                }) {t} else if t == Type::IntLiteral {Type::Int(64, false)} else if let Type::Reference(b, _) = t {*b} else {t};
                 let mut errs;
-                match if let Some(t) = t.llvm_type(ctx) {
+                match if let Some(t) = dt.llvm_type(ctx) {
                     if ctx.is_const.get() {
                         let (val, es) = self.val.codegen(ctx);
                         errs = es;
@@ -629,8 +652,31 @@ impl AST for MutDefAST {
             }
             else {
                 let t = self.val.res_type(ctx);
+                let dt = if let Some(t) = self.type_.as_ref().and_then(|t| {
+                    let (t, mut es) = t.into_type(ctx);
+                    errs.append(&mut es);
+                    match t {
+                        Ok(t) => Some(t),
+                        Err(IntoTypeError::NotAnInt(name, loc)) => {
+                            errs.push(Diagnostic::error(loc, 311, Some(format!("cannot convert value of type {name} to u64"))));
+                            None
+                        },
+                        Err(IntoTypeError::NotCompileTime(loc)) => {
+                            errs.push(Diagnostic::error(loc, 324, None));
+                            None
+                        },
+                        Err(IntoTypeError::NotAModule(name, loc)) => {
+                            errs.push(Diagnostic::error(loc, 321, Some(format!("{name} is not a module"))));
+                            None
+                        },
+                        Err(IntoTypeError::DoesNotExist(name, loc)) => {
+                            errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                            None
+                        }
+                    }
+                }) {t} else if t == Type::IntLiteral {Type::Int(64, false)} else if let Type::Reference(b, _) = t {*b} else {t};
                 let mut errs;
-                match if let Some(t) = t.llvm_type(ctx) {
+                match if let Some(t) = dt.llvm_type(ctx) {
                     if ctx.is_const.get() {
                         let (val, es) = self.val.codegen(ctx);
                         errs = es;

--- a/src/cobalt/dottedname.rs
+++ b/src/cobalt/dottedname.rs
@@ -119,7 +119,7 @@ impl CompoundDottedName {
     }
     pub fn load<R: Read + BufRead>(buf: &mut R) -> io::Result<Option<Self>> {
         let mut c = 0u8;
-        buf.read_exact(std::slice::from_mut(&mut c))?;
+        if buf.read_exact(std::slice::from_mut(&mut c)).is_err() {return Ok(None)};
         match c {
             0 => Ok(None),
             1 | 2 => {

--- a/src/cobalt/types.rs
+++ b/src/cobalt/types.rs
@@ -60,13 +60,14 @@ impl Display for Type {
             Array(x, Some(s)) => write!(f, "{}[{s}]", *x),
             Function(ret, args) => {
                 write!(f, "fn (")?;
-                let len = args.len();
+                let mut len = args.len();
                 for (arg, ty) in args.iter() {
                     write!(f, "{}{}", match ty {
                         true => "const ",
                         false => ""
                     }, arg)?;
                     if len > 1 {write!(f, ", ")?}
+                    len -= 1;
                 }
                 write!(f, "): {}", *ret)
             },

--- a/src/cobalt/varmap.rs
+++ b/src/cobalt/varmap.rs
@@ -208,7 +208,7 @@ impl<'ctx> Symbol<'ctx> {
                             }
                         }
                     }
-                    else if let Some(t) = var.data_type.llvm_type(ctx) {
+                    else if let Some(t) = if let Type::Reference(ref b, _) = var.data_type {b.llvm_type(ctx)} else {None} {
                         let gv = ctx.module.add_global(t, None, std::str::from_utf8(&name).expect("LLVM variable names should be valid UTF-8")); // maybe do something with linkage/call convention?
                         gv.set_linkage(DLLImport);
                         var.comp_val = Some(BasicValueEnum::PointerValue(gv.as_pointer_value()));

--- a/src/cobalt/varmap.rs
+++ b/src/cobalt/varmap.rs
@@ -369,7 +369,11 @@ impl<'ctx> VarMap<'ctx> {
             out.write_all(&[0])?;
             sym.save(out)?;
         }
-        Ok(())
+        out.write_all(&[0])?;
+        for import in self.imports.iter() {
+            import.save(out)?;
+        }
+        out.write_all(&[0])
     }
     pub fn load<R: Read + BufRead>(&mut self, buf: &mut R, ctx: &CompCtx<'ctx>) -> io::Result<()> {
         loop {

--- a/src/cobalt/varmap.rs
+++ b/src/cobalt/varmap.rs
@@ -239,7 +239,7 @@ impl<'ctx> Symbol<'ctx> {
         match self {
             Symbol::Variable(Variable {data_type: dt, ..}) => eprintln!("variable of type {dt}"),
             Symbol::Module(m, i) => {
-                eprintln!("{}module", std::iter::repeat(' ').take(depth).collect::<String>());
+                eprintln!("module");
                 depth += 4;
                 let pre = std::iter::repeat(' ').take(depth).collect::<String>();
                 i.iter().for_each(|i| eprintln!("{pre}import {i}"));

--- a/src/libs.rs
+++ b/src/libs.rs
@@ -6,10 +6,7 @@ pub fn find_libs<'a>(mut libs: Vec<String>, dirs: &Vec<&str>, ctx: Option<&cobal
     let mut out = vec![];
     for x in dirs.iter().flat_map(|dir| walkdir::WalkDir::new(dir).follow_links(true).into_iter()).filter_map(|x| x.ok()).filter(|x| x.file_type().is_file()) {
         let path = x.into_path();
-        match path.extension().and_then(OsStr::to_str) {
-            Some("so") | Some("dylib") | Some("dll") => {},
-            _ => continue
-        }
+        if let Some(ext) = path.file_name().and_then(OsStr::to_str).map(|x| x.find('.').map(|i| &x[i..]).unwrap_or(x)) {if !(ext.contains(".so") || ext.contains(".dylib") || ext.contains(".dll")) {continue}} else {continue}
         if let Some(stem) = path.file_stem().and_then(|x| x.to_str()) {
             for lib in libs.iter_mut().filter(|x| x.len() > 0) {
                 if lib == &stem || (stem.starts_with("lib") && lib == &&stem[3..]) {

--- a/src/libs.rs
+++ b/src/libs.rs
@@ -1,62 +1,9 @@
 use std::path::PathBuf;
 use std::ffi::OsStr;
-use std::io::{self, BufReader, BufRead};
-use std::fs::File;
+use std::io;
+use std::process::{Command, Output};
 pub fn find_libs<'a>(mut libs: Vec<String>, dirs: &Vec<&str>, ctx: Option<&cobalt::CompCtx>) -> io::Result<(Vec<(PathBuf, String)>, Vec<String>)> {
     let mut out = vec![];
-    let mut nf = vec![];
-    for x in dirs.iter().flat_map(|dir| walkdir::WalkDir::new(dir).follow_links(true).into_iter()).filter_map(|x| x.ok()).filter(|x| x.file_type().is_file()) {
-        let path = x.into_path();
-        if path.extension().and_then(OsStr::to_str) != Some("colib") {continue}
-        if let Some(stem) = path.file_stem().and_then(|x| x.to_str()) {
-            for lib in libs.iter_mut().filter(|x| x.len() > 0) {
-                if lib == &stem {
-                    let mut passed_libs = false;
-                    let mut passed_syms = false;
-                    let mut archive = ar::Archive::new(File::open(&path)?);
-                    while let Some(entry) = archive.next_entry() {
-                        let entry = entry?;
-                        let id = entry.header().identifier();
-                        if id == b".co-syms" {
-                            if passed_syms {continue}
-                            let mut buf = BufReader::new(entry);
-                            if let Some(ctx) = ctx {ctx.with_vars(|v| v.load(&mut buf, &ctx))?;}
-                            passed_syms = true;
-                            if passed_libs {break}
-                        }
-                        else if id == b".libs" {
-                            if passed_libs {continue}
-                            let mut libs = vec![];
-                            let mut dirs = vec![];
-                            let mut reader = BufReader::new(entry);
-                            loop {
-                                let mut data = vec![];
-                                reader.read_until(0, &mut data)?;
-                                if data.last() == Some(&0) {data.pop();}
-                                if data.len() == 0 {break}
-                                if let Ok(s) = std::str::from_utf8(&data) {libs.push(s.to_string());}
-                            }
-                            loop {
-                                let mut data = vec![];
-                                reader.read_until(0, &mut data)?;
-                                if data.last() == Some(&0) {data.pop();}
-                                if data.len() == 0 {break}
-                                if let Ok(s) = std::str::from_utf8(&data) {dirs.push(s.to_string());}
-                            }
-                            let mut res = find_libs(libs, &dirs.iter().map(|x| x.as_str()).collect(), ctx)?;
-                            out.append(&mut res.0);
-                            nf.append(&mut res.1);
-                            passed_libs = true;
-                            if passed_syms {break}
-                        }
-                    }
-                    let mut val = String::new();
-                    std::mem::swap(&mut val, lib);
-                    out.push((path.clone(), val));
-                }
-            }
-        }
-    }
     for x in dirs.iter().flat_map(|dir| walkdir::WalkDir::new(dir).follow_links(true).into_iter()).filter_map(|x| x.ok()).filter(|x| x.file_type().is_file()) {
         let path = x.into_path();
         match path.extension().and_then(OsStr::to_str) {
@@ -68,6 +15,12 @@ pub fn find_libs<'a>(mut libs: Vec<String>, dirs: &Vec<&str>, ctx: Option<&cobal
                 if lib == &stem || (stem.starts_with("lib") && lib == &&stem[3..]) {
                     let mut val = String::new();
                     std::mem::swap(&mut val, lib);
+                    if let Some(ctx) = ctx {
+                        match Command::new("objcopy").arg(&path).args(["--dump-section", ".colib=/dev/stdout"]).output() { // TODO: use ELF parser library
+                            Ok(Output {status, stdout, ..}) if status.success() => ctx.with_vars(|v| v.load(&mut stdout.as_slice(), ctx))?,
+                            _ => {}
+                        }
+                    }
                     out.push((path.clone(), val));
                 }
             }
@@ -89,5 +42,5 @@ pub fn find_libs<'a>(mut libs: Vec<String>, dirs: &Vec<&str>, ctx: Option<&cobal
             }
         }
     }
-    Ok((out, nf.into_iter().chain(libs.into_iter().filter(|x| x.len() > 0).map(|x| x.to_string())).collect()))
+    Ok((out, libs.into_iter().filter(|x| x.len() > 0).map(|x| x.to_string()).collect()))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,6 +412,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             if !no_default_link {
+                if let Some(pwd) = std::env::current_dir().ok().and_then(|pwd| pwd.to_str().map(String::from)) {link_dirs.insert(0, pwd);}
                 if let Ok(home) = std::env::var("HOME") {link_dirs.extend_from_slice(&[format!("{home}/.cobalt/packages"), format!("{home}/.local/lib/cobalt"), "/usr/local/lib/cobalt/packages".to_string(), "/usr/lib/cobalt/packages".to_string(), "/lib/cobalt/packages".to_string(), "/usr/local/lib".to_string(), "/usr/lib".to_string(), "/lib".to_string()]);}
                 else {link_dirs.extend(["/usr/local/lib/cobalt/packages", "/usr/lib/cobalt/packages", "/lib/cobalt/packages", "/usr/local/lib", "/usr/lib", "/lib"].into_iter().map(String::from));}
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,6 +332,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut continue_if_err = false;
             let mut no_default_link = false;
             let mut profile: Option<&str> = None;
+            let mut headers: Vec<&str> = vec![];
             let mut linker_args: Vec<&str> = vec![];
             {
                 let mut it = args.iter().skip(2).skip_while(|x| x.len() == 0);
@@ -482,6 +483,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     'X' => {
                                         linker_args.extend(it.next().map(|x| x.as_str()).unwrap_or("").split(","));
                                     },
+                                    'h' => {
+                                        if let Some(x) = it.next() {
+                                            headers.push(x.as_str());
+                                        }
+                                        else {
+                                            eprintln!("{ERROR}: expected header file after -h flag");
+                                            exit(1)
+                                        }
+                                    },
                                     x => {
                                         eprintln!("{ERROR}: unknown flag -{x}");
                                         exit(1)
@@ -547,6 +557,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if notfound.len() > 0 {exit(102)}
                 libs
             } else {vec![]};
+            for head in headers {
+                let mut file = BufReader::new(std::fs::File::open(&head)?);
+                ctx.with_vars(|v| v.load(&mut file, &ctx))?;
+            }
             let mut fail = false;
             let mut overall_fail = false;
             let mut stdout = &mut StandardStream::stdout(ColorChoice::Always);
@@ -672,6 +686,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut link_dirs: Vec<String> = vec![];
             let mut continue_if_err = false;
             let mut no_default_link = false;
+            let mut headers: Vec<&str> = vec![];
             let mut profile: Option<&str> = None;
             {
                 let mut it = args.iter().skip(2).skip_while(|x| x.len() == 0);
@@ -744,6 +759,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                             exit(1)
                                         }
                                     },
+                                    'h' => {
+                                        if let Some(x) = it.next() {
+                                            headers.push(x.as_str());
+                                        }
+                                        else {
+                                            eprintln!("{ERROR}: expected header file after -h flag");
+                                            exit(1)
+                                        }
+                                    },
                                     x => {
                                         eprintln!("{ERROR}: unknown flag -{x}");
                                         exit(1)
@@ -783,6 +807,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if notfound.len() > 0 {exit(102)}
                 libs
             } else {vec![]};
+            for head in headers {
+                let mut file = BufReader::new(std::fs::File::open(&head)?);
+                ctx.with_vars(|v| v.load(&mut file, &ctx))?;
+            }
             let mut fail = false;
             let mut overall_fail = false;
             let mut stdout = &mut StandardStream::stdout(ColorChoice::Always);


### PR DESCRIPTION
The original purpose of this commit was to make `co aot --lib` emit dynamic libraries, but there's a few improvements to the library output now.
Changes:
- Most notably, library generation now emits a dynamic library—shared object, dll, or dylib
  - The header information is now stored in the `.colib` section.
- I gave up on trying to use `ld` to compile executables. `co aot [--exe]` just uses the code that was used for `--exe-libc`.
- Library headers can now be saved without using `ar`.
  - They can now be saved with `co aot --header`, with the default extension of `.coh`.
  - Headers can be included in compilation commands with the `-h` flag. There isn't much reason to do this, but it's an option now.
  - In debug builds, there are two new commands.
    - `lib-header` saves a header, and is basically a less useful version of `aot --header`. I added it before I added the flag.
    - `read-lib` loeads each library (into separate `VarMap`s) and dumps each one to stderr.
- There are a few bugfixes that aren't strictly link-related, but came up here.
  - This compiles properly:
    ```
    let a = 0;
    let b = a;
    ```
    - Before, `b` was `i64*` and LLVM gave an error about the `store`.
  - When variables are read from a header, they aren't loaded as pointers to the value any more.
Commits:
- Switched library output to generate shared objects
- Fixed IO error from loading libraries
- Changed output file name
- Changed library symbols to use dllimport linkage
- Added pwd to default link dirs
- Fixed VarDefAST and MutDefAST not dereferencing references to non-constant values
- Added lib-header and read-lib debug commands
- Fixed library loading variables as pointers in LLVM
- Expanded library search to use libs with SONAME
- Gave up on replacing C compiler
- Added option to emit header
- Made module dumps look better
- Added -h flag to load headers
- Added options to link libraries in co check
