### PR TITLE
Update 'build' subcommand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ ar = "0.9.0"
 codespan-reporting = "0.11.1"
 temp-file = "0.1.7"
 ureq = "2.6.2"
+path-calculate = "0.1.3"
 
 [lib]
 name = "cobalt"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1226,7 +1226,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 triple: &triple.unwrap_or_else(TargetMachine::get_default_triple),
                 continue_build: false,
                 continue_comp: false,
-                link_dirs
+                link_dirs: link_dirs.iter().map(|x| x.as_str()).collect()
             }));
         },
         "install" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1180,24 +1180,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
                 None => {
                     let cfg;
-                    if !Path::new("cobalt.toml").exists() {
-                        eprintln!("{ERROR}: couldn't find cobalt.toml in current directory");
-                        exit(100)
+                    let mut path = std::env::current_dir()?;
+                    loop {
+                        path.push("cobalt.toml");
+                        if path.exists() {break}
+                        path.pop();
+                        if !path.pop() {
+                            eprintln!("{ERROR}: couldn't find cobalt.toml in current directory");
+                            exit(100)
+                        }
                     }
-                    match std::fs::read_to_string("cobalt.toml") {
+                    match std::fs::read_to_string(&path) {
                         Ok(c) => cfg = c,
                         Err(e) => {
                             eprintln!("error when reading project file: {e}");
                             exit(100)
                         }
                     }
+                    path.pop();
                     (match toml::from_str::<build::Project>(cfg.as_str()) {
                         Ok(proj) => proj,
                         Err(e) => {
                             eprintln!("error when parsing project file: {e}");
                             exit(100)
                         }
-                    }, PathBuf::from("."))
+                    }, path)
                 }
             };
             if !no_default_link {

--- a/src/package.rs
+++ b/src/package.rs
@@ -164,6 +164,8 @@ impl Package {
             install_loc.push("cobalt.toml");
             let cfg = std::fs::read_to_string(&install_loc)?;
             install_loc.pop();
+            let link_dirs = if let Ok(home) = std::env::var("HOME") {vec![format!("{home}/.cobalt/packages"), format!("{home}/.local/lib/cobalt"), "/usr/local/lib/cobalt/packages".to_string(), "/usr/lib/cobalt/packages".to_string(), "/lib/cobalt/packages".to_string(), "/usr/local/lib".to_string(), "/usr/lib".to_string(), "/lib".to_string()]}
+                            else {["/usr/local/lib/cobalt/packages", "/usr/lib/cobalt/packages", "/lib/cobalt/packages", "/usr/local/lib", "/usr/lib", "/lib"].into_iter().map(String::from).collect()};
             let res = build(toml::from_str(&cfg)?, None, &BuildOptions {
                 source_dir: &install_loc,
                 build_dir: &install_dir,
@@ -171,8 +173,7 @@ impl Package {
                 continue_build: false,
                 triple: &triple,
                 profile: "default",
-                link_dirs:  if let Ok(home) = std::env::var("HOME") {vec![format!("{home}/.cobalt/packages"), format!("{home}/.local/lib/cobalt"), "/usr/local/lib/cobalt/packages".to_string(), "/usr/lib/cobalt/packages".to_string(), "/lib/cobalt/packages".to_string(), "/usr/local/lib".to_string(), "/usr/lib".to_string(), "/lib".to_string()]}
-                            else {["/usr/local/lib/cobalt/packages", "/usr/lib/cobalt/packages", "/lib/cobalt/packages", "/usr/local/lib", "/usr/lib", "/lib"].into_iter().map(String::from).collect()}
+                link_dirs: link_dirs.iter().map(|x| x.as_str()).collect()
             });
             if opts.clean {std::fs::remove_dir_all(install_loc)?}
             if res == 0 {Ok(())} else {Err(InstallError::BuildFailed(res))}


### PR DESCRIPTION
Cobalt's build system fell behind all of the work on the `dyn-colib` branch, mostly because everything was tested through the `aot` subcommand.
Changes:
- Library targets on the `build` command now output the shared object version.
- Parent directories are searched for a `cobalt.toml` file if it is not found in the current one (only if no project directory is specified)
- When you build a project, you get feedback on what's going on.
  - This is on stdout, so you can easily do `co build > /dev/null` to silence the output while still seeing errors.
Commits:
- Updated driver to build dynamic libraries
- made build subcommand search parent directories if run without an argument
- Added more interaction from build commands
