### PR TITLE
Use shorter integer widths where possible

### DIFF
--- a/src/cobalt/ast/literals.rs
+++ b/src/cobalt/ast/literals.rs
@@ -26,12 +26,12 @@ impl AST for IntLiteralAST {
             None | Some(("", _)) => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val), Type::IntLiteral), vec![]),
             Some(("isize", _)) => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(64, false)), vec![]),
             Some((x, _)) if x.as_bytes()[0] == 0x69 && x[1..].chars().all(char::is_numeric) => {
-                let size: u64 = x[1..].parse().unwrap_or(0);
+                let size: u16 = x[1..].parse().unwrap_or(0);
                 (Variable::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(size, false)), vec![])
             },
             Some(("usize", _)) => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(64, true)), vec![]),
             Some((x, _)) if x.as_bytes()[0] == 0x75 && x[1..].chars().all(char::is_numeric) => {
-                let size: u64 = x[1..].parse().unwrap_or(0);
+                let size: u16 = x[1..].parse().unwrap_or(0);
                 (Variable::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(size, true)), vec![])
             },
             Some((x, loc)) => (Variable::error(), vec![Diagnostic::error(loc.clone(), 390, Some(format!("unknown suffix {x} for integer literal")))])
@@ -120,12 +120,12 @@ impl AST for CharLiteralAST {
             None | Some(("", _)) => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Char), vec![]),
             Some(("isize", _)) => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(64, false)), vec![]),
             Some((x, _)) if x.as_bytes()[0] == 0x69 && x[1..].chars().all(char::is_numeric) => {
-                let size: u64 = x[1..].parse().unwrap_or(0);
+                let size: u16 = x[1..].parse().unwrap_or(0);
                 (Variable::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(size, false)), vec![])
             },
             Some(("usize", _)) => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(64, true)), vec![]),
             Some((x, _)) if x.as_bytes()[0] == 0x75 && x[1..].chars().all(char::is_numeric) => {
-                let size: u64 = x[1..].parse().unwrap_or(0);
+                let size: u16 = x[1..].parse().unwrap_or(0);
                 (Variable::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(size, true)), vec![])
             },
             Some((x, loc)) => (Variable::error(), vec![Diagnostic::error(loc.clone(), 390, Some(format!("unknown suffix {x} for character literal")))])

--- a/src/cobalt/misc.rs
+++ b/src/cobalt/misc.rs
@@ -1,13 +1,13 @@
 use std::fmt::*;
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Flags {
-    pub word_size: u64,
+    pub word_size: u16,
     pub(crate) up: bool
 }
 impl Default for Flags {
     fn default()->Self {
         Flags {
-            word_size: std::mem::size_of::<isize>() as u64,
+            word_size: std::mem::size_of::<isize>() as u16,
             up: true
         }
     }

--- a/src/cobalt/parsed_type.rs
+++ b/src/cobalt/parsed_type.rs
@@ -10,8 +10,8 @@ pub enum IntoTypeError {
 pub enum ParsedType {
     Error,
     Null, Bool,
-    Int(u64),
-    UInt(u64),
+    Int(u16),
+    UInt(u16),
     ISize, USize,
     F16, F32, F64, F128,
     Pointer(Box<ParsedType>, bool),
@@ -67,7 +67,7 @@ impl ParsedType {
                 let var = types::utils::impl_convert(var, Type::Int(64, false), ctx);
                 ctx.is_const.set(old_const);
                 return (if var.is_none() {Err(IntoTypeError::NotAnInt(err, size.loc()))}
-                else if let Some(InterData::Int(val)) = var.unwrap().inter_val {Ok(Type::Array(Box::new(base), Some(val as u64)))}
+                else if let Some(InterData::Int(val)) = var.unwrap().inter_val {Ok(Type::Array(Box::new(base), Some(val as u32)))}
                 else {Err(IntoTypeError::NotCompileTime(size.loc()))}, errs);
             },
             TypeOf(expr) => {

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -422,7 +422,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                         (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(x), false) => {
                             let pt = ctx.context.i64_type();
                             let v1 = ctx.builder.build_load(l, "").into_pointer_value();
-                            let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
+                            let v2 = ctx.builder.build_int_mul(r, pt.const_int(x as u64, false), "");
                             let v3 = ctx.builder.build_ptr_to_int(v1, pt, "");
                             let v4 = ctx.builder.build_int_add(v3, v2, "");
                             let v5 = ctx.builder.build_int_to_ptr(v4, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::from(0u16)), "");
@@ -439,7 +439,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                         (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(x), false) => {
                             let pt = ctx.context.i64_type();
                             let v1 = ctx.builder.build_load(l, "").into_pointer_value();
-                            let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
+                            let v2 = ctx.builder.build_int_mul(r, pt.const_int(x as u64, false), "");
                             let v3 = ctx.builder.build_ptr_to_int(v1, pt, "");
                             let v4 = ctx.builder.build_int_sub(v3, v2, "");
                             let v5 = ctx.builder.build_int_to_ptr(v4, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::from(0u16)), "");
@@ -895,7 +895,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                     (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(x), false) => Some({
                         let pt = ctx.context.i64_type();
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
-                        let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
+                        let v2 = ctx.builder.build_int_mul(r, pt.const_int(x as u64, false), "");
                         let v3 = ctx.builder.build_int_add(v1, v2, "");
                         PointerValue(ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::from(0u16)), ""))
                     }),
@@ -910,7 +910,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                     (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(x), false) => Some({
                         let pt = ctx.context.i64_type();
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
-                        let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
+                        let v2 = ctx.builder.build_int_mul(r, pt.const_int(x as u64, false), "");
                         let v3 = ctx.builder.build_int_sub(v1, v2, "");
                         PointerValue(ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::from(0u16)), ""))
                     }),
@@ -928,7 +928,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                     (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(x), false) => Some({
                         let pt = ctx.context.i64_type();
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
-                        let v2 = ctx.builder.build_int_mul(r, pt.const_int(x, false), "");
+                        let v2 = ctx.builder.build_int_mul(r, pt.const_int(x as u64, false), "");
                         let v3 = ctx.builder.build_int_add(v1, v2, "");
                         PointerValue(ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::from(0u16)), ""))
                     }),
@@ -1333,7 +1333,7 @@ pub fn pre_op<'ctx>(mut val: Variable<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> O
                             let pt = ctx.context.i64_type();
                             let v1 = ctx.builder.build_load(v, "").into_pointer_value();
                             let v2 = ctx.builder.build_ptr_to_int(v1, pt, "");
-                            let v3 = ctx.builder.build_int_add(v2, pt.const_int(x, false), "");
+                            let v3 = ctx.builder.build_int_add(v2, pt.const_int(x as u64, false), "");
                             let v4 = ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::from(0u16)), "");
                             ctx.builder.build_store(v, v4);
                         }
@@ -1346,7 +1346,7 @@ pub fn pre_op<'ctx>(mut val: Variable<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> O
                             let pt = ctx.context.i64_type();
                             let v1 = ctx.builder.build_load(v, "").into_pointer_value();
                             let v2 = ctx.builder.build_ptr_to_int(v1, pt, "");
-                            let v3 = ctx.builder.build_int_sub(v2, pt.const_int(x, false), "");
+                            let v3 = ctx.builder.build_int_sub(v2, pt.const_int(x as u64, false), "");
                             let v4 = ctx.builder.build_int_to_ptr(v3, b.llvm_type(ctx).unwrap().ptr_type(inkwell::AddressSpace::from(0u16)), "");
                             ctx.builder.build_store(v, v4);
                         }

--- a/src/cobalt/varmap.rs
+++ b/src/cobalt/varmap.rs
@@ -48,13 +48,13 @@ impl InterData {
             },
             InterData::Array(v) => {
                 out.write_all(&[5])?;
-                out.write_all(&(v.len() as u64).to_be_bytes())?; // length
+                out.write_all(&(v.len() as u32).to_be_bytes())?; // length
                 for val in v.iter() {val.save(out)?;} // InterData is self-puncatuating
                 Ok(())
             },
             InterData::Function(v) => { // serialized the same as InterData::Array
                 out.write_all(&[6])?;
-                out.write_all(&(v.defaults.len() as u64).to_be_bytes())?;
+                out.write_all(&(v.defaults.len() as u32).to_be_bytes())?;
                 for val in v.defaults.iter() {val.save(out)?;}
                 Ok(())
             },
@@ -90,17 +90,17 @@ impl InterData {
                 Some(InterData::Str(std::str::from_utf8(&vec).expect("Interpreted strings should be valid UTF-8").to_string()))
             },
             5 => {
-                let mut bytes = [0; 8];
+                let mut bytes = [0; 4];
                 buf.read_exact(&mut bytes)?;
-                let len = u64::from_be_bytes(bytes);
+                let len = u32::from_be_bytes(bytes);
                 let mut vec = Vec::with_capacity(len as usize);
                 for _ in 0..len {vec.push(Self::load(buf)?.expect("# of unwrapped array elements doesn't match the prefixed count"))}
                 Some(InterData::Array(vec))
             },
             6 => {
-                let mut bytes = [0; 8];
+                let mut bytes = [0; 4];
                 buf.read_exact(&mut bytes)?;
-                let len = u64::from_be_bytes(bytes);
+                let len = u32::from_be_bytes(bytes);
                 let mut vec = Vec::with_capacity(len as usize);
                 for _ in 0..len {vec.push(Self::load(buf)?.expect("# of unwrapped default parameters doesn't match the prefixed count"))}
                 Some(InterData::Function(FnData{defaults: vec}))

--- a/src/main.rs
+++ b/src/main.rs
@@ -547,7 +547,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ).expect("failed to create target machine");
             let mut flags = cobalt::Flags::default();
             let ink_ctx = inkwell::context::Context::create();
-            if let Some(size) = ink_ctx.ptr_sized_int_type(&target_machine.get_target_data(), None).size_of().get_zero_extended_constant() {flags.word_size = size;}
+            if let Some(size) = ink_ctx.ptr_sized_int_type(&target_machine.get_target_data(), None).size_of().get_zero_extended_constant() {flags.word_size = size as u16;}
             let ctx = cobalt::context::CompCtx::with_flags(&ink_ctx, in_file, flags);
             ctx.module.set_triple(&triple);
             let libs = if linked.len() > 0 {
@@ -966,7 +966,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ).expect("failed to create target machine");
             let mut flags = cobalt::Flags::default();
             let ink_ctx = inkwell::context::Context::create();
-            if let Some(size) = ink_ctx.ptr_sized_int_type(&target_machine.get_target_data(), None).size_of().get_zero_extended_constant() {flags.word_size = size;}
+            if let Some(size) = ink_ctx.ptr_sized_int_type(&target_machine.get_target_data(), None).size_of().get_zero_extended_constant() {flags.word_size = size as u16;}
             let ctx = cobalt::context::CompCtx::with_flags(&ink_ctx, in_file, flags);
             ctx.module.set_triple(&triple);
             if linked.len() > 0 {


### PR DESCRIPTION
In an attempt to reduce the huge number of null bytes in headers as well as save memory, certain areas don't use `u64` any more.
The changes are:
- `Type::Int` (`u16` for size)
- `Flags.word_size` (`u16`)
- `SizeType::Static` (`u32`)
- Serialization of `InterData::Function` and `InterData::Array` now cap at `u16` for (default) parameter count and length, respectively.
