### PR TITLE
Add conversions for pointers

### DIFF
--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -260,6 +260,7 @@ impl AST for VarDefAST {
                     else {
                         let gv = ctx.module.add_global(t, None, linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name).as_str());
                         gv.set_constant(false);
+                        gv.set_initializer(&t.const_zero());
                         if let Some((link, _)) = link_type {gv.set_linkage(link)}
                         let f = ctx.module.add_function(format!("__internals.init.{}", self.name).as_str(), ctx.context.void_type().fn_type(&[], false), Some(inkwell::module::Linkage::Private));
                         let entry = ctx.context.append_basic_block(f, "entry");
@@ -714,6 +715,7 @@ impl AST for MutDefAST {
                     else {
                         let gv = ctx.module.add_global(t, None, linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name).as_str());
                         gv.set_constant(false);
+                        gv.set_initializer(&t.const_zero());
                         if let Some((link, _)) = link_type {gv.set_linkage(link)}
                         let f = ctx.module.add_function(format!("__internals.init.{}", self.name).as_str(), ctx.context.void_type().fn_type(&[], false), Some(inkwell::module::Linkage::Private));
                         let entry = ctx.context.append_basic_block(f, "entry");

--- a/src/cobalt/context.rs
+++ b/src/cobalt/context.rs
@@ -9,6 +9,7 @@ pub struct CompCtx<'ctx> {
     pub module: Module<'ctx>,
     pub builder: Builder<'ctx>,
     pub is_const: Cell<bool>,
+    pub null_type: inkwell::types::BasicTypeEnum<'ctx>,
     vars: Cell<MaybeUninit<Box<VarMap<'ctx>>>>,
     name: Cell<MaybeUninit<String>>
 }
@@ -20,6 +21,7 @@ impl<'ctx> CompCtx<'ctx> {
             module: ctx.create_module(name),
             builder: ctx.create_builder(),
             is_const: Cell::new(false),
+            null_type: ctx.opaque_struct_type("null").into(),
             vars: Cell::new(MaybeUninit::new(Box::default())),
             name: Cell::new(MaybeUninit::new(".".to_string()))
         }
@@ -31,6 +33,7 @@ impl<'ctx> CompCtx<'ctx> {
             module: ctx.create_module(name),
             builder: ctx.create_builder(),
             is_const: Cell::new(false),
+            null_type: ctx.opaque_struct_type("null").into(),
             vars: Cell::new(MaybeUninit::new(Box::default())),
             name: Cell::new(MaybeUninit::new(".".to_string()))
         }

--- a/src/cobalt/types.rs
+++ b/src/cobalt/types.rs
@@ -125,7 +125,7 @@ impl Type {
             Null | Function(..) | Module | TypeData | InlineAsm | Error => None,
             Array(_, Some(_)) => todo!("arrays aren't implemented yet"),
             Array(_, None) => todo!("arrays aren't implemented yet"),
-            Pointer(b, _) | Reference(b, _) => Some(PointerType(b.llvm_type(ctx)?.ptr_type(inkwell::AddressSpace::from(0u16)))),
+            Pointer(b, _) | Reference(b, _) => if b.size() == Static(0) {Some(PointerType(ctx.null_type.ptr_type(inkwell::AddressSpace::from(0u16))))} else {Some(PointerType(b.llvm_type(ctx)?.ptr_type(inkwell::AddressSpace::from(0u16))))},
             Borrow(b) => b.llvm_type(ctx)
         }
     }

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -1538,7 +1538,7 @@ pub fn impl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 }),
                 _ => None
             },
-            Type::Error => Some(Variable {comp_val: None, inter_val: None, data_type: Type::Error, export: true})
+            Type::Error => Some(Variable {comp_val: None, inter_val: None, data_type: Type::Error, export: true}),
             _ => None
         }
     }
@@ -1692,7 +1692,7 @@ pub fn expl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 }),
                 _ => None
             },
-            Type::Error => Some(Variable {comp_val: None, inter_val: None, data_type: Type::Error, export: true})
+            Type::Error => Some(Variable {comp_val: None, inter_val: None, data_type: Type::Error, export: true}),
             _ => None
         }
     }

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -1748,6 +1748,7 @@ pub fn expl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 },
                 _ => None
             },
+            Type::Null => Some(Variable {comp_val: target.llvm_type(ctx).map(|t| t.const_zero()), inter_val: None, data_type: target, export: true}),
             Type::Error => Some(Variable {comp_val: None, inter_val: None, data_type: Type::Error, export: true}),
             _ => None
         }

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -1538,6 +1538,28 @@ pub fn impl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 }),
                 _ => None
             },
+            Type::Pointer(_, false) => match target {
+                Type::Pointer(rb, false) if *rb == Type::Null => Some(Variable {
+                    comp_val: val.value(ctx).map(|v| ctx.builder.build_bitcast(v, ctx.null_type.ptr_type(inkwell::AddressSpace::from(0u16)), "")),
+                    inter_val: None,
+                    data_type: Type::Pointer(Box::new(Type::Null), false),
+                    export: true
+                }),
+                _ => None
+            },
+            Type::Pointer(ref lb, true) => match target {
+                Type::Pointer(rb, false) => match *rb {
+                    Type::Null => Some(Variable {
+                        comp_val: val.value(ctx).map(|v| ctx.builder.build_bitcast(v, ctx.null_type.ptr_type(inkwell::AddressSpace::from(0u16)), "")),
+                        inter_val: None,
+                        data_type: Type::Pointer(Box::new(Type::Null), false),
+                        export: true
+                    }),
+                    x if x == **lb => Some(Variable {data_type: Type::Pointer(Box::new(x), false), ..val}),
+                    _ => None
+                },
+                _ => None
+            },
             Type::Error => Some(Variable {comp_val: None, inter_val: None, data_type: Type::Error, export: true}),
             _ => None
         }
@@ -1690,6 +1712,40 @@ pub fn expl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                     data_type: x.clone(),
                     ..val
                 }),
+                _ => None
+            },
+            Type::Pointer(ref lb, false) => match target {
+                Type::Pointer(rb, false) if *rb == Type::Null => Some(Variable {
+                    comp_val: val.value(ctx).map(|v| ctx.builder.build_bitcast(v, ctx.null_type.ptr_type(inkwell::AddressSpace::from(0u16)), "")),
+                    inter_val: None,
+                    data_type: Type::Pointer(Box::new(Type::Null), false),
+                    export: true
+                }),
+                Type::Pointer(rb, false) if **lb == Type::Null => Some(Variable {
+                    comp_val: val.value(ctx).and_then(|v| Some(ctx.builder.build_bitcast(v, rb.llvm_type(ctx)?.ptr_type(inkwell::AddressSpace::from(0u16)), ""))),
+                    inter_val: None,
+                    data_type: Type::Pointer(rb, false),
+                    export: true
+                }),
+                _ => None
+            },
+            Type::Pointer(ref lb, true) => match target {
+                Type::Pointer(rb, false) => match *rb {
+                    Type::Null => Some(Variable {
+                        comp_val: val.value(ctx).map(|v| ctx.builder.build_bitcast(v, ctx.null_type.ptr_type(inkwell::AddressSpace::from(0u16)), "")),
+                        inter_val: None,
+                        data_type: Type::Pointer(Box::new(Type::Null), false),
+                        export: true
+                    }),
+                    Type::Pointer(rb, m) if **lb == Type::Null => Some(Variable {
+                        comp_val: val.value(ctx).and_then(|v| Some(ctx.builder.build_bitcast(v, rb.llvm_type(ctx)?.ptr_type(inkwell::AddressSpace::from(0u16)), ""))),
+                        inter_val: None,
+                        data_type: Type::Pointer(rb, m),
+                        export: true
+                    }),
+                    x if x == **lb => Some(Variable {data_type: Type::Pointer(Box::new(x), false), ..val}),
+                    _ => None
+                },
                 _ => None
             },
             Type::Error => Some(Variable {comp_val: None, inter_val: None, data_type: Type::Error, export: true}),


### PR DESCRIPTION
Changes:
- Any pointer can implcitly be converted to `null const*` or `null mut*` (if the base is mutable)
- `null const*` and `null mut*` can be explicitly converted into any pointer type.
- `null` can be converted into any type as a constant zero.
  - e.g. `null: i8 const*` is a null pointer to `i8`
Commits:
- Changed null's LLVM representation to be an opaque struct
- Added pointer casts
- Added explicit conversion from null to a null state of any type
