### PR TITLE
Move variable data to variables instead of values

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -152,7 +152,7 @@ fn clear_mod<'ctx>(this: &mut HashMap<String, cobalt::Symbol<'ctx>>, module: &in
     for (_, sym) in this.iter_mut() {
         match sym {
             cobalt::Symbol::Module(m, _) => clear_mod(m, module),
-            cobalt::Symbol::Variable(v) => if let Some(inkwell::values::BasicValueEnum::PointerValue(pv)) = v.comp_val {
+            cobalt::Symbol::Variable(v, _) => if let Some(inkwell::values::BasicValueEnum::PointerValue(pv)) = v.comp_val {
                 let t = inkwell::types::BasicTypeEnum::try_from(pv.get_type().get_element_type());
                 if let Ok(t) = t {
                     v.comp_val = Some(inkwell::values::BasicValueEnum::PointerValue(module.add_global(t, None, pv.get_name().to_str().expect("Global variable should have a name!")).as_pointer_value()));

--- a/src/cobalt/ast.rs
+++ b/src/cobalt/ast.rs
@@ -20,7 +20,7 @@ pub trait AST {
     fn loc(&self) -> Location;
     fn is_const(&self) -> bool {false}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type;
-    fn codegen<'ctx>(& self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>);
+    fn codegen<'ctx>(& self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>);
     fn to_code(&self) -> String;
     fn print_impl(&self, f: &mut Formatter, pre: &mut TreePrefix) -> Result;
 }

--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -518,11 +518,15 @@ impl AST for FnDefAST {
             } {
                 Ok(x) => (x.as_var().unwrap().clone(), errs),
                 Err(RedefVariable::NotAModule(x, _)) => {
-                    errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
+                    errs.push(Diagnostic::error(self.name.ids[x].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
                     (Value::error(), errs)
                 },
-                Err(RedefVariable::AlreadyExists(x, _)) => {
-                    errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
+                Err(RedefVariable::AlreadyExists(x, d, _)) => {
+                    let mut err = Diagnostic::error(self.name.ids[x].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x))));
+                    if let Some(loc) = d {
+                        err.add_note(loc, "previously defined here".to_string());
+                    }
+                    errs.push(err);
                     (Value::error(), errs)
                 }
             }

--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -68,7 +68,7 @@ impl AST for FnDefAST {
             }
         }, pt == &ParamType::Constant)).collect())
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         let (ret, mut errs) = self.ret.into_type(ctx);
         let ret = match ret {
             Ok(t) => t,
@@ -259,7 +259,7 @@ impl AST for FnDefAST {
                 x => errs.push(Diagnostic::error(loc.clone(), 410, Some(format!("unknown annotation {x:?} for function definition"))))
             }
         }
-        if target_match == 0 {return (Variable::null(), errs)}
+        if target_match == 0 {return (Value::null(), errs)}
         let old_ip = ctx.builder.get_insert_block();
         let val = if let Type::Function(ref ret, ref params) = fty {
             match if let Some(llt) = ret.llvm_type(ctx) {
@@ -278,7 +278,7 @@ impl AST for FnDefAST {
                         f.as_global_value().set_linkage(link)
                     }
                     let cloned = params.clone(); // Rust doesn't like me using params in the following closure
-                    let var = ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
+                    let var = ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Value {
                         comp_val: Some(PointerValue(f.as_global_value().as_pointer_value())),
                         inter_val: Some(InterData::Function(FnData {
                             defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
@@ -319,7 +319,7 @@ impl AST for FnDefAST {
                                 if !is_const {
                                     let param = f.get_nth_param(param_count).unwrap();
                                     param.set_name(name.as_str());
-                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), (0, 0..0))), Symbol::Variable(Variable {
+                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), (0, 0..0))), Symbol::Variable(Value {
                                         comp_val: Some(param),
                                         inter_val: None,
                                         data_type: ty.clone(),
@@ -328,7 +328,7 @@ impl AST for FnDefAST {
                                     param_count += 1;
                                 }
                                 else {
-                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), (0, 0..0))), Symbol::Variable(Variable {
+                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), (0, 0..0))), Symbol::Variable(Value {
                                         comp_val: None,
                                         inter_val: None,
                                         data_type: ty.clone(),
@@ -353,7 +353,7 @@ impl AST for FnDefAST {
                 }
                 else {
                     let cloned = params.clone(); // Rust doesn't like me using params in the following closure
-                    ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
+                    ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Value {
                         comp_val: None,
                         inter_val: Some(InterData::Function(FnData {
                             defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
@@ -397,7 +397,7 @@ impl AST for FnDefAST {
                         f.as_global_value().set_linkage(link)
                     }
                     let cloned = params.clone(); // Rust doesn't like me using params in the following closure
-                    let var = ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
+                    let var = ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Value {
                         comp_val: Some(PointerValue(f.as_global_value().as_pointer_value())),
                         inter_val: Some(InterData::Function(FnData {
                             defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
@@ -438,7 +438,7 @@ impl AST for FnDefAST {
                                 if !is_const {
                                     let param = f.get_nth_param(param_count).unwrap();
                                     param.set_name(name.as_str());
-                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), (0, 0..0))), Symbol::Variable(Variable {
+                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), (0, 0..0))), Symbol::Variable(Value {
                                         comp_val: Some(param),
                                         inter_val: None,
                                         data_type: ty.clone(),
@@ -447,7 +447,7 @@ impl AST for FnDefAST {
                                     param_count += 1;
                                 }
                                 else {
-                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), (0, 0..0))), Symbol::Variable(Variable {
+                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), (0, 0..0))), Symbol::Variable(Value {
                                         comp_val: None,
                                         inter_val: None,
                                         data_type: ty.clone(),
@@ -468,7 +468,7 @@ impl AST for FnDefAST {
                 }
                 else {
                     let cloned = params.clone(); // Rust doesn't like me using params in the following closure
-                    ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
+                    ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Value {
                         comp_val: None,
                         inter_val: Some(InterData::Function(FnData {
                             defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
@@ -498,7 +498,7 @@ impl AST for FnDefAST {
             }
             else {
                 let cloned = params.clone(); // Rust doesn't like me using params in the following closure
-                ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Variable {
+                ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Value {
                     comp_val: None,
                     inter_val: Some(InterData::Function(FnData {
                         defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
@@ -528,11 +528,11 @@ impl AST for FnDefAST {
                 Ok(x) => (x.as_var().unwrap().clone(), errs),
                 Err(RedefVariable::NotAModule(x, _)) => {
                     errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
-                    (Variable::error(), errs)
+                    (Value::error(), errs)
                 },
                 Err(RedefVariable::AlreadyExists(x, _)) => {
                     errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
-                    (Variable::error(), errs)
+                    (Value::error(), errs)
                 }
             }
         } else {panic!("In order for this to be reachable, fty would have to somehow be mutated, which is impossible")}.clone();
@@ -607,13 +607,13 @@ impl AST for CallAST {
             _ => Type::Error
         }
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         let (val, mut errs) = self.target.codegen(ctx);
         (types::utils::call(val, self.loc.clone(), self.cparen.clone(), self.args.iter().map(|a| {
             let (arg, mut es) = a.codegen(ctx);
             errs.append(&mut es);
             (arg, a.loc())
-        }).collect(), ctx).unwrap_or_else(|err| {errs.push(err); Variable::error()}), errs)
+        }).collect(), ctx).unwrap_or_else(|err| {errs.push(err); Value::error()}), errs)
     }
     fn to_code(&self) -> String {
         let mut out = format!("{}(", self.target.to_code());
@@ -649,7 +649,7 @@ impl IntrinsicAST {
 impl AST for IntrinsicAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> Type {if self.name == "asm" {Type::InlineAsm} else {Type::Error}}
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         match self.name.as_str() {
             "asm" => {
                 if let Some(ref args) = self.args {
@@ -700,7 +700,7 @@ impl AST for IntrinsicAST {
                                 "usize" => Type::Int(ctx.flags.word_size * 8, true),
                                 x if x.as_bytes()[0] == 0x69 && x[1..].chars().all(char::is_numeric) => Type::Int(x[1..].parse().unwrap_or(64), false),
                                 x if x.as_bytes()[0] == 0x75 && x[1..].chars().all(char::is_numeric) => Type::Int(x[1..].parse().unwrap_or(64), true),
-                                x => return (Variable::error(), vec![Diagnostic::error(self.loc.clone(), 433, Some(format!("expected 'null', 'f{{size}}', 'i{{size}}', 'u{{size}}', or a pointer to one, got {x}")))])
+                                x => return (Value::error(), vec![Diagnostic::error(self.loc.clone(), 433, Some(format!("expected 'null', 'f{{size}}', 'i{{size}}', 'u{{size}}', or a pointer to one, got {x}")))])
                             };
                             for m in modifiers {
                                 match m {
@@ -714,17 +714,17 @@ impl AST for IntrinsicAST {
                             (ty, constraint[(idx + 1)..].to_string())
                         }
                         else {(Type::Null, constraint.to_string())};
-                        (Variable::metaval(InterData::InlineAsm(Box::new(ty), constraint, body), Type::InlineAsm), vec![])
+                        (Value::metaval(InterData::InlineAsm(Box::new(ty), constraint, body), Type::InlineAsm), vec![])
                     }
                     else {
-                        (Variable::error(), vec![Diagnostic::error(self.loc.clone(), 431, None)])
+                        (Value::error(), vec![Diagnostic::error(self.loc.clone(), 431, None)])
                     }
                 }
                 else {
-                    (Variable::error(), vec![Diagnostic::error(self.loc.clone(), 430, None)])
+                    (Value::error(), vec![Diagnostic::error(self.loc.clone(), 430, None)])
                 }
             },
-            x => (Variable::error(), vec![Diagnostic::error(self.loc.clone(), 391, Some(format!("unknown intrinsic {x:?}")))])
+            x => (Value::error(), vec![Diagnostic::error(self.loc.clone(), 391, Some(format!("unknown intrinsic {x:?}")))])
         }
     }
     fn to_code(&self) -> String {self.name.clone() + self.args.as_ref().map(|x| x.as_str()).unwrap_or("")}

--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -302,8 +302,7 @@ impl AST for FnDefAST {
                             })).collect()
                         })),
                         data_type: fty.clone(),
-                        export: true
-                    }))).clone();
+                    }, VariableData::new(self.loc.clone())))).clone();
                     if is_extern.is_none() {
                         let old_scope = ctx.push_scope(&self.name);
                         ctx.map_vars(|v| Box::new(VarMap::new(Some(v))));
@@ -323,8 +322,7 @@ impl AST for FnDefAST {
                                         comp_val: Some(param),
                                         inter_val: None,
                                         data_type: ty.clone(),
-                                        export: true
-                                    }))).map_or((), |_| ());
+                                    }, VariableData::default()))).map_or((), |_| ());
                                     param_count += 1;
                                 }
                                 else {
@@ -332,8 +330,7 @@ impl AST for FnDefAST {
                                         comp_val: None,
                                         inter_val: None,
                                         data_type: ty.clone(),
-                                        export: true
-                                    }))).map_or((), |_| ());
+                                    }, VariableData::default()))).map_or((), |_| ());
                                 }
                             }
                         }
@@ -376,9 +373,8 @@ impl AST for FnDefAST {
                                 }
                             })).collect()
                         })),
-                        data_type: fty,
-                        export: true
-                    }))).clone()
+                        data_type: fty
+                    }, VariableData::new(self.loc.clone())))).clone()
                 }
             }
             else if **ret == Type::Null {
@@ -420,9 +416,8 @@ impl AST for FnDefAST {
                                 }
                             })).collect()
                         })),
-                        data_type: fty.clone(),
-                        export: true
-                    }))).clone();
+                        data_type: fty.clone()
+                    }, VariableData::new(self.loc.clone())))).clone();
                     if is_extern.is_none() {
                         let old_scope = ctx.push_scope(&self.name);
                         ctx.map_vars(|v| Box::new(VarMap::new(Some(v))));
@@ -441,18 +436,16 @@ impl AST for FnDefAST {
                                     ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), (0, 0..0))), Symbol::Variable(Value {
                                         comp_val: Some(param),
                                         inter_val: None,
-                                        data_type: ty.clone(),
-                                        export: true
-                                    }))).map_or((), |_| ());
+                                        data_type: ty.clone()
+                                    }, VariableData::default()))).map_or((), |_| ());
                                     param_count += 1;
                                 }
                                 else {
                                     ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), (0, 0..0))), Symbol::Variable(Value {
                                         comp_val: None,
                                         inter_val: None,
-                                        data_type: ty.clone(),
-                                        export: true
-                                    }))).map_or((), |_| ());
+                                        data_type: ty.clone()
+                                    }, VariableData::default()))).map_or((), |_| ());
                                 }
                             }
                         }
@@ -491,9 +484,8 @@ impl AST for FnDefAST {
                                 }
                             })).collect()
                         })),
-                        data_type: fty,
-                        export: true
-                    }))).clone()
+                        data_type: fty
+                    }, VariableData::new(self.loc.clone())))).clone()
                 }
             }
             else {
@@ -521,9 +513,8 @@ impl AST for FnDefAST {
                             }
                         })).collect()
                     })),
-                    data_type: fty,
-                    export: true
-                }))).clone()
+                    data_type: fty
+                }, VariableData::new(self.loc.clone())))).clone()
             } {
                 Ok(x) => (x.as_var().unwrap().clone(), errs),
                 Err(RedefVariable::NotAModule(x, _)) => {

--- a/src/cobalt/ast/groups.rs
+++ b/src/cobalt/ast/groups.rs
@@ -7,9 +7,9 @@ pub struct BlockAST {
 impl AST for BlockAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.vals.last().map(|x| x.res_type(ctx)).unwrap_or(Type::Null)}
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         ctx.map_vars(|v| Box::new(VarMap::new(Some(v))));
-        let mut out = Variable::null();
+        let mut out = Value::null();
         let mut errs = vec![];
         for val in self.vals.iter() {
             let (ast, mut es) = val.codegen(ctx);
@@ -49,8 +49,8 @@ pub struct GroupAST {
 impl AST for GroupAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.vals.last().map(|x| x.res_type(ctx)).unwrap_or(Type::Null)}
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {
-        let mut out = Variable::null();
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
+        let mut out = Value::null();
         let mut errs = vec![];
         for val in self.vals.iter() {
             let (ast, mut es) = val.codegen(ctx);
@@ -89,13 +89,13 @@ pub struct TopLevelAST {
 impl AST for TopLevelAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> Type {Type::Null}
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         let mut errs = vec![];
         for val in self.vals.iter() {
             let mut es = val.codegen(ctx).1;
             errs.append(&mut es);
         }
-        (Variable::null(), errs)
+        (Value::null(), errs)
     }
     fn to_code(&self) -> String {
         let mut out = String::new();

--- a/src/cobalt/ast/literals.rs
+++ b/src/cobalt/ast/literals.rs
@@ -22,20 +22,20 @@ impl AST for IntLiteralAST {
             _ => Type::Null
         }
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         match self.suffix.as_ref().map(|(x, y)| (x.as_str(), y)) {
-            None | Some(("", _)) => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val), Type::IntLiteral), vec![]),
-            Some(("isize", _)) => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(64, false)), vec![]),
+            None | Some(("", _)) => (Value::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val), Type::IntLiteral), vec![]),
+            Some(("isize", _)) => (Value::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(64, false)), vec![]),
             Some((x, _)) if x.as_bytes()[0] == 0x69 && x[1..].chars().all(char::is_numeric) => {
                 let size: u16 = x[1..].parse().unwrap_or(0);
-                (Variable::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(size, false)), vec![])
+                (Value::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(size, false)), vec![])
             },
-            Some(("usize", _)) => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(64, true)), vec![]),
+            Some(("usize", _)) => (Value::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(64, true)), vec![]),
             Some((x, _)) if x.as_bytes()[0] == 0x75 && x[1..].chars().all(char::is_numeric) => {
                 let size: u16 = x[1..].parse().unwrap_or(0);
-                (Variable::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(size, true)), vec![])
+                (Value::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(size, true)), vec![])
             },
-            Some((x, loc)) => (Variable::error(), vec![Diagnostic::error(loc.clone(), 390, Some(format!("unknown suffix {x} for integer literal")))])
+            Some((x, loc)) => (Value::error(), vec![Diagnostic::error(loc.clone(), 390, Some(format!("unknown suffix {x} for integer literal")))])
         }
     }
     fn to_code(&self) -> String {
@@ -72,13 +72,13 @@ impl AST for FloatLiteralAST {
             _ => Type::Null
         }
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         match self.suffix.as_ref().map(|(x, y)| (x.as_str(), y)) {
-            None | Some(("f64", _)) => (Variable::interpreted(FloatValue(ctx.context.f64_type().const_float(self.val)), InterData::Float(self.val), Type::Float64), vec![]),
-            Some(("f16", _)) => (Variable::interpreted(FloatValue(ctx.context.f16_type().const_float(self.val)), InterData::Float(self.val), Type::Float16), vec![]),
-            Some(("f32", _)) => (Variable::interpreted(FloatValue(ctx.context.f32_type().const_float(self.val)), InterData::Float(self.val), Type::Float32), vec![]),
-            Some(("f128", _)) => (Variable::interpreted(FloatValue(ctx.context.f128_type().const_float(self.val)), InterData::Float(self.val), Type::Float128), vec![]),
-            Some((x, loc)) => (Variable::error(), vec![Diagnostic::error(loc.clone(), 390, Some(format!("unknown suffix {x} for float literal")))])
+            None | Some(("f64", _)) => (Value::interpreted(FloatValue(ctx.context.f64_type().const_float(self.val)), InterData::Float(self.val), Type::Float64), vec![]),
+            Some(("f16", _)) => (Value::interpreted(FloatValue(ctx.context.f16_type().const_float(self.val)), InterData::Float(self.val), Type::Float16), vec![]),
+            Some(("f32", _)) => (Value::interpreted(FloatValue(ctx.context.f32_type().const_float(self.val)), InterData::Float(self.val), Type::Float32), vec![]),
+            Some(("f128", _)) => (Value::interpreted(FloatValue(ctx.context.f128_type().const_float(self.val)), InterData::Float(self.val), Type::Float128), vec![]),
+            Some((x, loc)) => (Value::error(), vec![Diagnostic::error(loc.clone(), 390, Some(format!("unknown suffix {x} for float literal")))])
         }
     }
     fn to_code(&self) -> String {
@@ -116,20 +116,20 @@ impl AST for CharLiteralAST {
             _ => Type::Null
         }
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         match self.suffix.as_ref().map(|(x, y)| (x.as_str(), y)) {
-            None | Some(("", _)) => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Char), vec![]),
-            Some(("isize", _)) => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(64, false)), vec![]),
+            None | Some(("", _)) => (Value::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Char), vec![]),
+            Some(("isize", _)) => (Value::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(64, false)), vec![]),
             Some((x, _)) if x.as_bytes()[0] == 0x69 && x[1..].chars().all(char::is_numeric) => {
                 let size: u16 = x[1..].parse().unwrap_or(0);
-                (Variable::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(size, false)), vec![])
+                (Value::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(size, false)), vec![])
             },
-            Some(("usize", _)) => (Variable::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(64, true)), vec![]),
+            Some(("usize", _)) => (Value::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(64, true)), vec![]),
             Some((x, _)) if x.as_bytes()[0] == 0x75 && x[1..].chars().all(char::is_numeric) => {
                 let size: u16 = x[1..].parse().unwrap_or(0);
-                (Variable::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(size, true)), vec![])
+                (Value::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(size, true)), vec![])
             },
-            Some((x, loc)) => (Variable::error(), vec![Diagnostic::error(loc.clone(), 390, Some(format!("unknown suffix {x} for character literal")))])
+            Some((x, loc)) => (Value::error(), vec![Diagnostic::error(loc.clone(), 390, Some(format!("unknown suffix {x} for character literal")))])
         }
     }
     fn to_code(&self) -> String {
@@ -163,10 +163,10 @@ impl AST for StringLiteralAST {
             Some(_) => Type::Null
         }
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         match &self.suffix {
-            None => (Variable::interpreted(PointerValue(ctx.builder.build_global_string_ptr(self.val.as_str(), "cobalt.str").as_pointer_value()), InterData::Str(self.val.clone()), Type::Pointer(Box::new(Type::Int(8, false)), false)), vec![]),
-            Some((x, loc)) => (Variable::error(), vec![Diagnostic::error(loc.clone(), 390, Some(format!("unknown suffix {x} for string literal")))])
+            None => (Value::interpreted(PointerValue(ctx.builder.build_global_string_ptr(self.val.as_str(), "cobalt.str").as_pointer_value()), InterData::Str(self.val.clone()), Type::Pointer(Box::new(Type::Int(8, false)), false)), vec![]),
+            Some((x, loc)) => (Value::error(), vec![Diagnostic::error(loc.clone(), 390, Some(format!("unknown suffix {x} for string literal")))])
         }
     }
     fn to_code(&self) -> String {
@@ -218,7 +218,7 @@ impl AST for ArrayLiteralAST {
         }
         Type::Reference(Box::new(Type::Array(Box::new(elem), Some(self.vals.len().try_into().unwrap_or(u32::MAX)))), true)
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Variable<'ctx>, Vec<Diagnostic>) {
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         let mut elems = vec![];
         let mut ty = Type::Null;
         let mut first = true;
@@ -256,7 +256,7 @@ impl AST for ArrayLiteralAST {
             elems.truncate(u32::MAX as usize);
         }
         let elems = elems.into_iter().filter_map(|v| types::utils::impl_convert(v, ty.clone(), ctx)).collect::<Vec<_>>();
-        (Variable {
+        (Value {
             comp_val: if let (Some(llt), false) = (ty.llvm_type(ctx), ctx.is_const.get()) {
                 let arr_ty = llt.array_type(elems.len() as u32);
                 let alloca = 

--- a/src/cobalt/ast/literals.rs
+++ b/src/cobalt/ast/literals.rs
@@ -275,8 +275,7 @@ impl AST for ArrayLiteralAST {
                 Some(llv.into())
             } else {None},
             data_type: Type::Reference(Box::new(Type::Array(Box::new(ty), Some(elems.len() as u32))), true),
-            inter_val: Some(InterData::Array(elems.into_iter().map(|v| v.inter_val.unwrap_or(InterData::Null)).collect())),
-            export: true
+            inter_val: Some(InterData::Array(elems.into_iter().map(|v| v.inter_val.unwrap_or(InterData::Null)).collect()))
         }, errs)
 
     }

--- a/src/cobalt/ast/scope.rs
+++ b/src/cobalt/ast/scope.rs
@@ -34,11 +34,11 @@ impl AST for ModuleAST {
         ctx.map_vars(|mut v| {
             match v.lookup_mod(&self.name) {
                 Ok((m, i)) => Box::new(VarMap {parent: Some(v), symbols: m, imports: i}),
-                Err(UndefValue::NotAModule(x)) => {
+                Err(UndefVariable::NotAModule(x)) => {
                     errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
                     Box::new(VarMap::new(Some(v)))
                 },
-                Err(UndefValue::DoesNotExist(x)) => {
+                Err(UndefVariable::DoesNotExist(x)) => {
                     errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
                     Box::new(VarMap::new(Some(v)))
                 }

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -136,11 +136,15 @@ impl AST for VarDefAST {
                 }, VariableData::new(self.loc.clone())))) {
                     Ok(x) => (x.as_var().unwrap().clone(), errs),
                     Err(RedefVariable::NotAModule(x, _)) => {
-                        errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
+                        errs.push(Diagnostic::error(self.name.ids[x].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
                         (Value::error(), errs)
                     },
-                    Err(RedefVariable::AlreadyExists(x, _)) => {
-                        errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
+                    Err(RedefVariable::AlreadyExists(x, d, _)) => {
+                        let mut err = Diagnostic::error(self.name.ids[x].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x))));
+                        if let Some(loc) = d {
+                            err.add_note(loc, "previously defined here".to_string());
+                        }
+                        errs.push(err);
                         (Value::error(), errs)
                     }
                 }
@@ -203,11 +207,15 @@ impl AST for VarDefAST {
                 } {
                     Ok(x) => (x.as_var().unwrap().clone(), errs),
                     Err(RedefVariable::NotAModule(x, _)) => {
-                        errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
+                        errs.push(Diagnostic::error(self.name.ids[x].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
                         (Value::error(), errs)
                     },
-                    Err(RedefVariable::AlreadyExists(x, _)) => {
-                        errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
+                    Err(RedefVariable::AlreadyExists(x, d, _)) => {
+                        let mut err = Diagnostic::error(self.name.ids[x].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x))));
+                        if let Some(loc) = d {
+                            err.add_note(loc, "previously defined here".to_string());
+                        }
+                        errs.push(err);
                         (Value::error(), errs)
                     }
                 }
@@ -421,11 +429,15 @@ impl AST for VarDefAST {
                 } {
                     Ok(x) => (x.as_var().unwrap().clone(), errs),
                     Err(RedefVariable::NotAModule(x, _)) => {
-                        errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
+                        errs.push(Diagnostic::error(self.name.ids[x].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
                         (Value::error(), errs)
                     },
-                    Err(RedefVariable::AlreadyExists(x, _)) => {
-                        errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
+                    Err(RedefVariable::AlreadyExists(x, d, _)) => {
+                        let mut err = Diagnostic::error(self.name.ids[x].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x))));
+                        if let Some(loc) = d {
+                            err.add_note(loc, "previously defined here".to_string());
+                        }
+                        errs.push(err);
                         (Value::error(), errs)
                     }
                 }
@@ -500,11 +512,15 @@ impl AST for VarDefAST {
             } {
                 Ok(x) => (x.as_var().unwrap().clone(), errs),
                 Err(RedefVariable::NotAModule(x, _)) => {
-                    errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
+                    errs.push(Diagnostic::error(self.name.ids[x].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
                     (Value::error(), errs)
                 },
-                Err(RedefVariable::AlreadyExists(x, _)) => {
-                    errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
+                Err(RedefVariable::AlreadyExists(x, d, _)) => {
+                    let mut err = Diagnostic::error(self.name.ids[x].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x))));
+                    if let Some(loc) = d {
+                        err.add_note(loc, "previously defined here".to_string());
+                    }
+                    errs.push(err);
                     (Value::error(), errs)
                 }
             }
@@ -660,11 +676,15 @@ impl AST for MutDefAST {
                 }, VariableData::new(self.loc.clone())))) {
                     Ok(x) => (x.as_var().unwrap().clone(), errs),
                     Err(RedefVariable::NotAModule(x, _)) => {
-                        errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
+                        errs.push(Diagnostic::error(self.name.ids[x].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
                         (Value::error(), errs)
                     },
-                    Err(RedefVariable::AlreadyExists(x, _)) => {
-                        errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
+                    Err(RedefVariable::AlreadyExists(x, d, _)) => {
+                        let mut err = Diagnostic::error(self.name.ids[x].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x))));
+                        if let Some(loc) = d {
+                            err.add_note(loc, "previously defined here".to_string());
+                        }
+                        errs.push(err);
                         (Value::error(), errs)
                     }
                 }
@@ -729,11 +749,15 @@ impl AST for MutDefAST {
                 } {
                     Ok(x) => (x.as_var().unwrap().clone(), errs),
                     Err(RedefVariable::NotAModule(x, _)) => {
-                        errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
+                        errs.push(Diagnostic::error(self.name.ids[x].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
                         (Value::error(), errs)
                     },
-                    Err(RedefVariable::AlreadyExists(x, _)) => {
-                        errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
+                    Err(RedefVariable::AlreadyExists(x, d, _)) => {
+                        let mut err = Diagnostic::error(self.name.ids[x].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x))));
+                        if let Some(loc) = d {
+                            err.add_note(loc, "previously defined here".to_string());
+                        }
+                        errs.push(err);
                         (Value::error(), errs)
                     }
                 }
@@ -947,11 +971,15 @@ impl AST for MutDefAST {
                 } {
                     Ok(x) => (x.as_var().unwrap().clone(), errs),
                     Err(RedefVariable::NotAModule(x, _)) => {
-                        errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
+                        errs.push(Diagnostic::error(self.name.ids[x].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
                         (Value::error(), errs)
                     },
-                    Err(RedefVariable::AlreadyExists(x, _)) => {
-                        errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
+                    Err(RedefVariable::AlreadyExists(x, d, _)) => {
+                        let mut err = Diagnostic::error(self.name.ids[x].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x))));
+                        if let Some(loc) = d {
+                            err.add_note(loc, "previously defined here".to_string());
+                        }
+                        errs.push(err);
                         (Value::error(), errs)
                     }
                 }
@@ -1025,11 +1053,15 @@ impl AST for MutDefAST {
             } {
                 Ok(x) => (x.as_var().unwrap().clone(), errs),
                 Err(RedefVariable::NotAModule(x, _)) => {
-                    errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
+                    errs.push(Diagnostic::error(self.name.ids[x].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
                     (Value::error(), errs)
                 },
-                Err(RedefVariable::AlreadyExists(x, _)) => {
-                    errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
+                Err(RedefVariable::AlreadyExists(x, d, _)) => {
+                    let mut err = Diagnostic::error(self.name.ids[x].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x))));
+                    if let Some(loc) = d {
+                        err.add_note(loc, "previously defined here".to_string());
+                    }
+                    errs.push(err);
                     (Value::error(), errs)
                 }
             }
@@ -1110,11 +1142,15 @@ impl AST for ConstDefAST {
         match ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(val, VariableData::new(self.loc.clone())))) {
             Ok(x) => (x.as_var().unwrap().clone(), errs),
             Err(RedefVariable::NotAModule(x, _)) => {
-                errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
+                errs.push(Diagnostic::error(self.name.ids[x].1.clone(), 321, Some(format!("{} is not a module", self.name.start(x)))));
                 (Value::error(), errs)
             },
-            Err(RedefVariable::AlreadyExists(x, _)) => {
-                errs.push(Diagnostic::error(self.name.ids[x - 1].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x)))));
+            Err(RedefVariable::AlreadyExists(x, d, _)) => {
+                let mut err = Diagnostic::error(self.name.ids[x].1.clone(), 323, Some(format!("{} has already been defined", self.name.start(x))));
+                if let Some(loc) = d {
+                    err.add_note(loc, "previously defined here".to_string());
+                }
+                errs.push(err);
                 (Value::error(), errs)
             }
         }

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -116,7 +116,7 @@ pub fn sub_type(val: Type, idx: Type) -> Type {
         }
     }
 }
-pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> Option<Variable<'ctx>> {
+pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> Option<Value<'ctx>> {
     match (lhs.data_type, rhs.data_type) {
         (Type::Borrow(l), r) => {
             lhs.data_type = *l;
@@ -499,7 +499,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
             bin_op(lhs, rhs, op, ctx)
         },
         (Type::Int(ls, lu), Type::Int(rs, ru)) if ls == rs => match op {
-            "+" => Some(Variable {
+            "+" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_add(l, r, ""))),
                     _ => None
@@ -511,7 +511,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(max(ls, rs), lu && ru),
                 export: true
             }),
-            "-" => Some(Variable {
+            "-" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_sub(l, r, ""))),
                     _ => None
@@ -523,7 +523,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(max(ls, rs), lu && ru),
                 export: true
             }),
-            "*" => Some(Variable {
+            "*" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_mul(l, r, ""))),
                     _ => None
@@ -535,7 +535,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(max(ls, rs), lu && ru),
                 export: true
             }),
-            "/" => Some(Variable {
+            "/" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(if ru {ctx.builder.build_int_unsigned_div(l, r, "")} else {ctx.builder.build_int_signed_div(l, r, "")})),
                     _ => None
@@ -547,7 +547,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(max(ls, rs), ru),
                 export: true
             }),
-            "%" => Some(Variable {
+            "%" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(if ru {ctx.builder.build_int_unsigned_rem(l, r, "")} else {ctx.builder.build_int_signed_rem(l, r, "")})),
                     _ => None
@@ -559,7 +559,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(max(ls, rs), ru),
                 export: true
             }),
-            "&" => Some(Variable {
+            "&" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_and(l, r, ""))),
                     _ => None
@@ -571,7 +571,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(min(ls, rs), lu || ru),
                 export: true
             }),
-            "|" => Some(Variable {
+            "|" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_or(l, r, ""))),
                     _ => None
@@ -583,7 +583,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(max(ls, rs), lu || ru),
                 export: true
             }),
-            "^" => Some(Variable {
+            "^" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_xor(l, r, ""))),
                     _ => None
@@ -595,7 +595,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(max(ls, rs), lu || ru),
                 export: true
             }),
-            ">>" => Some(Variable {
+            ">>" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_left_shift(l, r, ""))),
                     _ => None
@@ -607,7 +607,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(max(ls, rs), lu || ru),
                 export: true
             }),
-            "<<" => Some(Variable {
+            "<<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_right_shift(l, r, false, ""))),
                     _ => None
@@ -619,7 +619,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(max(ls, rs), lu || ru),
                 export: true
             }),
-            "<" => Some(Variable {
+            "<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {ULT} else {SLT}, l, r, ""))),
                     _ => None
@@ -631,7 +631,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            ">" => Some(Variable {
+            ">" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {UGT} else {SGT}, l, r, ""))),
                     _ => None
@@ -643,7 +643,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            "<=" => Some(Variable {
+            "<=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {ULE} else {SLE}, l, r, ""))),
                     _ => None
@@ -655,7 +655,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            ">=" => Some(Variable {
+            ">=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {UGE} else {SGE}, l, r, ""))),
                     _ => None
@@ -667,7 +667,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            "==" => Some(Variable {
+            "==" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(EQ, l, r, ""))),
                     _ => None
@@ -679,7 +679,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            "!=" => Some(Variable {
+            "!=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(NE, l, r, ""))),
                     _ => None
@@ -694,14 +694,14 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
             "^^" => None, // TODO: implement exponents
             _ => None
         },
-        (x @ Type::Int(..), Type::IntLiteral) => bin_op(Variable {data_type: x.clone(), ..lhs}, impl_convert(Variable {data_type: Type::IntLiteral, ..rhs}, x, ctx)?, op, ctx),
+        (x @ Type::Int(..), Type::IntLiteral) => bin_op(Value {data_type: x.clone(), ..lhs}, impl_convert(Value {data_type: Type::IntLiteral, ..rhs}, x, ctx)?, op, ctx),
         (Type::IntLiteral, x @ Type::Int(..)) => {
             let t = x.clone();
             lhs.data_type = Type::IntLiteral;
-            bin_op(impl_convert(lhs, x, ctx)?, Variable {data_type: t, ..rhs}, op, ctx)
+            bin_op(impl_convert(lhs, x, ctx)?, Value {data_type: t, ..rhs}, op, ctx)
         },
         (Type::IntLiteral, Type::IntLiteral) => match op {
-            "+" => Some(Variable {
+            "+" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_add(l, r, ""))),
                     _ => None
@@ -713,7 +713,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::IntLiteral,
                 export: true
             }),
-            "-" => Some(Variable {
+            "-" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_sub(l, r, ""))),
                     _ => None
@@ -725,7 +725,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::IntLiteral,
                 export: true
             }),
-            "*" => Some(Variable {
+            "*" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_mul(l, r, ""))),
                     _ => None
@@ -737,7 +737,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::IntLiteral,
                 export: true
             }),
-            "/" => Some(Variable {
+            "/" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_signed_div(l, r, ""))),
                     _ => None
@@ -749,7 +749,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::IntLiteral,
                 export: true
             }),
-            "%" => Some(Variable {
+            "%" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_signed_rem(l, r, ""))),
                     _ => None
@@ -761,7 +761,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::IntLiteral,
                 export: true
             }),
-            "&" => Some(Variable {
+            "&" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_and(l, r, ""))),
                     _ => None
@@ -773,7 +773,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::IntLiteral,
                 export: true
             }),
-            "|" => Some(Variable {
+            "|" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_or(l, r, ""))),
                     _ => None
@@ -785,7 +785,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::IntLiteral,
                 export: true
             }),
-            "^" => Some(Variable {
+            "^" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_xor(l, r, ""))),
                     _ => None
@@ -797,7 +797,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::IntLiteral,
                 export: true
             }),
-            ">>" => Some(Variable {
+            ">>" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_left_shift(l, r, ""))),
                     _ => None
@@ -809,7 +809,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::IntLiteral,
                 export: true
             }),
-            "<<" => Some(Variable {
+            "<<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_right_shift(l, r, false, ""))),
                     _ => None
@@ -822,7 +822,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 export: true
             }),
             "^^" => None, // TODO: implement exponents
-            "<" => Some(Variable {
+            "<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(SLT, l, r, ""))),
                     _ => None
@@ -834,7 +834,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            ">" => Some(Variable {
+            ">" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(SGT, l, r, ""))),
                     _ => None
@@ -846,7 +846,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            "<=" => Some(Variable {
+            "<=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(SLE, l, r, ""))),
                     _ => None
@@ -858,7 +858,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            ">=" => Some(Variable {
+            ">=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(SGE, l, r, ""))),
                     _ => None
@@ -870,7 +870,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            "==" => Some(Variable {
+            "==" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(EQ, l, r, ""))),
                     _ => None
@@ -882,7 +882,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            "!=" => Some(Variable {
+            "!=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(NE, l, r, ""))),
                     _ => None
@@ -897,7 +897,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
             _ => None
         },
         (Type::Pointer(b, s), Type::Int(..) | Type::IntLiteral) => match op {
-            "+" => Some(Variable {
+            "+" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, b.size(), ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) => Some(unsafe {ctx.builder.build_gep(l, &[r], "").into()}),
                     _ => None
@@ -906,7 +906,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Pointer(b, s),
                 export: true
             }),
-            "-" => Some(Variable {
+            "-" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, b.size(), ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) => Some(unsafe {
                         let v = ctx.builder.build_int_neg(r, "");
@@ -921,7 +921,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
             _ => None
         },
         (Type::Int(..) | Type::IntLiteral, Type::Pointer(b, s)) => match op {
-            "+" => Some(Variable {
+            "+" => Some(Value {
                 comp_val: match (rhs.comp_val, lhs.comp_val, b.size(), ctx.is_const.get()) { // I just swapped the sides here
                     (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) => Some(unsafe {ctx.builder.build_gep(l, &[r], "").into()}),
                     _ => None
@@ -933,7 +933,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
             _ => None
         },
         (l @ Type::Pointer(..), r @ Type::Pointer(..)) => match op {
-            "-" if l == r => Some(Variable {
+            "-" if l == r => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
                         let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32);
@@ -947,7 +947,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(64, false),
                 export: true
             }),
-            "<" => Some(Variable {
+            "<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
                         let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32);
@@ -961,7 +961,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            ">" => Some(Variable {
+            ">" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
                         let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32);
@@ -975,7 +975,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            "<=" => Some(Variable {
+            "<=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
                         let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32);
@@ -989,7 +989,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            ">=" => Some(Variable {
+            ">=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
                         let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32);
@@ -1003,7 +1003,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            "==" => Some(Variable {
+            "==" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
                         let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32);
@@ -1017,7 +1017,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            "!=" => Some(Variable {
+            "!=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
                         let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32);
@@ -1052,7 +1052,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
             bin_op(lhs, rhs, op, ctx)
         },
         (l @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128), r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128)) if l == r => match op {
-            "+" => Some(Variable {
+            "+" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(FloatValue(ctx.builder.build_float_add(l, r, ""))),
                     _ => None
@@ -1064,7 +1064,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: l,
                 export: true
             }),
-            "-" => Some(Variable {
+            "-" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(FloatValue(ctx.builder.build_float_sub(l, r, ""))),
                     _ => None
@@ -1076,7 +1076,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: l,
                 export: true
             }),
-            "*" => Some(Variable {
+            "*" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(FloatValue(ctx.builder.build_float_mul(l, r, ""))),
                     _ => None
@@ -1088,7 +1088,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: l,
                 export: true
             }),
-            "/" => Some(Variable {
+            "/" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(FloatValue(ctx.builder.build_float_div(l, r, ""))),
                     _ => None
@@ -1100,7 +1100,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: l,
                 export: true
             }),
-            "%" => Some(Variable {
+            "%" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(_l)), Some(FloatValue(_r)), false) => None, // TODO: implement fmod
                     _ => None
@@ -1112,7 +1112,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: l,
                 export: true
             }),
-            "^^" => Some(Variable {
+            "^^" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(_l)), Some(FloatValue(_r)), false) => None, // TODO: implement powf
                     _ => None
@@ -1124,7 +1124,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: bin_type(l, r, op),
                 export: true
             }),
-            "<" => Some(Variable {
+            "<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OLT, l, r, ""))),
                     _ => None
@@ -1136,7 +1136,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            ">" => Some(Variable {
+            ">" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OGT, l, r, ""))),
                     _ => None
@@ -1148,7 +1148,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            "<=" => Some(Variable {
+            "<=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OLE, l, r, ""))),
                     _ => None
@@ -1160,7 +1160,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            ">=" => Some(Variable {
+            ">=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OGE, l, r, ""))),
                     _ => None
@@ -1172,7 +1172,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            "==" => Some(Variable {
+            "==" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OEQ, l, r, ""))),
                     _ => None
@@ -1184,7 +1184,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
                 data_type: Type::Int(1, false),
                 export: true
             }),
-            "!=" => Some(Variable {
+            "!=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(ONE, l, r, ""))),
                     _ => None
@@ -1223,7 +1223,7 @@ pub fn bin_op<'ctx>(mut lhs: Variable<'ctx>, mut rhs: Variable<'ctx>, op: &str, 
         _ => None
     }
 }
-pub fn pre_op<'ctx>(mut val: Variable<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> Option<Variable<'ctx>> {
+pub fn pre_op<'ctx>(mut val: Value<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> Option<Value<'ctx>> {
     match val.data_type {
         Type::Borrow(x) => {
             val.data_type = *x;
@@ -1366,13 +1366,13 @@ pub fn pre_op<'ctx>(mut val: Variable<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> O
                 val.data_type = Type::IntLiteral;
                 Some(val)
             },
-            "-" => Some(Variable {
+            "-" => Some(Value {
                 comp_val: if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(IntValue(ctx.builder.build_int_neg(v, "")))} else {None},
                 inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(-v))} else {None},
                 data_type: Type::IntLiteral,
                 export: true
             }),
-            "~" => Some(Variable {
+            "~" => Some(Value {
                 comp_val: if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(IntValue(ctx.builder.build_xor(v, ctx.context.i64_type().const_all_ones(), "")))} else {None},
                 inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(!v))} else {None},
                 data_type: Type::IntLiteral,
@@ -1385,13 +1385,13 @@ pub fn pre_op<'ctx>(mut val: Variable<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> O
                 val.data_type = Type::Int(s, u);
                 Some(val)
             },
-            "-" => Some(Variable {
+            "-" => Some(Value {
                 comp_val: if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(IntValue(ctx.builder.build_int_neg(v, "")))} else {None},
                 inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(-v))} else {None},
                 data_type: Type::Int(s, u),
                 export: true
             }),
-            "~" => Some(Variable {
+            "~" => Some(Value {
                 comp_val: if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(IntValue(ctx.builder.build_xor(v, ctx.context.custom_width_int_type(s as u32).const_all_ones(), "")))} else {None},
                 inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(!v))} else {None},
                 data_type: Type::Int(s, u),
@@ -1404,7 +1404,7 @@ pub fn pre_op<'ctx>(mut val: Variable<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> O
                 val.data_type = x;
                 Some(val)
             },
-            "-" => Some(Variable {
+            "-" => Some(Value {
                 comp_val: if let (Some(FloatValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(FloatValue(ctx.builder.build_float_neg(v, "")))} else {None},
                 inter_val: if let Some(InterData::Float(v)) = val.inter_val {Some(InterData::Float(-v))} else {None},
                 data_type: x,
@@ -1422,12 +1422,12 @@ pub fn pre_op<'ctx>(mut val: Variable<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> O
         _ => None
     }
 }
-pub fn post_op<'ctx>(val: Variable<'ctx>, _op: &str, _ctx: &CompCtx<'ctx>) -> Option<Variable<'ctx>> {
+pub fn post_op<'ctx>(val: Value<'ctx>, _op: &str, _ctx: &CompCtx<'ctx>) -> Option<Value<'ctx>> {
     match val.data_type { // The only posfix operators are ? and !, and they're for error handling
         _ => None
     }
 }
-pub fn subscript<'ctx>(mut val: Variable<'ctx>, mut idx: Variable<'ctx>, ctx: &CompCtx<'ctx>) -> Option<Variable<'ctx>> {
+pub fn subscript<'ctx>(mut val: Value<'ctx>, mut idx: Value<'ctx>, ctx: &CompCtx<'ctx>) -> Option<Value<'ctx>> {
     match idx.data_type {
         Type::Borrow(x) => {
             idx.data_type = *x;
@@ -1446,7 +1446,7 @@ pub fn subscript<'ctx>(mut val: Variable<'ctx>, mut idx: Variable<'ctx>, ctx: &C
             idx.data_type = a;
             match val.data_type.clone() {
                 Type::Pointer(b, m) => match idx.data_type.clone() {
-                    Type::IntLiteral | Type::Int(..) => Some(Variable {
+                    Type::IntLiteral | Type::Int(..) => Some(Value {
                         comp_val: match (val.comp_val, idx.value(ctx), b.size(), ctx.is_const.get()) {
                             (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) => Some(unsafe {ctx.builder.build_gep(l, &[r], "").into()}),
                             _ => None
@@ -1459,7 +1459,7 @@ pub fn subscript<'ctx>(mut val: Variable<'ctx>, mut idx: Variable<'ctx>, ctx: &C
                 },
                 Type::Reference(b, m) => match *b {
                     Type::Array(b, None) => match idx.data_type.clone() {
-                        Type::IntLiteral | Type::Int(_, true) => Some(Variable {
+                        Type::IntLiteral | Type::Int(_, true) => Some(Value {
                             comp_val: if let (Some(StructValue(sv)), Some(IntValue(iv)), SizeType::Static(_), false) = (val.value(ctx), idx.value(ctx), b.size(), ctx.is_const.get()) {
                                 let raw = ctx.builder.build_extract_value(sv, 0, "").unwrap().into_pointer_value();
                                 if ctx.flags.bounds_checks {
@@ -1494,7 +1494,7 @@ pub fn subscript<'ctx>(mut val: Variable<'ctx>, mut idx: Variable<'ctx>, ctx: &C
                             data_type: Type::Reference(b, m),
                             export: true
                         }),
-                        Type::Int(_, false) => Some(Variable {
+                        Type::Int(_, false) => Some(Value {
                             comp_val: if let (Some(StructValue(sv)), Some(IntValue(iv)), SizeType::Static(_), false) = (val.value(ctx), idx.value(ctx), b.size(), ctx.is_const.get()) {
                                 let raw = ctx.builder.build_extract_value(sv, 0, "").unwrap().into_pointer_value();
                                 if ctx.flags.bounds_checks {
@@ -1532,7 +1532,7 @@ pub fn subscript<'ctx>(mut val: Variable<'ctx>, mut idx: Variable<'ctx>, ctx: &C
                         _ => None
                     },
                     Type::Array(b, Some(s)) => match idx.data_type.clone() {
-                        Type::IntLiteral | Type::Int(_, true) => Some(Variable {
+                        Type::IntLiteral | Type::Int(_, true) => Some(Value {
                             comp_val: if let (Some(PointerValue(raw)), Some(IntValue(iv)), SizeType::Static(_), false) = (val.value(ctx), idx.value(ctx), b.size(), ctx.is_const.get()) {
                                 if ctx.flags.bounds_checks {
                                     let len = idx.data_type.llvm_type(ctx).unwrap().into_int_type().const_int(s as u64, false);
@@ -1566,7 +1566,7 @@ pub fn subscript<'ctx>(mut val: Variable<'ctx>, mut idx: Variable<'ctx>, ctx: &C
                             data_type: Type::Reference(b, m),
                             export: true
                         }),
-                        Type::Int(_, false) => Some(Variable {
+                        Type::Int(_, false) => Some(Value {
                             comp_val: if let (Some(PointerValue(raw)), Some(IntValue(iv)), SizeType::Static(_), false) = (val.value(ctx), idx.value(ctx), b.size(), ctx.is_const.get()) {
                                 if ctx.flags.bounds_checks {
                                     let len = idx.data_type.llvm_type(ctx).unwrap().into_int_type().const_int(s as u64, false);
@@ -1617,10 +1617,10 @@ pub fn subscript<'ctx>(mut val: Variable<'ctx>, mut idx: Variable<'ctx>, ctx: &C
         }
     }
 }
-pub fn impl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'ctx>) -> Option<Variable<'ctx>> {
+pub fn impl_convert<'ctx>(mut val: Value<'ctx>, target: Type, ctx: &CompCtx<'ctx>) -> Option<Value<'ctx>> {
     if val.data_type == target {Some(val)}
-    else if target == Type::Null {Some(Variable::null())}
-    else if target == Type::Error {Some(Variable::error())}
+    else if target == Type::Null {Some(Value::null())}
+    else if target == Type::Error {Some(Value::error())}
     else {
         match val.data_type {
             Type::Borrow(b) => {
@@ -1628,10 +1628,10 @@ pub fn impl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 impl_convert(val, target, ctx)
             },
             Type::Reference(b, true) => {
-                if &target == &Type::Reference(b.clone(), false) {return Some(Variable {data_type: Type::Reference(b, false), ..val});}
+                if &target == &Type::Reference(b.clone(), false) {return Some(Value {data_type: Type::Reference(b, false), ..val});}
                 match *b {
                     Type::Array(b, Some(_)) => match target {
-                        Type::Pointer(b2, m) if b == b2 => Some(Variable {data_type: Type::Pointer(b, m), ..val}),
+                        Type::Pointer(b2, m) if b == b2 => Some(Value {data_type: Type::Pointer(b, m), ..val}),
                         _ => None
                     },
                     Type::Array(b, None) => match target {
@@ -1640,7 +1640,7 @@ pub fn impl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                             if let Some(StructValue(sv)) = val.value(ctx) {
                                 val.comp_val = ctx.builder.build_extract_value(sv, 0, "");
                             }
-                            Some(Variable {data_type: Type::Pointer(b, m), ..val})
+                            Some(Value {data_type: Type::Pointer(b, m), ..val})
                         },
                         _ => None
                     },
@@ -1657,7 +1657,7 @@ pub fn impl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
             },
             Type::Reference(b, false) => match *b {
                 Type::Array(b, Some(_)) => match target {
-                    Type::Pointer(b2, false) if b == b2 => Some(Variable {data_type: Type::Pointer(b, false), ..val}),
+                    Type::Pointer(b2, false) if b == b2 => Some(Value {data_type: Type::Pointer(b, false), ..val}),
                     _ => None
                 },
                 Type::Array(b, None) => match target {
@@ -1666,7 +1666,7 @@ pub fn impl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                         if let Some(StructValue(sv)) = val.value(ctx) {
                             val.comp_val = ctx.builder.build_extract_value(sv, 0, "");
                         }
-                        Some(Variable {data_type: Type::Pointer(b, false), ..val})
+                        Some(Value {data_type: Type::Pointer(b, false), ..val})
                     },
                     _ => None
                 },
@@ -1681,14 +1681,14 @@ pub fn impl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 }
             },
             Type::IntLiteral => match target {
-                x @ Type::Int(..) => Some(Variable {
+                x @ Type::Int(..) => Some(Value {
                     comp_val: if let Some(InterData::Int(v)) = val.inter_val {Some(IntValue(x.llvm_type(ctx).unwrap().into_int_type().const_int(v as u64, true)))}
                               else if let Some(IntValue(v)) = val.comp_val {Some(IntValue(ctx.builder.build_int_z_extend(v, x.llvm_type(ctx).unwrap().into_int_type(), "")))}
                               else {None},
                     data_type: x,
                     ..val
                 }),
-                x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Variable {
+                x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Value {
                     comp_val: if let Some(InterData::Int(v)) = val.inter_val {Some(FloatValue(x.llvm_type(ctx).unwrap().into_float_type().const_float(v as f64)))}
                               else if let Some(IntValue(v)) = val.comp_val {Some(FloatValue(ctx.builder.build_signed_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "")))}
                               else {None},
@@ -1699,25 +1699,25 @@ pub fn impl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 _ => None
             },
             Type::Int(ls, true) => match target {
-                Type::Int(1, false) => Some(Variable {
+                Type::Int(1, false) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_compare(NE, v, ctx.context.custom_width_int_type(ls as u32).const_zero(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
                     data_type: Type::Int(1, false),
                     export: true
                 }),
-                Type::Int(rs, true) if ls < rs => Some(Variable {
+                Type::Int(rs, true) if ls < rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_z_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
                     data_type: Type::Int(rs, true),
                     export: true
                 }),
-                Type::Int(rs, false) if ls < rs => Some(Variable {
+                Type::Int(rs, false) if ls < rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
                     data_type: Type::Int(rs, false),
                     export: true
                 }),
-                x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Variable {
+                x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_unsigned_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
                     data_type: x,
@@ -1726,19 +1726,19 @@ pub fn impl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 _ => None
             },
             Type::Int(ls, false) => match target {
-                Type::Int(1, false) => Some(Variable {
+                Type::Int(1, false) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_compare(NE, v, ctx.context.custom_width_int_type(ls as u32).const_zero(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
                     data_type: Type::Int(1, false),
                     export: true
                 }),
-                Type::Int(rs, ru) if ls < rs => Some(Variable {
+                Type::Int(rs, ru) if ls < rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
                     data_type: Type::Int(rs, ru),
                     export: true
                 }),
-                x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Variable {
+                x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_signed_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
                     data_type: x,
@@ -1747,7 +1747,7 @@ pub fn impl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 _ => None
             },
             Type::Pointer(_, false) => match target {
-                Type::Pointer(rb, false) if *rb == Type::Null => Some(Variable {
+                Type::Pointer(rb, false) if *rb == Type::Null => Some(Value {
                     comp_val: val.value(ctx).map(|v| ctx.builder.build_bitcast(v, ctx.null_type.ptr_type(inkwell::AddressSpace::from(0u16)), "")),
                     inter_val: None,
                     data_type: Type::Pointer(Box::new(Type::Null), false),
@@ -1757,26 +1757,26 @@ pub fn impl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
             },
             Type::Pointer(ref lb, true) => match target {
                 Type::Pointer(rb, false) => match *rb {
-                    Type::Null => Some(Variable {
+                    Type::Null => Some(Value {
                         comp_val: val.value(ctx).map(|v| ctx.builder.build_bitcast(v, ctx.null_type.ptr_type(inkwell::AddressSpace::from(0u16)), "")),
                         inter_val: None,
                         data_type: Type::Pointer(Box::new(Type::Null), false),
                         export: true
                     }),
-                    x if x == **lb => Some(Variable {data_type: Type::Pointer(Box::new(x), false), ..val}),
+                    x if x == **lb => Some(Value {data_type: Type::Pointer(Box::new(x), false), ..val}),
                     _ => None
                 },
                 _ => None
             },
-            Type::Error => Some(Variable {comp_val: None, inter_val: None, data_type: Type::Error, export: true}),
+            Type::Error => Some(Value {comp_val: None, inter_val: None, data_type: Type::Error, export: true}),
             _ => None
         }
     }
 }
-pub fn expl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'ctx>) -> Option<Variable<'ctx>> {
+pub fn expl_convert<'ctx>(mut val: Value<'ctx>, target: Type, ctx: &CompCtx<'ctx>) -> Option<Value<'ctx>> {
     if val.data_type == target {return Some(val)}
-    else if target == Type::Null {Some(Variable::null())}
-    else if target == Type::Error {Some(Variable::error())}
+    else if target == Type::Null {Some(Value::null())}
+    else if target == Type::Error {Some(Value::error())}
     else {
         match val.data_type {
             Type::Borrow(b) => {
@@ -1784,10 +1784,10 @@ pub fn expl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 impl_convert(val, target, ctx)
             },
             Type::Reference(b, true) => {
-                if &target == &Type::Reference(b.clone(), false) {return Some(Variable {data_type: Type::Reference(b, false), ..val});}
+                if &target == &Type::Reference(b.clone(), false) {return Some(Value {data_type: Type::Reference(b, false), ..val});}
                 match *b {
                     Type::Array(b, Some(_)) => match target {
-                        Type::Pointer(b2, m) if b == b2 => Some(Variable {data_type: Type::Pointer(b, m), ..val}),
+                        Type::Pointer(b2, m) if b == b2 => Some(Value {data_type: Type::Pointer(b, m), ..val}),
                         _ => None
                     },
                     Type::Array(b, None) => match target {
@@ -1796,7 +1796,7 @@ pub fn expl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                             if let Some(StructValue(sv)) = val.value(ctx) {
                                 val.comp_val = ctx.builder.build_extract_value(sv, 0, "");
                             }
-                            Some(Variable {data_type: Type::Pointer(b, m), ..val})
+                            Some(Value {data_type: Type::Pointer(b, m), ..val})
                         },
                         _ => None
                     },
@@ -1813,7 +1813,7 @@ pub fn expl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
             },
             Type::Reference(b, false) => match *b {
                 Type::Array(b, Some(_)) => match target {
-                    Type::Pointer(b2, false) if b == b2 => Some(Variable {data_type: Type::Pointer(b, false), ..val}),
+                    Type::Pointer(b2, false) if b == b2 => Some(Value {data_type: Type::Pointer(b, false), ..val}),
                     _ => None
                 },
                 Type::Array(b, None) => match target {
@@ -1822,7 +1822,7 @@ pub fn expl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                         if let Some(StructValue(sv)) = val.value(ctx) {
                             val.comp_val = ctx.builder.build_extract_value(sv, 0, "");
                         }
-                        Some(Variable {data_type: Type::Pointer(b, false), ..val})
+                        Some(Value {data_type: Type::Pointer(b, false), ..val})
                     },
                     _ => None
                 },
@@ -1837,14 +1837,14 @@ pub fn expl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 }
             },
             Type::IntLiteral => match target {
-                x @ Type::Int(..) => Some(Variable {
+                x @ Type::Int(..) => Some(Value {
                     comp_val: if let Some(InterData::Int(v)) = val.inter_val {Some(IntValue(x.llvm_type(ctx).unwrap().into_int_type().const_int(v as u64, true)))}
                               else if let Some(IntValue(v)) = val.comp_val {Some(IntValue(ctx.builder.build_int_z_extend(v, x.llvm_type(ctx).unwrap().into_int_type(), "")))}
                               else {None},
                     data_type: x,
                     ..val
                 }),
-                x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Variable {
+                x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Value {
                     comp_val: if let Some(InterData::Int(v)) = val.inter_val {Some(FloatValue(x.llvm_type(ctx).unwrap().into_float_type().const_float(v as f64)))}
                               else if let Some(IntValue(v)) = val.comp_val {Some(FloatValue(ctx.builder.build_signed_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "")))}
                               else {None},
@@ -1855,38 +1855,38 @@ pub fn expl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 _ => None
             },
             Type::Int(ls, true) => match target {
-                Type::Int(rs, ru) if ls == rs => Some(Variable {data_type: Type::Int(rs, ru), ..val}),
-                Type::Int(1, false) => Some(Variable {
+                Type::Int(rs, ru) if ls == rs => Some(Value {data_type: Type::Int(rs, ru), ..val}),
+                Type::Int(1, false) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_compare(NE, v, ctx.context.custom_width_int_type(ls as u32).const_zero(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
                     data_type: Type::Int(1, false),
                     export: true
                 }),
-                Type::Int(rs, true) if ls < rs => Some(Variable {
+                Type::Int(rs, true) if ls < rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_z_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
                     data_type: Type::Int(rs, true),
                     export: true
                 }),
-                Type::Int(rs, false) if ls < rs => Some(Variable {
+                Type::Int(rs, false) if ls < rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
                     data_type: Type::Int(rs, false),
                     export: true
                 }),
-                Type::Int(rs, ru) if ls > rs => Some(Variable {
+                Type::Int(rs, ru) if ls > rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_truncate(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
                     data_type: Type::Int(rs, ru),
                     export: true
                 }),
-                x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Variable {
+                x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_unsigned_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
                     data_type: x,
                     export: true
                 }),
-                Type::Pointer(b, m) => Some(Variable {
+                Type::Pointer(b, m) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_to_ptr(v, Type::Pointer(b.clone(), m).llvm_type(ctx).unwrap().into_pointer_type(), "").into())} else {None},
                     inter_val: None,
                     data_type: Type::Pointer(b, m),
@@ -1895,32 +1895,32 @@ pub fn expl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 _ => None
             },
             Type::Int(ls, false) => match target {
-                Type::Int(rs, ru) if ls == rs => Some(Variable {data_type: Type::Int(rs, ru), ..val}),
-                Type::Int(1, false) => Some(Variable {
+                Type::Int(rs, ru) if ls == rs => Some(Value {data_type: Type::Int(rs, ru), ..val}),
+                Type::Int(1, false) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_compare(NE, v, ctx.context.custom_width_int_type(ls as u32).const_zero(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
                     data_type: Type::Int(1, false),
                     export: true
                 }),
-                Type::Int(rs, ru) if ls < rs => Some(Variable {
+                Type::Int(rs, ru) if ls < rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
                     data_type: Type::Int(rs, ru),
                     export: true
                 }),
-                Type::Int(rs, ru) if ls > rs => Some(Variable {
+                Type::Int(rs, ru) if ls > rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_truncate(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
                     data_type: Type::Int(rs, ru),
                     export: true
                 }),
-                x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Variable {
+                x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_signed_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
                     data_type: x,
                     export: true
                 }),
-                Type::Pointer(b, m) => Some(Variable {
+                Type::Pointer(b, m) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_to_ptr(v, Type::Pointer(b.clone(), m).llvm_type(ctx).unwrap().into_pointer_type(), "").into())} else {None},
                     inter_val: None,
                     data_type: Type::Pointer(b, m),
@@ -1929,25 +1929,25 @@ pub fn expl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 _ => None
             },
             ref x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => match target {
-                Type::Int(1, false) => Some(Variable {
+                Type::Int(1, false) => Some(Value {
                     comp_val: if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_float_compare(ONE, v, x.llvm_type(ctx).unwrap().into_float_type().const_zero(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
                     data_type: Type::Int(1, false),
                     export: true
                 }),
-                Type::Int(s, false) => Some(Variable {
+                Type::Int(s, false) => Some(Value {
                     comp_val: if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_float_to_signed_int(v, ctx.context.custom_width_int_type(s as u32), "").into())} else {None},
                     inter_val: if let Some(InterData::Float(v)) = val.inter_val {Some(InterData::Int(v as i128))} else {None},
                     data_type: Type::Int(s, false),
                     export: true
                 }),
-                Type::Int(s, true) => Some(Variable {
+                Type::Int(s, true) => Some(Value {
                     comp_val: if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_float_to_unsigned_int(v, ctx.context.custom_width_int_type(s as u32), "").into())} else {None},
                     inter_val: if let Some(InterData::Float(v)) = val.inter_val {Some(InterData::Int(v as i128))} else {None},
                     data_type: Type::Int(s, false),
                     export: true
                 }),
-                r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Variable {
+                r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Value {
                     comp_val: if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_float_cast(v, r.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
                     data_type: x.clone(),
                     ..val
@@ -1955,13 +1955,13 @@ pub fn expl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 _ => None
             },
             Type::Pointer(ref lb, false) => match target {
-                Type::Pointer(rb, false) if *rb == Type::Null => Some(Variable {
+                Type::Pointer(rb, false) if *rb == Type::Null => Some(Value {
                     comp_val: val.value(ctx).map(|v| ctx.builder.build_bitcast(v, ctx.null_type.ptr_type(inkwell::AddressSpace::from(0u16)), "")),
                     inter_val: None,
                     data_type: Type::Pointer(Box::new(Type::Null), false),
                     export: true
                 }),
-                Type::Pointer(rb, false) if **lb == Type::Null => Some(Variable {
+                Type::Pointer(rb, false) if **lb == Type::Null => Some(Value {
                     comp_val: val.value(ctx).and_then(|v| Some(ctx.builder.build_bitcast(v, rb.llvm_type(ctx)?.ptr_type(inkwell::AddressSpace::from(0u16)), ""))),
                     inter_val: None,
                     data_type: Type::Pointer(rb, false),
@@ -1970,28 +1970,28 @@ pub fn expl_convert<'ctx>(mut val: Variable<'ctx>, target: Type, ctx: &CompCtx<'
                 _ => None
             },
             Type::Pointer(ref lb, true) => match target {
-                Type::Pointer(rb, m) if *rb == Type::Null => Some(Variable {
+                Type::Pointer(rb, m) if *rb == Type::Null => Some(Value {
                     comp_val: val.value(ctx).map(|v| ctx.builder.build_bitcast(v, ctx.null_type.ptr_type(inkwell::AddressSpace::from(0u16)), "")),
                     inter_val: None,
                     data_type: Type::Pointer(Box::new(Type::Null), m),
                     export: true
                 }),
-                Type::Pointer(rb, m) if **lb == Type::Null => Some(Variable {
+                Type::Pointer(rb, m) if **lb == Type::Null => Some(Value {
                     comp_val: val.value(ctx).and_then(|v| Some(ctx.builder.build_bitcast(v, rb.llvm_type(ctx)?.ptr_type(inkwell::AddressSpace::from(0u16)), ""))),
                     inter_val: None,
                     data_type: Type::Pointer(rb, m),
                     export: true
                 }),
-                Type::Pointer(x, false) if x == *lb => Some(Variable {data_type: Type::Pointer(x, false), ..val}),
+                Type::Pointer(x, false) if x == *lb => Some(Value {data_type: Type::Pointer(x, false), ..val}),
                 _ => None
             },
-            Type::Null => Some(Variable {comp_val: target.llvm_type(ctx).map(|t| t.const_zero()), inter_val: None, data_type: target, export: true}),
-            Type::Error => Some(Variable {comp_val: None, inter_val: None, data_type: Type::Error, export: true}),
+            Type::Null => Some(Value {comp_val: target.llvm_type(ctx).map(|t| t.const_zero()), inter_val: None, data_type: target, export: true}),
+            Type::Error => Some(Value {comp_val: None, inter_val: None, data_type: Type::Error, export: true}),
             _ => None
         }
     }
 }
-fn prep_asm<'ctx>(mut arg: Variable<'ctx>, ctx: &CompCtx<'ctx>) -> Option<(BasicMetadataTypeEnum<'ctx>, BasicMetadataValueEnum<'ctx>)> {
+fn prep_asm<'ctx>(mut arg: Value<'ctx>, ctx: &CompCtx<'ctx>) -> Option<(BasicMetadataTypeEnum<'ctx>, BasicMetadataValueEnum<'ctx>)> {
     let i64_ty = ctx.context.i64_type();
     let i32_ty = ctx.context.i32_type();
     let i16_ty = ctx.context.i16_type();
@@ -2025,9 +2025,9 @@ fn prep_asm<'ctx>(mut arg: Variable<'ctx>, ctx: &CompCtx<'ctx>) -> Option<(Basic
         _ => None
     }
 }
-pub fn call<'ctx>(mut target: Variable<'ctx>, loc: Location, cparen: Location, mut args: Vec<(Variable<'ctx>, Location)>, ctx: &CompCtx<'ctx>) -> Result<Variable<'ctx>, Diagnostic> {
+pub fn call<'ctx>(mut target: Value<'ctx>, loc: Location, cparen: Location, mut args: Vec<(Value<'ctx>, Location)>, ctx: &CompCtx<'ctx>) -> Result<Value<'ctx>, Diagnostic> {
     match target.data_type {
-        Type::Error => Ok(Variable::error()),
+        Type::Error => Ok(Value::error()),
         Type::Borrow(b) => {
             target.data_type = *b;
             call(target, loc, cparen, args, ctx)
@@ -2044,7 +2044,7 @@ pub fn call<'ctx>(mut target: Variable<'ctx>, loc: Location, cparen: Location, m
         Type::Function(ret, params) => {
             let mut err = Diagnostic::error(loc.clone(), 313, Some(format!("function type is {}", Type::Function(ret.clone(), params.clone())))).note(loc.clone(), {
                 let mut out = format!("argument types are (");
-                args.iter().for_each(|(Variable {data_type, ..}, _)| out += format!("{data_type}, ").as_str());
+                args.iter().for_each(|(Value {data_type, ..}, _)| out += format!("{data_type}, ").as_str());
                 out.truncate(out.len() - 2);
                 out.push(')');
                 out
@@ -2060,7 +2060,7 @@ pub fn call<'ctx>(mut target: Variable<'ctx>, loc: Location, cparen: Location, m
             }
             let (c, r) = args.into_iter().chain(if let Some(InterData::Function(FnData {defaults, ..})) = target.inter_val {
                 let d = defaults.len();
-                defaults.iter().zip(params.iter().skip(p - d)).skip(a + d - p).map(|(v, (t, c))| (Variable {
+                defaults.iter().zip(params.iter().skip(p - d)).skip(a + d - p).map(|(v, (t, c))| (Value {
                     comp_val: if *c {None} else {v.into_compiled(ctx)},
                     inter_val: Some(v.clone()),
                     data_type: t.clone(),
@@ -2078,15 +2078,15 @@ pub fn call<'ctx>(mut target: Variable<'ctx>, loc: Location, cparen: Location, m
                 else {
                     good = false;
                     err.add_note(l.clone(), e);
-                    Variable::error()
+                    Value::error()
                 }, c)
             }).partition::<Vec<_>, _>(|(_, c)| **c);
             if !good {return Err(err)}
             if c.len() > 0 {return Err(Diagnostic::error(loc.clone(), 900, None))}
             good = true;
             let val: Option<inkwell::values::CallableValue> = if let Some(PointerValue(v)) = target.comp_val {v.try_into().ok()} else {None};
-            let args: Vec<inkwell::values::BasicMetadataValueEnum> = r.into_iter().filter_map(|(Variable {comp_val, ..}, _)| comp_val.map(|v| v.into()).or_else(|| {good = false; None})).collect();
-            Ok(Variable {
+            let args: Vec<inkwell::values::BasicMetadataValueEnum> = r.into_iter().filter_map(|(Value {comp_val, ..}, _)| comp_val.map(|v| v.into()).or_else(|| {good = false; None})).collect();
+            Ok(Value {
                 comp_val: val.and_then(|v| ctx.builder.build_call(v, args.as_slice(), "").try_as_basic_value().left()),
                 inter_val: None,
                 data_type: *ret,
@@ -2115,7 +2115,7 @@ pub fn call<'ctx>(mut target: Variable<'ctx>, loc: Location, cparen: Location, m
                 let fty = llt.fn_type(&params, false);
                 let asm = ctx.context.create_inline_asm(fty, b, c, true, true, None, false);
                 let ret = ctx.builder.build_call(CallableValue::try_from(asm).unwrap(), &comp_args, "");
-                Ok(Variable {
+                Ok(Value {
                     comp_val: ret.try_as_basic_value().left(),
                     inter_val: None,
                     data_type: *r,
@@ -2126,12 +2126,12 @@ pub fn call<'ctx>(mut target: Variable<'ctx>, loc: Location, cparen: Location, m
                 let fty = ctx.context.void_type().fn_type(&params, false);
                 let asm = ctx.context.create_inline_asm(fty, b, c, true, true, None, false);
                 ctx.builder.build_call(CallableValue::try_from(asm).unwrap(), &comp_args, "");
-                Ok(Variable::null())
+                Ok(Value::null())
             }
-        } else {Ok(Variable::error())},
+        } else {Ok(Value::error())},
         t => Err(Diagnostic::error(loc.clone(), 313, Some(format!("target type is {t}"))).info({
             let mut out = format!("argument types are (");
-            args.iter().for_each(|(Variable {data_type, ..}, _)| out += format!("{data_type}, ").as_str());
+            args.iter().for_each(|(Value {data_type, ..}, _)| out += format!("{data_type}, ").as_str());
             out.truncate(out.len() - 2);
             out.push(')');
             out

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -508,9 +508,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l + r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), lu && ru),
-                export: true
-            }),
+                data_type: Type::Int(max(ls, rs), lu && ru)            }),
             "-" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_sub(l, r, ""))),
@@ -520,9 +518,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l - r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), lu && ru),
-                export: true
-            }),
+                data_type: Type::Int(max(ls, rs), lu && ru)            }),
             "*" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_mul(l, r, ""))),
@@ -532,9 +528,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l * r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), lu && ru),
-                export: true
-            }),
+                data_type: Type::Int(max(ls, rs), lu && ru)            }),
             "/" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(if ru {ctx.builder.build_int_unsigned_div(l, r, "")} else {ctx.builder.build_int_signed_div(l, r, "")})),
@@ -544,9 +538,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l / r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), ru),
-                export: true
-            }),
+                data_type: Type::Int(max(ls, rs), ru)            }),
             "%" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(if ru {ctx.builder.build_int_unsigned_rem(l, r, "")} else {ctx.builder.build_int_signed_rem(l, r, "")})),
@@ -556,9 +548,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l % r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), ru),
-                export: true
-            }),
+                data_type: Type::Int(max(ls, rs), ru)            }),
             "&" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_and(l, r, ""))),
@@ -568,9 +558,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l & r)),
                     _ => None
                 },
-                data_type: Type::Int(min(ls, rs), lu || ru),
-                export: true
-            }),
+                data_type: Type::Int(min(ls, rs), lu || ru)            }),
             "|" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_or(l, r, ""))),
@@ -580,9 +568,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l | r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), lu || ru),
-                export: true
-            }),
+                data_type: Type::Int(max(ls, rs), lu || ru)            }),
             "^" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_xor(l, r, ""))),
@@ -592,9 +578,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l ^ r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), lu || ru),
-                export: true
-            }),
+                data_type: Type::Int(max(ls, rs), lu || ru)            }),
             ">>" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_left_shift(l, r, ""))),
@@ -604,9 +588,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l << r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), lu || ru),
-                export: true
-            }),
+                data_type: Type::Int(max(ls, rs), lu || ru)            }),
             "<<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_right_shift(l, r, false, ""))),
@@ -616,9 +598,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l >> r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), lu || ru),
-                export: true
-            }),
+                data_type: Type::Int(max(ls, rs), lu || ru)            }),
             "<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {ULT} else {SLT}, l, r, ""))),
@@ -628,9 +608,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l < r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             ">" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {UGT} else {SGT}, l, r, ""))),
@@ -640,9 +618,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l > r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             "<=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {ULE} else {SLE}, l, r, ""))),
@@ -652,9 +628,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l <= r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             ">=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {UGE} else {SGE}, l, r, ""))),
@@ -664,9 +638,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l >= r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             "==" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(EQ, l, r, ""))),
@@ -676,9 +648,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l == r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             "!=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(NE, l, r, ""))),
@@ -688,9 +658,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l < r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             "^^" => None, // TODO: implement exponents
             _ => None
         },
@@ -710,9 +678,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l + r)),
                     _ => None
                 },
-                data_type: Type::IntLiteral,
-                export: true
-            }),
+                data_type: Type::IntLiteral            }),
             "-" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_sub(l, r, ""))),
@@ -722,9 +688,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l - r)),
                     _ => None
                 },
-                data_type: Type::IntLiteral,
-                export: true
-            }),
+                data_type: Type::IntLiteral            }),
             "*" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_mul(l, r, ""))),
@@ -734,9 +698,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l * r)),
                     _ => None
                 },
-                data_type: Type::IntLiteral,
-                export: true
-            }),
+                data_type: Type::IntLiteral            }),
             "/" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_signed_div(l, r, ""))),
@@ -746,9 +708,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l / r)),
                     _ => None
                 },
-                data_type: Type::IntLiteral,
-                export: true
-            }),
+                data_type: Type::IntLiteral            }),
             "%" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_signed_rem(l, r, ""))),
@@ -758,9 +718,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l % r)),
                     _ => None
                 },
-                data_type: Type::IntLiteral,
-                export: true
-            }),
+                data_type: Type::IntLiteral            }),
             "&" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_and(l, r, ""))),
@@ -770,9 +728,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l & r)),
                     _ => None
                 },
-                data_type: Type::IntLiteral,
-                export: true
-            }),
+                data_type: Type::IntLiteral            }),
             "|" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_or(l, r, ""))),
@@ -782,9 +738,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l | r)),
                     _ => None
                 },
-                data_type: Type::IntLiteral,
-                export: true
-            }),
+                data_type: Type::IntLiteral            }),
             "^" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_xor(l, r, ""))),
@@ -794,9 +748,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l ^ r)),
                     _ => None
                 },
-                data_type: Type::IntLiteral,
-                export: true
-            }),
+                data_type: Type::IntLiteral            }),
             ">>" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_left_shift(l, r, ""))),
@@ -806,9 +758,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l << r)),
                     _ => None
                 },
-                data_type: Type::IntLiteral,
-                export: true
-            }),
+                data_type: Type::IntLiteral            }),
             "<<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_right_shift(l, r, false, ""))),
@@ -818,9 +768,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l >> r)),
                     _ => None
                 },
-                data_type: Type::IntLiteral,
-                export: true
-            }),
+                data_type: Type::IntLiteral            }),
             "^^" => None, // TODO: implement exponents
             "<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
@@ -831,9 +779,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l < r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             ">" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(SGT, l, r, ""))),
@@ -843,9 +789,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l > r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             "<=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(SLE, l, r, ""))),
@@ -855,9 +799,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l <= r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             ">=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(SGE, l, r, ""))),
@@ -867,9 +809,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l >= r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             "==" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(EQ, l, r, ""))),
@@ -879,9 +819,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l == r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             "!=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(NE, l, r, ""))),
@@ -891,9 +829,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l < r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             _ => None
         },
         (Type::Pointer(b, s), Type::Int(..) | Type::IntLiteral) => match op {
@@ -903,9 +839,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Pointer(b, s),
-                export: true
-            }),
+                data_type: Type::Pointer(b, s)            }),
             "-" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, b.size(), ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) => Some(unsafe {
@@ -915,9 +849,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Pointer(b, s),
-                export: true
-            }),
+                data_type: Type::Pointer(b, s)            }),
             _ => None
         },
         (Type::Int(..) | Type::IntLiteral, Type::Pointer(b, s)) => match op {
@@ -927,9 +859,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Pointer(b, s),
-                export: true
-            }),
+                data_type: Type::Pointer(b, s)            }),
             _ => None
         },
         (l @ Type::Pointer(..), r @ Type::Pointer(..)) => match op {
@@ -944,9 +874,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Int(64, false),
-                export: true
-            }),
+                data_type: Type::Int(64, false)            }),
             "<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
@@ -958,9 +886,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             ">" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
@@ -972,9 +898,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             "<=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
@@ -986,9 +910,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             ">=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
@@ -1000,9 +922,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             "==" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
@@ -1014,9 +934,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             "!=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
@@ -1028,9 +946,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             _ => None
         },
         (l @ (Type::Float16 | Type::Float32 | Type::Float64), r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128)) if l.size() < r.size() => {
@@ -1061,9 +977,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l + r)),
                     _ => None
                 },
-                data_type: l,
-                export: true
-            }),
+                data_type: l            }),
             "-" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(FloatValue(ctx.builder.build_float_sub(l, r, ""))),
@@ -1073,9 +987,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l - r)),
                     _ => None
                 },
-                data_type: l,
-                export: true
-            }),
+                data_type: l            }),
             "*" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(FloatValue(ctx.builder.build_float_mul(l, r, ""))),
@@ -1085,9 +997,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l * r)),
                     _ => None
                 },
-                data_type: l,
-                export: true
-            }),
+                data_type: l            }),
             "/" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(FloatValue(ctx.builder.build_float_div(l, r, ""))),
@@ -1097,9 +1007,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l / r)),
                     _ => None
                 },
-                data_type: l,
-                export: true
-            }),
+                data_type: l            }),
             "%" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(_l)), Some(FloatValue(_r)), false) => None, // TODO: implement fmod
@@ -1109,9 +1017,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l.rem_euclid(r))),
                     _ => None
                 },
-                data_type: l,
-                export: true
-            }),
+                data_type: l            }),
             "^^" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(_l)), Some(FloatValue(_r)), false) => None, // TODO: implement powf
@@ -1121,9 +1027,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l.powf(r))),
                     _ => None
                 },
-                data_type: bin_type(l, r, op),
-                export: true
-            }),
+                data_type: bin_type(l, r, op)            }),
             "<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OLT, l, r, ""))),
@@ -1133,9 +1037,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(if l < r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             ">" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OGT, l, r, ""))),
@@ -1145,9 +1047,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(if l > r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             "<=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OLE, l, r, ""))),
@@ -1157,9 +1057,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(if l <= r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             ">=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OGE, l, r, ""))),
@@ -1169,9 +1067,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(if l >= r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             "==" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OEQ, l, r, ""))),
@@ -1181,9 +1077,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(if l == r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             "!=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(ONE, l, r, ""))),
@@ -1193,9 +1087,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(if l != r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false),
-                export: true
-            }),
+                data_type: Type::Int(1, false)            }),
             _ => None
         },
         (l @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128), r @ (Type::IntLiteral | Type::Int(..))) => {
@@ -1369,15 +1261,11 @@ pub fn pre_op<'ctx>(mut val: Value<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> Opti
             "-" => Some(Value {
                 comp_val: if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(IntValue(ctx.builder.build_int_neg(v, "")))} else {None},
                 inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(-v))} else {None},
-                data_type: Type::IntLiteral,
-                export: true
-            }),
+                data_type: Type::IntLiteral            }),
             "~" => Some(Value {
                 comp_val: if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(IntValue(ctx.builder.build_xor(v, ctx.context.i64_type().const_all_ones(), "")))} else {None},
                 inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(!v))} else {None},
-                data_type: Type::IntLiteral,
-                export: true
-            }),
+                data_type: Type::IntLiteral            }),
             _ => None
         },
         Type::Int(s, u) => match op {
@@ -1388,15 +1276,11 @@ pub fn pre_op<'ctx>(mut val: Value<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> Opti
             "-" => Some(Value {
                 comp_val: if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(IntValue(ctx.builder.build_int_neg(v, "")))} else {None},
                 inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(-v))} else {None},
-                data_type: Type::Int(s, u),
-                export: true
-            }),
+                data_type: Type::Int(s, u)            }),
             "~" => Some(Value {
                 comp_val: if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(IntValue(ctx.builder.build_xor(v, ctx.context.custom_width_int_type(s as u32).const_all_ones(), "")))} else {None},
                 inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(!v))} else {None},
-                data_type: Type::Int(s, u),
-                export: true
-            }),
+                data_type: Type::Int(s, u)            }),
             _ => None
         },
         x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => match op {
@@ -1407,9 +1291,7 @@ pub fn pre_op<'ctx>(mut val: Value<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> Opti
             "-" => Some(Value {
                 comp_val: if let (Some(FloatValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(FloatValue(ctx.builder.build_float_neg(v, "")))} else {None},
                 inter_val: if let Some(InterData::Float(v)) = val.inter_val {Some(InterData::Float(-v))} else {None},
-                data_type: x,
-                export: true
-            }),
+                data_type: x            }),
             _ => None
         }
         Type::Pointer(b, m) => match op {
@@ -1452,9 +1334,7 @@ pub fn subscript<'ctx>(mut val: Value<'ctx>, mut idx: Value<'ctx>, ctx: &CompCtx
                             _ => None
                         },
                         inter_val: None,
-                        data_type: Type::Reference(b, m),
-                        export: true
-                    }),
+                        data_type: Type::Reference(b, m)                    }),
                     _ => None
                 },
                 Type::Reference(b, m) => match *b {
@@ -1491,9 +1371,7 @@ pub fn subscript<'ctx>(mut val: Value<'ctx>, mut idx: Value<'ctx>, ctx: &CompCtx
                                 else {Some(unsafe {ctx.builder.build_gep(raw, &[iv], "").into()})}
                             } else {None},
                             inter_val: if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) = (val.inter_val, idx.inter_val) {vals.get(val as usize).cloned()} else {None},
-                            data_type: Type::Reference(b, m),
-                            export: true
-                        }),
+                            data_type: Type::Reference(b, m)                        }),
                         Type::Int(_, false) => Some(Value {
                             comp_val: if let (Some(StructValue(sv)), Some(IntValue(iv)), SizeType::Static(_), false) = (val.value(ctx), idx.value(ctx), b.size(), ctx.is_const.get()) {
                                 let raw = ctx.builder.build_extract_value(sv, 0, "").unwrap().into_pointer_value();
@@ -1526,9 +1404,7 @@ pub fn subscript<'ctx>(mut val: Value<'ctx>, mut idx: Value<'ctx>, ctx: &CompCtx
                                 else {Some(unsafe {ctx.builder.build_gep(raw, &[iv], "").into()})}
                             } else {None},
                             inter_val: if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) = (val.inter_val, idx.inter_val) {vals.get(val as usize).cloned()} else {None},
-                            data_type: Type::Reference(b, m),
-                            export: true
-                        }),
+                            data_type: Type::Reference(b, m)                        }),
                         _ => None
                     },
                     Type::Array(b, Some(s)) => match idx.data_type.clone() {
@@ -1563,9 +1439,7 @@ pub fn subscript<'ctx>(mut val: Value<'ctx>, mut idx: Value<'ctx>, ctx: &CompCtx
                                 else {Some(unsafe {ctx.builder.build_gep(raw, &[iv], "").into()})}
                             } else {None},
                             inter_val: if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) = (val.inter_val, idx.inter_val) {vals.get(val as usize).cloned()} else {None},
-                            data_type: Type::Reference(b, m),
-                            export: true
-                        }),
+                            data_type: Type::Reference(b, m)                        }),
                         Type::Int(_, false) => Some(Value {
                             comp_val: if let (Some(PointerValue(raw)), Some(IntValue(iv)), SizeType::Static(_), false) = (val.value(ctx), idx.value(ctx), b.size(), ctx.is_const.get()) {
                                 if ctx.flags.bounds_checks {
@@ -1597,9 +1471,7 @@ pub fn subscript<'ctx>(mut val: Value<'ctx>, mut idx: Value<'ctx>, ctx: &CompCtx
                                 else {Some(unsafe {ctx.builder.build_gep(raw, &[iv], "").into()})}
                             } else {None},
                             inter_val: if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) = (val.inter_val, idx.inter_val) {vals.get(val as usize).cloned()} else {None},
-                            data_type: Type::Reference(b, m),
-                            export: true
-                        }),
+                            data_type: Type::Reference(b, m)                        }),
                         _ => None
                     },
                     x => {
@@ -1693,66 +1565,48 @@ pub fn impl_convert<'ctx>(mut val: Value<'ctx>, target: Type, ctx: &CompCtx<'ctx
                               else if let Some(IntValue(v)) = val.comp_val {Some(FloatValue(ctx.builder.build_signed_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "")))}
                               else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
-                    data_type: x,
-                    export: true
-                }),
+                    data_type: x                }),
                 _ => None
             },
             Type::Int(ls, true) => match target {
                 Type::Int(1, false) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_compare(NE, v, ctx.context.custom_width_int_type(ls as u32).const_zero(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
-                    data_type: Type::Int(1, false),
-                    export: true
-                }),
+                    data_type: Type::Int(1, false)                }),
                 Type::Int(rs, true) if ls < rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_z_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
-                    data_type: Type::Int(rs, true),
-                    export: true
-                }),
+                    data_type: Type::Int(rs, true)                }),
                 Type::Int(rs, false) if ls < rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
-                    data_type: Type::Int(rs, false),
-                    export: true
-                }),
+                    data_type: Type::Int(rs, false)                }),
                 x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_unsigned_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
-                    data_type: x,
-                    export: true
-                }),
+                    data_type: x                }),
                 _ => None
             },
             Type::Int(ls, false) => match target {
                 Type::Int(1, false) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_compare(NE, v, ctx.context.custom_width_int_type(ls as u32).const_zero(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
-                    data_type: Type::Int(1, false),
-                    export: true
-                }),
+                    data_type: Type::Int(1, false)                }),
                 Type::Int(rs, ru) if ls < rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
-                    data_type: Type::Int(rs, ru),
-                    export: true
-                }),
+                    data_type: Type::Int(rs, ru)                }),
                 x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_signed_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
-                    data_type: x,
-                    export: true
-                }),
+                    data_type: x                }),
                 _ => None
             },
             Type::Pointer(_, false) => match target {
                 Type::Pointer(rb, false) if *rb == Type::Null => Some(Value {
                     comp_val: val.value(ctx).map(|v| ctx.builder.build_bitcast(v, ctx.null_type.ptr_type(inkwell::AddressSpace::from(0u16)), "")),
                     inter_val: None,
-                    data_type: Type::Pointer(Box::new(Type::Null), false),
-                    export: true
-                }),
+                    data_type: Type::Pointer(Box::new(Type::Null), false)                }),
                 _ => None
             },
             Type::Pointer(ref lb, true) => match target {
@@ -1760,15 +1614,13 @@ pub fn impl_convert<'ctx>(mut val: Value<'ctx>, target: Type, ctx: &CompCtx<'ctx
                     Type::Null => Some(Value {
                         comp_val: val.value(ctx).map(|v| ctx.builder.build_bitcast(v, ctx.null_type.ptr_type(inkwell::AddressSpace::from(0u16)), "")),
                         inter_val: None,
-                        data_type: Type::Pointer(Box::new(Type::Null), false),
-                        export: true
-                    }),
+                        data_type: Type::Pointer(Box::new(Type::Null), false)                    }),
                     x if x == **lb => Some(Value {data_type: Type::Pointer(Box::new(x), false), ..val}),
                     _ => None
                 },
                 _ => None
             },
-            Type::Error => Some(Value {comp_val: None, inter_val: None, data_type: Type::Error, export: true}),
+            Type::Error => Some(Value {comp_val: None, inter_val: None, data_type: Type::Error}),
             _ => None
         }
     }
@@ -1849,9 +1701,7 @@ pub fn expl_convert<'ctx>(mut val: Value<'ctx>, target: Type, ctx: &CompCtx<'ctx
                               else if let Some(IntValue(v)) = val.comp_val {Some(FloatValue(ctx.builder.build_signed_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "")))}
                               else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
-                    data_type: x,
-                    export: true
-                }),
+                    data_type: x                }),
                 _ => None
             },
             Type::Int(ls, true) => match target {
@@ -1859,39 +1709,27 @@ pub fn expl_convert<'ctx>(mut val: Value<'ctx>, target: Type, ctx: &CompCtx<'ctx
                 Type::Int(1, false) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_compare(NE, v, ctx.context.custom_width_int_type(ls as u32).const_zero(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
-                    data_type: Type::Int(1, false),
-                    export: true
-                }),
+                    data_type: Type::Int(1, false)                }),
                 Type::Int(rs, true) if ls < rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_z_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
-                    data_type: Type::Int(rs, true),
-                    export: true
-                }),
+                    data_type: Type::Int(rs, true)                }),
                 Type::Int(rs, false) if ls < rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
-                    data_type: Type::Int(rs, false),
-                    export: true
-                }),
+                    data_type: Type::Int(rs, false)                }),
                 Type::Int(rs, ru) if ls > rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_truncate(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
-                    data_type: Type::Int(rs, ru),
-                    export: true
-                }),
+                    data_type: Type::Int(rs, ru)                }),
                 x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_unsigned_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
-                    data_type: x,
-                    export: true
-                }),
+                    data_type: x                }),
                 Type::Pointer(b, m) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_to_ptr(v, Type::Pointer(b.clone(), m).llvm_type(ctx).unwrap().into_pointer_type(), "").into())} else {None},
                     inter_val: None,
-                    data_type: Type::Pointer(b, m),
-                    export: true
-                }),
+                    data_type: Type::Pointer(b, m)                }),
                 _ => None
             },
             Type::Int(ls, false) => match target {
@@ -1899,54 +1737,38 @@ pub fn expl_convert<'ctx>(mut val: Value<'ctx>, target: Type, ctx: &CompCtx<'ctx
                 Type::Int(1, false) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_compare(NE, v, ctx.context.custom_width_int_type(ls as u32).const_zero(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
-                    data_type: Type::Int(1, false),
-                    export: true
-                }),
+                    data_type: Type::Int(1, false)                }),
                 Type::Int(rs, ru) if ls < rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
-                    data_type: Type::Int(rs, ru),
-                    export: true
-                }),
+                    data_type: Type::Int(rs, ru)                }),
                 Type::Int(rs, ru) if ls > rs => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_truncate(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
                     inter_val: val.inter_val,
-                    data_type: Type::Int(rs, ru),
-                    export: true
-                }),
+                    data_type: Type::Int(rs, ru)                }),
                 x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_signed_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
-                    data_type: x,
-                    export: true
-                }),
+                    data_type: x                }),
                 Type::Pointer(b, m) => Some(Value {
                     comp_val: if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_to_ptr(v, Type::Pointer(b.clone(), m).llvm_type(ctx).unwrap().into_pointer_type(), "").into())} else {None},
                     inter_val: None,
-                    data_type: Type::Pointer(b, m),
-                    export: true
-                }),
+                    data_type: Type::Pointer(b, m)                }),
                 _ => None
             },
             ref x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => match target {
                 Type::Int(1, false) => Some(Value {
                     comp_val: if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_float_compare(ONE, v, x.llvm_type(ctx).unwrap().into_float_type().const_zero(), "").into())} else {None},
                     inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
-                    data_type: Type::Int(1, false),
-                    export: true
-                }),
+                    data_type: Type::Int(1, false)                }),
                 Type::Int(s, false) => Some(Value {
                     comp_val: if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_float_to_signed_int(v, ctx.context.custom_width_int_type(s as u32), "").into())} else {None},
                     inter_val: if let Some(InterData::Float(v)) = val.inter_val {Some(InterData::Int(v as i128))} else {None},
-                    data_type: Type::Int(s, false),
-                    export: true
-                }),
+                    data_type: Type::Int(s, false)                }),
                 Type::Int(s, true) => Some(Value {
                     comp_val: if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_float_to_unsigned_int(v, ctx.context.custom_width_int_type(s as u32), "").into())} else {None},
                     inter_val: if let Some(InterData::Float(v)) = val.inter_val {Some(InterData::Int(v as i128))} else {None},
-                    data_type: Type::Int(s, false),
-                    export: true
-                }),
+                    data_type: Type::Int(s, false)                }),
                 r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Some(Value {
                     comp_val: if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_float_cast(v, r.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
                     data_type: x.clone(),
@@ -1958,35 +1780,27 @@ pub fn expl_convert<'ctx>(mut val: Value<'ctx>, target: Type, ctx: &CompCtx<'ctx
                 Type::Pointer(rb, false) if *rb == Type::Null => Some(Value {
                     comp_val: val.value(ctx).map(|v| ctx.builder.build_bitcast(v, ctx.null_type.ptr_type(inkwell::AddressSpace::from(0u16)), "")),
                     inter_val: None,
-                    data_type: Type::Pointer(Box::new(Type::Null), false),
-                    export: true
-                }),
+                    data_type: Type::Pointer(Box::new(Type::Null), false)                }),
                 Type::Pointer(rb, false) if **lb == Type::Null => Some(Value {
                     comp_val: val.value(ctx).and_then(|v| Some(ctx.builder.build_bitcast(v, rb.llvm_type(ctx)?.ptr_type(inkwell::AddressSpace::from(0u16)), ""))),
                     inter_val: None,
-                    data_type: Type::Pointer(rb, false),
-                    export: true
-                }),
+                    data_type: Type::Pointer(rb, false)                }),
                 _ => None
             },
             Type::Pointer(ref lb, true) => match target {
                 Type::Pointer(rb, m) if *rb == Type::Null => Some(Value {
                     comp_val: val.value(ctx).map(|v| ctx.builder.build_bitcast(v, ctx.null_type.ptr_type(inkwell::AddressSpace::from(0u16)), "")),
                     inter_val: None,
-                    data_type: Type::Pointer(Box::new(Type::Null), m),
-                    export: true
-                }),
+                    data_type: Type::Pointer(Box::new(Type::Null), m)                }),
                 Type::Pointer(rb, m) if **lb == Type::Null => Some(Value {
                     comp_val: val.value(ctx).and_then(|v| Some(ctx.builder.build_bitcast(v, rb.llvm_type(ctx)?.ptr_type(inkwell::AddressSpace::from(0u16)), ""))),
                     inter_val: None,
-                    data_type: Type::Pointer(rb, m),
-                    export: true
-                }),
+                    data_type: Type::Pointer(rb, m)                }),
                 Type::Pointer(x, false) if x == *lb => Some(Value {data_type: Type::Pointer(x, false), ..val}),
                 _ => None
             },
-            Type::Null => Some(Value {comp_val: target.llvm_type(ctx).map(|t| t.const_zero()), inter_val: None, data_type: target, export: true}),
-            Type::Error => Some(Value {comp_val: None, inter_val: None, data_type: Type::Error, export: true}),
+            Type::Null => Some(Value {comp_val: target.llvm_type(ctx).map(|t| t.const_zero()), inter_val: None, data_type: target}),
+            Type::Error => Some(Value {comp_val: None, inter_val: None, data_type: Type::Error}),
             _ => None
         }
     }
@@ -2063,9 +1877,7 @@ pub fn call<'ctx>(mut target: Value<'ctx>, loc: Location, cparen: Location, mut 
                 defaults.iter().zip(params.iter().skip(p - d)).skip(a + d - p).map(|(v, (t, c))| (Value {
                     comp_val: if *c {None} else {v.into_compiled(ctx)},
                     inter_val: Some(v.clone()),
-                    data_type: t.clone(),
-                    export: true
-                }, cparen.clone())).collect()
+                    data_type: t.clone()                }, cparen.clone())).collect()
             } else {vec![]}).zip(params.iter()).enumerate().map(|(n, ((v, l), (t, c)))| {
                 let e = format!("expected value of type {t} in {}{} argument, got {}", n + 1, if  n % 100 / 10 == 1 {"th"} else {suffixes[n % 10]}, v.data_type);
                 (if let Some(val) = impl_convert(v.clone(), t.clone(), ctx) {
@@ -2089,9 +1901,7 @@ pub fn call<'ctx>(mut target: Value<'ctx>, loc: Location, cparen: Location, mut 
             Ok(Value {
                 comp_val: val.and_then(|v| ctx.builder.build_call(v, args.as_slice(), "").try_as_basic_value().left()),
                 inter_val: None,
-                data_type: *ret,
-                export: true
-            })
+                data_type: *ret            })
         },
         Type::InlineAsm => if let (Some(InterData::InlineAsm(r, c, b)), false) = (target.inter_val, ctx.is_const.get()) {
             let mut params = Vec::with_capacity(args.len());
@@ -2118,9 +1928,7 @@ pub fn call<'ctx>(mut target: Value<'ctx>, loc: Location, cparen: Location, mut 
                 Ok(Value {
                     comp_val: ret.try_as_basic_value().left(),
                     inter_val: None,
-                    data_type: *r,
-                    export: true
-                })
+                    data_type: *r                })
             }
             else {
                 let fty = ctx.context.void_type().fn_type(&params, false);

--- a/src/cobalt/varmap.rs
+++ b/src/cobalt/varmap.rs
@@ -120,34 +120,62 @@ impl InterData {
 pub struct Value<'ctx> {
     pub comp_val: Option<BasicValueEnum<'ctx>>,
     pub inter_val: Option<InterData>,
-    pub data_type: Type,
-    pub export: bool
+    pub data_type: Type
 }
 impl<'ctx> Value<'ctx> {
-    pub fn error() -> Self {Value {comp_val: None, inter_val: None, data_type: Type::Error, export: true}}
-    pub fn null() -> Self {Value {comp_val: None, inter_val: Some(InterData::Null), data_type: Type::Null, export: true}}
-    pub fn compiled(comp_val: BasicValueEnum<'ctx>, data_type: Type) -> Self {Value {comp_val: Some(comp_val), inter_val: None, data_type, export: true}}
-    pub fn interpreted(comp_val: BasicValueEnum<'ctx>, inter_val: InterData, data_type: Type) -> Self {Value {comp_val: Some(comp_val), inter_val: Some(inter_val), data_type, export: true}}
-    pub fn metaval(inter_val: InterData, data_type: Type) -> Self {Value {comp_val: None, inter_val: Some(inter_val), data_type, export: true}}
+    pub fn error() -> Self {Value {comp_val: None, inter_val: None, data_type: Type::Error}}
+    pub fn null() -> Self {Value {comp_val: None, inter_val: Some(InterData::Null), data_type: Type::Null}}
+    pub fn compiled(comp_val: BasicValueEnum<'ctx>, data_type: Type) -> Self {Value {comp_val: Some(comp_val), inter_val: None, data_type}}
+    pub fn interpreted(comp_val: BasicValueEnum<'ctx>, inter_val: InterData, data_type: Type) -> Self {Value {comp_val: Some(comp_val), inter_val: Some(inter_val), data_type}}
+    pub fn metaval(inter_val: InterData, data_type: Type) -> Self {Value {comp_val: None, inter_val: Some(inter_val), data_type}}
     pub fn value(&self, ctx: &CompCtx<'ctx>) -> Option<BasicValueEnum<'ctx>> {self.comp_val.clone().or_else(|| self.inter_val.as_ref().and_then(|v| v.into_compiled(ctx)))}
+}
+#[derive(Clone, PartialEq, Eq)]
+pub struct VariableData {
+    pub good: bool,
+    pub export: bool,
+    pub loc: Option<Location>,
+}
+impl VariableData {
+    pub fn new(loc: Location) -> Self {
+        VariableData {
+            good: true,
+            export: true,
+            loc: Some(loc)
+        }
+    }
+}
+impl Default for VariableData {
+    fn default() -> Self {
+        VariableData {
+            good: true,
+            export: true,
+            loc: None
+        }
+    }
+}
+impl<'ctx> From<Value<'ctx>> for Symbol<'ctx> {
+    fn from(val: Value<'ctx>) -> Self {
+        Symbol::Variable(val, VariableData::default())
+    }
 }
 #[derive(Clone)]
 pub enum Symbol<'ctx> {
-    Variable(Value<'ctx>),
+    Variable(Value<'ctx>, VariableData),
     Module(HashMap<String, Symbol<'ctx>>, Vec<CompoundDottedName>)
 }
 impl<'ctx> Symbol<'ctx> {
-    pub fn into_var(self) -> Option<Value<'ctx>> {if let Symbol::Variable(x) = self {Some(x)} else {None}}
+    pub fn into_var(self) -> Option<Value<'ctx>> {if let Symbol::Variable(x, _) = self {Some(x)} else {None}}
     pub fn into_mod(self) -> Option<(HashMap<String, Symbol<'ctx>>, Vec<CompoundDottedName>)> {if let Symbol::Module(x, i) = self {Some((x, i))} else {None}}
-    pub fn as_var(&self) -> Option<&Value<'ctx>> {if let Symbol::Variable(x) = self {Some(x)} else {None}}
+    pub fn as_var(&self) -> Option<&Value<'ctx>> {if let Symbol::Variable(x, _) = self {Some(x)} else {None}}
     pub fn as_mod(&self) -> Option<(&HashMap<String, Symbol<'ctx>>, &Vec<CompoundDottedName>)> {if let Symbol::Module(x, i) = self {Some((x, i))} else {None}}
-    pub fn as_var_mut(&mut self) -> Option<&mut Value<'ctx>> {if let Symbol::Variable(x) = self {Some(x)} else {None}}
+    pub fn as_var_mut(&mut self) -> Option<&mut Value<'ctx>> {if let Symbol::Variable(x, _) = self {Some(x)} else {None}}
     pub fn as_mod_mut(&mut self) -> Option<(&mut HashMap<String, Symbol<'ctx>>, &mut Vec<CompoundDottedName>)> {if let Symbol::Module(x, i) = self {Some((x, i))} else {None}}
-    pub fn is_var(&self) -> bool {if let Symbol::Variable(_) = self {true} else {false}}
+    pub fn is_var(&self) -> bool {if let Symbol::Variable(..) = self {true} else {false}}
     pub fn is_mod(&self) -> bool {if let Symbol::Module(..) = self {true} else {false}}
     pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {
         match self {
-            Symbol::Variable(v) => if v.export {
+            Symbol::Variable(v, d) => if d.export {
                 out.write_all(&[1])?; // Value
                 out.write_all(v.comp_val.as_ref().map(|v| v.into_pointer_value().get_name().to_bytes().to_owned()).unwrap_or_else(Vec::new).as_slice())?; // LLVM symbol name, null-terminated
                 out.write_all(&[0])?;
@@ -176,7 +204,6 @@ impl<'ctx> Symbol<'ctx> {
         match c {
             1 => {
                 let mut var = Value::error();
-                var.export = true;
                 let mut name = vec![];
                 buf.read_until(0, &mut name)?;
                 if name.last() == Some(&0) {name.pop();}
@@ -214,7 +241,7 @@ impl<'ctx> Symbol<'ctx> {
                         var.comp_val = Some(BasicValueEnum::PointerValue(gv.as_pointer_value()));
                     }
                 }
-                Ok(Symbol::Variable(var))
+                Ok(var.into())
             },
             2 => {
                 let mut out = HashMap::new();
@@ -237,7 +264,7 @@ impl<'ctx> Symbol<'ctx> {
     }
     pub fn dump(&self, mut depth: usize) {
         match self {
-            Symbol::Variable(Value {data_type: dt, ..}) => eprintln!("variable of type {dt}"),
+            Symbol::Variable(Value {data_type: dt, ..}, _) => eprintln!("variable of type {dt}"),
             Symbol::Module(m, i) => {
                 eprintln!("module");
                 depth += 4;
@@ -303,7 +330,7 @@ impl<'ctx> VarMap<'ctx> {
                     &name.ids[idx..], &i.ids))
                     .ok_or(UndefVariable::DoesNotExist(idx))
                     .or_else(|e| self.parent.as_ref().map(|p| p.lookup(name)).unwrap_or(Err(e))),
-                Some(Symbol::Variable(_)) => return Err(UndefVariable::NotAModule(idx)),
+                Some(Symbol::Variable(..)) => return Err(UndefVariable::NotAModule(idx)),
                 Some(Symbol::Module(x, i)) => {
                     this = x;
                     imports = i;
@@ -342,7 +369,7 @@ impl<'ctx> VarMap<'ctx> {
         }
         match this.entry(name.ids[idx].0.clone()) {
             Entry::Occupied(mut x) => match x.get_mut() {
-                Symbol::Variable(_) => Err(RedefVariable::AlreadyExists(idx, Symbol::Module(sym.0, sym.1))),
+                Symbol::Variable(..) => Err(RedefVariable::AlreadyExists(idx, Symbol::Module(sym.0, sym.1))),
                 Symbol::Module(ref mut m, ref mut i) => {
                     *m = sym.0;
                     i.append(&mut sym.1);
@@ -363,7 +390,7 @@ impl<'ctx> VarMap<'ctx> {
         }
         match this.entry(name.ids[idx].0.clone()) {
             Entry::Occupied(mut x) => match x.get_mut() {
-                Symbol::Variable(_) => Err(UndefVariable::DoesNotExist(idx)), // should be AlreadyExists, but DoesNotExist wouldn't arise here
+                Symbol::Variable(..) => Err(UndefVariable::DoesNotExist(idx)), // should be AlreadyExists, but DoesNotExist wouldn't arise here
                 Symbol::Module(..) => Ok(x.remove().into_mod().unwrap())
             },
             Entry::Vacant(x) => Ok(x.insert(Symbol::Module(HashMap::new(), vec![])).clone().into_mod().unwrap())


### PR DESCRIPTION
There's now a better distinction between variables and values. Rather than having weird vestigial `good` and `export` values on `Value`, they're now in a `VariableData` struct attached to the `Symbol::Variable` variant. This cuts out over 100 `export: true`s, which were getting *really* repetitive.
Commits:
- Renamed Variable to Value
- Moved export field to VariableData field on `Symbol::Varible`
- Improved error messages for variable redefinitions
