### PR TITLE
Fix load conflicts when loading multiple modules

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -130,11 +130,11 @@ impl TargetData {
         libs.sort();
         libs.dedup();
         match libs::find_libs(libs.clone(), link_dirs, None) {
-            Ok((libs, notfound)) => {
+            Ok((libs, notfound, failed)) => {
                 for nf in notfound.iter() {eprintln!("{ERROR}: couldn't find library {nf}");}
                 if notfound.len() > 0 {return Err(102)}
                 libs.into_iter().for_each(|(path, name)| self.init_lib(&name, &path, targets));
-                Ok(())
+                if failed {Err(99)} else {Ok(())}
             },
             Err(e) => {
                 eprintln!("{ERROR}: {e}");

--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -112,7 +112,6 @@ impl AST for FnDefAST {
                 }
             }
         }, pt == &ParamType::Constant)).collect());
-        let mut errs = vec![];
         let mut link_type = None;
         let mut linkas = None;
         let mut is_extern = None;

--- a/src/libs.rs
+++ b/src/libs.rs
@@ -2,8 +2,9 @@ use std::path::PathBuf;
 use std::ffi::OsStr;
 use std::io;
 use std::process::{Command, Output};
-pub fn find_libs<'a>(mut libs: Vec<String>, dirs: &Vec<&str>, ctx: Option<&cobalt::CompCtx>) -> io::Result<(Vec<(PathBuf, String)>, Vec<String>)> {
+pub fn find_libs<'a>(mut libs: Vec<String>, dirs: &Vec<&str>, ctx: Option<&cobalt::CompCtx>) -> io::Result<(Vec<(PathBuf, String)>, Vec<String>, bool)> {
     let mut out = vec![];
+    let mut failed = false;
     for x in dirs.iter().flat_map(|dir| walkdir::WalkDir::new(dir).follow_links(true).into_iter()).filter_map(|x| x.ok()).filter(|x| x.file_type().is_file()) {
         let path = x.into_path();
         if let Some(ext) = path.file_name().and_then(OsStr::to_str).map(|x| x.find('.').map(|i| &x[i..]).unwrap_or(x)) {if !(ext.contains(".so") || ext.contains(".dylib") || ext.contains(".dll")) {continue}} else {continue}
@@ -14,7 +15,10 @@ pub fn find_libs<'a>(mut libs: Vec<String>, dirs: &Vec<&str>, ctx: Option<&cobal
                     std::mem::swap(&mut val, lib);
                     if let Some(ctx) = ctx {
                         match Command::new("objcopy").arg(&path).args(["--dump-section", ".colib=/dev/stdout"]).output() { // TODO: use ELF parser library
-                            Ok(Output {status, stdout, ..}) if status.success() => ctx.with_vars(|v| v.load(&mut stdout.as_slice(), ctx))?,
+                            Ok(Output {status, stdout, ..}) if status.success() => for conflict in ctx.with_vars(|v| v.load(&mut stdout.as_slice(), ctx))? {
+                                eprintln!("redefinition of {conflict} in {}", path.display());
+                                failed = true;
+                            },
                             _ => {}
                         }
                     }
@@ -39,5 +43,5 @@ pub fn find_libs<'a>(mut libs: Vec<String>, dirs: &Vec<&str>, ctx: Option<&cobal
             }
         }
     }
-    Ok((out, libs.into_iter().filter(|x| x.len() > 0).map(|x| x.to_string()).collect()))
+    Ok((out, libs.into_iter().filter(|x| x.len() > 0).map(|x| x.to_string()).collect(), failed))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -551,9 +551,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let ctx = cobalt::context::CompCtx::with_flags(&ink_ctx, in_file, flags);
             ctx.module.set_triple(&triple);
             let libs = if linked.len() > 0 {
-                let (libs, notfound) = libs::find_libs(linked.iter().map(|x| x.to_string()).collect(), &link_dirs.iter().map(|x| x.as_str()).collect(), Some(&ctx))?;
+                let (libs, notfound, failed) = libs::find_libs(linked.iter().map(|x| x.to_string()).collect(), &link_dirs.iter().map(|x| x.as_str()).collect(), Some(&ctx))?;
                 notfound.iter().for_each(|nf| eprintln!("{ERROR}: couldn't find library {nf}"));
                 if notfound.len() > 0 {exit(102)}
+                if failed {exit(99)}
                 libs
             } else {vec![]};
             for head in headers {
@@ -802,9 +803,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let ctx = cobalt::context::CompCtx::new(&ink_ctx, in_file);
             ctx.module.set_triple(&TargetMachine::get_default_triple());
             let libs = if linked.len() > 0 {
-                let (libs, notfound) = libs::find_libs(linked.iter().map(|x| x.to_string()).collect(), &link_dirs.iter().map(|x| x.as_str()).collect(), Some(&ctx))?;
+                let (libs, notfound, failed) = libs::find_libs(linked.iter().map(|x| x.to_string()).collect(), &link_dirs.iter().map(|x| x.as_str()).collect(), Some(&ctx))?;
                 notfound.iter().for_each(|nf| eprintln!("{ERROR}: couldn't find library {nf}"));
                 if notfound.len() > 0 {exit(102)}
+                if failed {exit(99)}
                 libs
             } else {vec![]};
             for head in headers {
@@ -973,9 +975,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let ctx = cobalt::context::CompCtx::with_flags(&ink_ctx, in_file, flags);
             ctx.module.set_triple(&triple);
             if linked.len() > 0 {
-                let notfound = libs::find_libs(linked.iter().map(|x| x.to_string()).collect(), &link_dirs.iter().map(|x| x.as_str()).collect(), Some(&ctx))?.1;
+                let (_, notfound, failed) = libs::find_libs(linked.iter().map(|x| x.to_string()).collect(), &link_dirs.iter().map(|x| x.as_str()).collect(), Some(&ctx))?;
                 notfound.iter().for_each(|nf| eprintln!("{ERROR}: couldn't find library {nf}"));
                 if notfound.len() > 0 {exit(102)}
+                if failed {exit(99)}
             }
             for head in headers {
                 let mut file = BufReader::new(std::fs::File::open(&head)?);


### PR DESCRIPTION
With two modules with the same symbol, even it is a module, the module would be overwritten by the second load. For example:
`a.co`:
```
module mod {
  let a = 0;
}
```
'b.co`:
```
module mod {
  let b = 0;
}
```
`c.co`:
```
let c = mod.a + mod.b;
```
Compiling with `co aot c.co -l a -l b` would give an error that `mod.a` is undefined, and `co aot c.co -l b -l a` would say that `mod.b` is undefined.
Now, either one works. Along with this, a symbol cannot be redefined by compiling two modules unaware of the conflict, as an error is emitted when both are linked.
Commits:
- Fixed errors not being shown in function definitions
- Fixed issue with symbols being overwritten from multiple libraries being loaded
