### PR TITLE
Add type aliases

### DIFF
--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -42,6 +42,10 @@ impl AST for FnDefAST {
             Err(IntoTypeError::DoesNotExist(name, loc)) => {
                 errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
                 Type::Error
+            },
+            Err(IntoTypeError::NotAType(name, loc)) => {
+                errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
+                Type::Error
             }
         };
         Type::Function(Box::new(ret), self.params.iter().map(|(_, pt, ty, _)| ({
@@ -63,6 +67,10 @@ impl AST for FnDefAST {
                 },
                 Err(IntoTypeError::DoesNotExist(name, loc)) => {
                     errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                    Type::Error
+                },
+                Err(IntoTypeError::NotAType(name, loc)) => {
+                    errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
                     Type::Error
                 }
             }
@@ -87,6 +95,10 @@ impl AST for FnDefAST {
             Err(IntoTypeError::DoesNotExist(name, loc)) => {
                 errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
                 Type::Error
+            },
+            Err(IntoTypeError::NotAType(name, loc)) => {
+                errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
+                Type::Error
             }
         };
         let fty = Type::Function(Box::new(ret), self.params.iter().map(|(_, pt, ty, _)| ({
@@ -108,6 +120,10 @@ impl AST for FnDefAST {
                 },
                 Err(IntoTypeError::DoesNotExist(name, loc)) => {
                     errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                    Type::Error
+                },
+                Err(IntoTypeError::NotAType(name, loc)) => {
+                    errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
                     Type::Error
                 }
             }

--- a/src/cobalt/ast/misc.rs
+++ b/src/cobalt/ast/misc.rs
@@ -33,6 +33,10 @@ impl AST for CastAST {
             Err(IntoTypeError::DoesNotExist(name, loc)) => {
                 errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
                 Type::Error
+            },
+            Err(IntoTypeError::NotAType(name, loc)) => {
+                errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
+                Type::Error
             }
         };
         let l = format!("source type is {}", val.data_type);
@@ -85,6 +89,10 @@ impl AST for BitCastAST {
             },
             Err(IntoTypeError::DoesNotExist(name, loc)) => {
                 errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                Type::Error
+            },
+            Err(IntoTypeError::NotAType(name, loc)) => {
+                errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
                 Type::Error
             }
         };

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -1241,11 +1241,11 @@ impl VarGetAST {
 impl AST for VarGetAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
-        if let Ok(Symbol::Variable(x, _)) = ctx.with_vars(|v| v.lookup(&self.name)) {x.data_type.clone()}
+        if let Ok(Symbol::Variable(x, _)) = ctx.lookup(&self.name) {x.data_type.clone()}
         else {Type::Error}
     }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
-        match ctx.with_vars(|v| v.lookup(&self.name)) {
+        match ctx.lookup(&self.name) {
             Ok(Symbol::Variable(x, _)) => (x.clone(), vec![]),
             Ok(Symbol::Module(..)) => (Value::error(), vec![Diagnostic::error(self.name.ids.last().unwrap().1.clone(), 322, Some(format!("{} is not a variable", self.name)))]),
             Err(UndefVariable::NotAModule(idx)) => (Value::error(), vec![Diagnostic::error(self.name.ids[idx].1.clone(), 321, Some(format!("{} is not a module", self.name.start(idx))))]),

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -1293,7 +1293,7 @@ impl AST for TypeDefAST {
     fn to_code(&self) -> String {format!("type {} = {}", self.name, self.val)}
     fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix) -> std::fmt::Result {
         writeln!(f, "type: {}", self.name)?;
-        writeln!(f, "{pre}├── {}", self.val)
+        writeln!(f, "{pre}└── {}", self.val)
     }
 }
 pub struct VarGetAST {

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -1273,7 +1273,7 @@ impl AST for TypeDefAST {
         };
         match ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(Value::make_type(Type::Nominal(ctx.mangle(&self.name))), VariableData::new(self.loc.clone())))) {
             Ok(x) => {
-                types::NOMINAL_TYPES.write().expect("Value should not be poisoned!").insert(ctx.mangle(&self.name), ty);
+                types::NOMINAL_TYPES.write().expect("Value should not be poisoned!").insert(ctx.mangle(&self.name), (ty, true));
                 (x.as_var().unwrap().clone(), errs)
             },
             Err(RedefVariable::NotAModule(x, _)) => {

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -109,6 +109,10 @@ impl AST for VarDefAST {
                         Err(IntoTypeError::DoesNotExist(name, loc)) => {
                             errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
                             Type::Error
+                        },
+                        Err(IntoTypeError::NotAType(name, loc)) => {
+                            errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
+                            Type::Error
                         }
                     }
                 }) {t} else {
@@ -172,6 +176,10 @@ impl AST for VarDefAST {
                         },
                         Err(IntoTypeError::DoesNotExist(name, loc)) => {
                             errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                            Type::Error
+                        },
+                        Err(IntoTypeError::NotAType(name, loc)) => {
+                            errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
                             Type::Error
                         }
                     }
@@ -242,6 +250,10 @@ impl AST for VarDefAST {
                         Err(IntoTypeError::DoesNotExist(name, loc)) => {
                             errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
                             Type::Error
+                        },
+                        Err(IntoTypeError::NotAType(name, loc)) => {
+                            errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
+                            Type::Error
                         }
                     }
                 }) {t} else {
@@ -280,6 +292,10 @@ impl AST for VarDefAST {
                                 },
                                 Err(IntoTypeError::DoesNotExist(name, loc)) => {
                                     errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                                    Type::Error
+                                },
+                                Err(IntoTypeError::NotAType(name, loc)) => {
+                                    errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
                                     Type::Error
                                 }
                             }
@@ -341,6 +357,10 @@ impl AST for VarDefAST {
                                 },
                                 Err(IntoTypeError::DoesNotExist(name, loc)) => {
                                     errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                                    Type::Error
+                                },
+                                Err(IntoTypeError::NotAType(name, loc)) => {
+                                    errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
                                     Type::Error
                                 }
                             }
@@ -406,6 +426,10 @@ impl AST for VarDefAST {
                             },
                             Err(IntoTypeError::DoesNotExist(name, loc)) => {
                                 errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                                Type::Error
+                            },
+                            Err(IntoTypeError::NotAType(name, loc)) => {
+                                errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
                                 Type::Error
                             }
                         }
@@ -476,6 +500,10 @@ impl AST for VarDefAST {
                     },
                     Err(IntoTypeError::DoesNotExist(name, loc)) => {
                         errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                        Type::Error
+                    },
+                    Err(IntoTypeError::NotAType(name, loc)) => {
+                        errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
                         Type::Error
                     }
                 }
@@ -649,6 +677,10 @@ impl AST for MutDefAST {
                         Err(IntoTypeError::DoesNotExist(name, loc)) => {
                             errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
                             Type::Error
+                        },
+                        Err(IntoTypeError::NotAType(name, loc)) => {
+                            errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
+                            Type::Error
                         }
                     }
                 }) {t} else {
@@ -713,6 +745,10 @@ impl AST for MutDefAST {
                         },
                         Err(IntoTypeError::DoesNotExist(name, loc)) => {
                             errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                            Type::Error
+                        },
+                        Err(IntoTypeError::NotAType(name, loc)) => {
+                            errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
                             Type::Error
                         }
                     }
@@ -785,6 +821,10 @@ impl AST for MutDefAST {
                         Err(IntoTypeError::DoesNotExist(name, loc)) => {
                             errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
                             Type::Error
+                        },
+                        Err(IntoTypeError::NotAType(name, loc)) => {
+                            errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
+                            Type::Error
                         }
                     }
                 }) {t} else {
@@ -822,6 +862,10 @@ impl AST for MutDefAST {
                                 },
                                 Err(IntoTypeError::DoesNotExist(name, loc)) => {
                                     errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                                    Type::Error
+                                },
+                                Err(IntoTypeError::NotAType(name, loc)) => {
+                                    errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
                                     Type::Error
                                 }
                             }
@@ -883,6 +927,10 @@ impl AST for MutDefAST {
                                 },
                                 Err(IntoTypeError::DoesNotExist(name, loc)) => {
                                     errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                                    Type::Error
+                                },
+                                Err(IntoTypeError::NotAType(name, loc)) => {
+                                    errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
                                     Type::Error
                                 }
                             }
@@ -948,6 +996,10 @@ impl AST for MutDefAST {
                             },
                             Err(IntoTypeError::DoesNotExist(name, loc)) => {
                                 errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                                Type::Error
+                            },
+                            Err(IntoTypeError::NotAType(name, loc)) => {
+                                errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
                                 Type::Error
                             }
                         }
@@ -1017,6 +1069,10 @@ impl AST for MutDefAST {
                     },
                     Err(IntoTypeError::DoesNotExist(name, loc)) => {
                         errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                        Type::Error
+                    },
+                    Err(IntoTypeError::NotAType(name, loc)) => {
+                        errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
                         Type::Error
                     }
                 }
@@ -1119,6 +1175,10 @@ impl AST for ConstDefAST {
                 },
                 Err(IntoTypeError::DoesNotExist(name, loc)) => {
                     errs.push(Diagnostic::error(loc, 320, Some(format!("{name} does not exist"))));
+                    Type::Error
+                },
+                Err(IntoTypeError::NotAType(name, loc)) => {
+                    errs.push(Diagnostic::error(loc, 326, Some(format!("{name} is not a type"))));
                     Type::Error
                 }
             }

--- a/src/cobalt/errors/info.rs
+++ b/src/cobalt/errors/info.rs
@@ -109,7 +109,8 @@ pub static ERR_REGISTRY: &[(u64, &[Option<ErrorInfo>])] = &[
     /*322*/ ErrorInfo::new("value is not a variable", ""),
     /*323*/ ErrorInfo::new("redefinition of variable", ""),
     /*324*/ ErrorInfo::new("value cannot be determined at compile-time", ""),
-    /*325*/ ErrorInfo::new("redefinition of values in module", "")]),
+    /*325*/ ErrorInfo::new("redefinition of values in module", ""),
+    /*326*/ ErrorInfo::new("value is not a type", "")]),
     (390, &[
     /*390*/ ErrorInfo::new("unknown literal suffix", ""),
     /*391*/ ErrorInfo::new("unknown intrinisc", ""),

--- a/src/cobalt/parsed_type.rs
+++ b/src/cobalt/parsed_type.rs
@@ -77,7 +77,7 @@ impl ParsedType {
                 ctx.is_const.set(old_const);
                 return (Ok(var.data_type), errs);
             },
-            Other(name) => match ctx.with_vars(|v| v.lookup(name)) {
+            Other(name) => match ctx.lookup(name) {
                 Ok(s) => match s {
                     Symbol::Variable(v, _) => if let Some(Value {data_type: Type::TypeData, inter_val: Some(InterData::Type(t)), ..}) = types::utils::impl_convert(v.clone(), Type::TypeData, ctx) {Ok(*t)} else {
                         let (n, l) = name.ids.last().cloned().unwrap_or((String::new(), (0, 0..0)));

--- a/src/cobalt/parser/lexer.rs
+++ b/src/cobalt/parser/lexer.rs
@@ -631,7 +631,7 @@ pub fn lex(data: &str, mut loc: (FileId, usize), flags: &Flags) -> (Vec<Token>, 
                     if flags.up {loc.1 += len};
                 }
                 outs.push(Token::new((loc.0, start..(loc.1 + 1)), match s.as_str() {
-                    "let" | "mut" | "const" | "fn" | "cr" | "module" | "import" => Statement(s),
+                    "let" | "mut" | "const" | "fn" | "cr" | "module" | "import" | "type" => Statement(s),
                     "if" | "else" | "while" => Keyword(s),
                     _ => Identifier(s)
                 }));

--- a/src/cobalt/types.rs
+++ b/src/cobalt/types.rs
@@ -194,7 +194,6 @@ impl Type {
             InlineAsm => out.write_all(&[14]),
             Error => panic!("error values shouldn't be serialized!"),
             Module => todo!("Modules can't be stored in variables yet!"),
-            TypeData => todo!("Types can't be stored in variables yet!"),
             Array(b, None) => {
                 out.write_all(&[15])?;
                 b.save(out)
@@ -204,7 +203,8 @@ impl Type {
                 data[1..].copy_from_slice(&s.to_be_bytes());
                 out.write_all(&data)?;
                 b.save(out)
-            }
+            },
+            TypeData => out.write_all(&[17])
         }
     }
     pub fn load<R: Read + BufRead>(buf: &mut R) -> io::Result<Self> {
@@ -248,7 +248,8 @@ impl Type {
                 buf.read_exact(&mut bytes)?;
                 Type::Array(Box::new(Type::load(buf)?), Some(u32::from_be_bytes(bytes)))
             },
-            x => panic!("read type value expecting value in 1..=16, got {x}")
+            17 => Type::TypeData,
+            x => panic!("read type value expecting value in 1..=17, got {x}")
         })
     }
 }

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -866,7 +866,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
             "-" if l == r => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
-                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32);
+                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32 * 8);
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_ptr_to_int(r, pt, "");
                         Some(IntValue(ctx.builder.build_int_sub(v1, v2, "")))
@@ -878,7 +878,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
             "<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
-                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32);
+                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32 * 8);
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_ptr_to_int(r, pt, "");
                         Some(IntValue(ctx.builder.build_int_compare(ULT, v1, v2, "")))
@@ -890,7 +890,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
             ">" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
-                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32);
+                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32 * 8);
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_ptr_to_int(r, pt, "");
                         Some(IntValue(ctx.builder.build_int_compare(UGT, v1, v2, "")))
@@ -902,7 +902,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
             "<=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
-                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32);
+                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32 * 8);
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_ptr_to_int(r, pt, "");
                         Some(IntValue(ctx.builder.build_int_compare(ULE, v1, v2, "")))
@@ -914,7 +914,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
             ">=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
-                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32);
+                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32 * 8);
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_ptr_to_int(r, pt, "");
                         Some(IntValue(ctx.builder.build_int_compare(UGE, v1, v2, "")))
@@ -926,7 +926,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
             "==" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
-                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32);
+                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32 * 8);
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_ptr_to_int(r, pt, "");
                         Some(IntValue(ctx.builder.build_int_compare(EQ, v1, v2, "")))
@@ -938,7 +938,7 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
             "!=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
-                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32);
+                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32 * 8);
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_ptr_to_int(r, pt, "");
                         Some(IntValue(ctx.builder.build_int_compare(NE, v1, v2, "")))

--- a/src/cobalt/varmap.rs
+++ b/src/cobalt/varmap.rs
@@ -134,6 +134,7 @@ impl<'ctx> Value<'ctx> {
     pub fn compiled(comp_val: BasicValueEnum<'ctx>, data_type: Type) -> Self {Value {comp_val: Some(comp_val), inter_val: None, data_type}}
     pub fn interpreted(comp_val: BasicValueEnum<'ctx>, inter_val: InterData, data_type: Type) -> Self {Value {comp_val: Some(comp_val), inter_val: Some(inter_val), data_type}}
     pub fn metaval(inter_val: InterData, data_type: Type) -> Self {Value {comp_val: None, inter_val: Some(inter_val), data_type}}
+    pub fn make_type(type_: Type) -> Self {Value {comp_val: None, inter_val: Some(InterData::Type(Box::new(type_))), data_type: Type::TypeData}}
     pub fn value(&self, ctx: &CompCtx<'ctx>) -> Option<BasicValueEnum<'ctx>> {self.comp_val.clone().or_else(|| self.inter_val.as_ref().and_then(|v| v.into_compiled(ctx)))}
 }
 #[derive(Clone, PartialEq, Eq)]
@@ -450,6 +451,24 @@ impl<'ctx> VarMap<'ctx> {
         self.symbols.iter().for_each(|(k, v)| {
             eprint!("    {k:?}: ");
             v.dump(4);
+        })
+    }
+}
+impl<'ctx> From<HashMap<String, Symbol<'ctx>>> for VarMap<'ctx> {
+    fn from(symbols: HashMap<String, Symbol<'ctx>>) -> Self {
+        VarMap {
+            parent: None,
+            symbols,
+            imports: Vec::new()
+        }
+    }
+}
+impl<'ctx> From<HashMap<String, Symbol<'ctx>>> for Box<VarMap<'ctx>> {
+    fn from(symbols: HashMap<String, Symbol<'ctx>>) -> Self {
+        Box::new(VarMap {
+            parent: None,
+            symbols,
+            imports: Vec::new()
         })
     }
 }


### PR DESCRIPTION
Types are now (kind of) first-class at compile-time. This means that you can do this:
```
const my_type = i32;
fn main(): my_type = 0;
```
In this case, `my_type` is just an alias, and conversions can take place from and to it.
If you want a new type, use `type`:
```
type my_type = i32;
fn main(): my_type = 0 :? my_type;
```
In this case, `my_type` is distinctly different from `i32`, and a bitcast is necessary to cast to and from it.
Commits:
- Added search for types for `ParsedType::into_type`
- Added ability to lookup types
- Completed serialization for types
- Added nominal type to `Type` enum
- Added `TypeDefAST` and changed nominal types to store their identifiers as strings instead of ordinals
- Added parsing for nominal type definitions
- Fixed serialization of nominal types
