### PR TITLE
Remove ambiguous operators

### DIFF
--- a/src/cobalt/parser/ast.rs
+++ b/src/cobalt/parser/ast.rs
@@ -102,9 +102,6 @@ fn parse_type(toks: &[Token], terminators: &'static str, flags: &Flags) -> (Pars
                     "&" => {out = ParsedType::Reference(Box::new(out), true); idx += 2;},
                     "*" => {out = ParsedType::Pointer(Box::new(out), true); idx += 2;},
                     "^" => {out = ParsedType::Borrow(Box::new(out)); idx += 2;},
-                    "&&" => {out = ParsedType::Reference(Box::new(ParsedType::Reference(Box::new(out), true)), true); idx += 2;},
-                    "**" => {out = ParsedType::Pointer(Box::new(ParsedType::Pointer(Box::new(out), true)), true); idx += 2;},
-                    "^^" => {out = ParsedType::Borrow(Box::new(ParsedType::Borrow(Box::new(out)))); idx += 2;},
                     x => {
                         errs.push(Diagnostic::error(toks[idx].loc.clone(), 213, Some(format!("got {x:#}"))));
                         break;
@@ -120,9 +117,6 @@ fn parse_type(toks: &[Token], terminators: &'static str, flags: &Flags) -> (Pars
                     "&" => {out = ParsedType::Reference(Box::new(out), false); idx += 2;},
                     "*" => {out = ParsedType::Pointer(Box::new(out), false); idx += 2;},
                     "^" => {out = ParsedType::Borrow(Box::new(out)); idx += 2;},
-                    "&&" => {out = ParsedType::Reference(Box::new(ParsedType::Reference(Box::new(out), false)), false); idx += 2;},
-                    "**" => {out = ParsedType::Pointer(Box::new(ParsedType::Pointer(Box::new(out), false)), false); idx += 2;},
-                    "^^" => {out = ParsedType::Borrow(Box::new(ParsedType::Borrow(Box::new(out)))); idx += 2;},
                     x => {
                         errs.push(Diagnostic::error(toks[idx].loc.clone(), 213, Some(format!("got {x:#}"))));
                         break;
@@ -137,9 +131,6 @@ fn parse_type(toks: &[Token], terminators: &'static str, flags: &Flags) -> (Pars
                 "&" => {out = ParsedType::Reference(Box::new(out), false); idx += 1;},
                 "*" => {out = ParsedType::Pointer(Box::new(out), false); idx += 1;},
                 "^" => {out = ParsedType::Borrow(Box::new(out)); idx += 1;},
-                "&&" => {out = ParsedType::Reference(Box::new(ParsedType::Reference(Box::new(out), false)), false); idx += 1;},
-                "**" => {out = ParsedType::Pointer(Box::new(ParsedType::Pointer(Box::new(out), false)), false); idx += 1;},
-                "^^" => {out = ParsedType::Borrow(Box::new(ParsedType::Borrow(Box::new(out)))); idx += 1;},
                 x => {
                     errs.push(Diagnostic::error(toks[idx].loc.clone(), 213, Some(format!("unexpected {x:#} in type"))));
                     break;
@@ -501,7 +492,7 @@ fn parse_flow(mut toks: &[Token], flags: &Flags) -> (Box<dyn AST>, Vec<Diagnosti
                             Special(';') => break,
                             Keyword(x) if x == "else" => break,
                             Statement(k) if (k != "const" && k != "mut") || match toks.get(i + 1).and_then(|x| if let Operator(ref x) = x.data {Some(x.as_str())} else {None}).unwrap_or("") {
-                                "&" | "*" | "&&" | "**" | "^" | "^^" => false,
+                                "&" | "*" | "^" => false,
                                 _ => true
                             } => {errs.push(Diagnostic::error(toks[i].loc.clone(), 280, None)); break},
                             Special('(') => {
@@ -1241,7 +1232,7 @@ fn parse_stmts(toks: &[Token], terminators: &'static str, flags: &Flags) -> (Box
             Special(c) if terminators.contains(*c) => break,
             Statement(_) if i == 0 => i += 1,
             Statement(k) if (k != "const" && k != "mut") && match toks.get(i + 1).and_then(|x| if let Operator(ref x) = x.data {Some(x.as_str())} else {None}).unwrap_or("") {
-                "&" | "*" | "&&" | "**" | "^" | "^^" => false,
+                "&" | "*" | "^" => false,
                 _ => true
             } => {errs.push(Diagnostic::error(toks[i].loc.clone(), 280, Some(format!("expected ';', got {k:?}")))); break},
             Special('(') => {
@@ -1298,7 +1289,7 @@ fn parse_expr_nosplit(toks: &[Token], terminators: &'static str, flags: &Flags) 
             Special(c) if terminators.contains(*c) => break,
             Statement(_) if i == 0 => i += 1,
             Statement(k) if (k != "const" && k != "mut") || match toks.get(i + 1).and_then(|x| if let Operator(ref x) = x.data {Some(x.as_str())} else {None}).unwrap_or("") {
-                "&" | "*" | "&&" | "**" | "^" | "^^" => false,
+                "&" | "*" | "^" => false,
                 _ => true
             } => {errs.push(Diagnostic::error(toks[i].loc.clone(), 280, Some(format!("expected ';', got {k:?}")))); break},
             Special('(') => {
@@ -1356,7 +1347,7 @@ fn parse_expr(toks: &[Token], terminators: &'static str, flags: &Flags) -> (Box<
             Special(c) if terminators.contains(*c) => break,
             Statement(_) if i == 0 => i += 1,
             Statement(k) if (k != "const" && k != "mut") || match toks.get(i + 1).and_then(|x| if let Operator(ref x) = x.data {Some(x.as_str())} else {None}).unwrap_or("") {
-                "&" | "*" | "&&" | "**" | "^" | "^^" => false,
+                "&" | "*" | "^" => false,
                 _ => true
             } => {errs.push(Diagnostic::error(toks[i].loc.clone(), 280, Some(format!("expected ';', got {k:?}")))); break},
             Special('(') => {

--- a/src/cobalt/parser/lexer.rs
+++ b/src/cobalt/parser/lexer.rs
@@ -692,8 +692,8 @@ pub fn lex(data: &str, mut loc: (FileId, usize), flags: &Flags) -> (Vec<Token>, 
             },
             '&' | '|' => { // operator of the form @, @=, @?
                 match it.peek() {
-                    Some(&'=') => outs.push(Token::new((loc.0, loc.1..(loc.1 + 2), Operator(format!("{c}=")))),
-                    Some(&'?') => outs.push(Token::new((loc.0, loc.1..(loc.1 + 2), Operator(format!("{c}?")))),
+                    Some(&'=') => {it.next(); outs.push(Token::new((loc.0, loc.1..(loc.1 + 2)), Operator(format!("{c}="))))},
+                    Some(&'?') => {it.next(); outs.push(Token::new((loc.0, loc.1..(loc.1 + 2)), Operator(format!("{c}?"))))},
                     _ => outs.push(Token::new((loc.0, loc.1..(loc.1 + 1)), Operator(c.to_string())))
                 }
             },

--- a/src/cobalt/parser/lexer.rs
+++ b/src/cobalt/parser/lexer.rs
@@ -661,7 +661,7 @@ pub fn lex(data: &str, mut loc: (FileId, usize), flags: &Flags) -> (Vec<Token>, 
                     outs.push(Token::new((loc.0, loc.1..(loc.1 + 1)), Operator(c.to_string())));
                 }
             },
-            '+' | '-' | '&' | '|' | '^' => { // operator of the form @, @@, @=
+            '+' | '-' => { // operator of the form @, @@, @=
                 if let Some(c2) = it.peek() {
                     let c3 = *c2;
                     if c3 == '=' || c3 == c {
@@ -689,6 +689,13 @@ pub fn lex(data: &str, mut loc: (FileId, usize), flags: &Flags) -> (Vec<Token>, 
                     if flags.up {loc.1 += 1;}
                 }
                 outs.push(Token::new((loc.0, (start..(loc.1 + 1))), Operator(s)));
+            },
+            '&' | '|' => { // operator of the form @, @=, @?
+                match it.peek() {
+                    Some(&'=') => outs.push(Token::new((loc.0, loc.1..(loc.1 + 2), Operator(format!("{c}=")))),
+                    Some(&'?') => outs.push(Token::new((loc.0, loc.1..(loc.1 + 2), Operator(format!("{c}?")))),
+                    _ => outs.push(Token::new((loc.0, loc.1..(loc.1 + 1)), Operator(c.to_string())))
+                }
             },
             _ => errs.push(Diagnostic::error((loc.0, loc.1..(loc.1 + 1)), 101, Some(format!("character is {c:?} (U+{:0>4X})", c as u32))))
         }

--- a/src/cobalt/parser/ops.rs
+++ b/src/cobalt/parser/ops.rs
@@ -5,17 +5,17 @@ pub enum OpType {
     Op(&'static str)
 }
 pub const COBALT_BIN_OPS: &[OpType] = &[
-    Op("="), Op("+="), Op("-="), Op("*="), Op("/="), Op("%="), Op("&="), Op("|="), Op("^="), Op("<<="), Op(">>="),  Rtl, 
-    Op("||"),                                                                                                       Ltr, 
-    Op("&&"),                                                                                                       Ltr, 
-    Op("|"),                                                                                                        Ltr, 
-    Op("^"),                                                                                                        Ltr, 
-    Op("&"),                                                                                                        Ltr, 
-    Op("=="), Op("!="),                                                                                             Ltr, 
-    Op("<"), Op(">"), Op("<="), Op(">="),                                                                           Ltr, 
-    Op("<<"), Op(">>"),                                                                                             Ltr, 
-    Op("+"), Op("-"),                                                                                               Ltr, 
-    Op("*"), Op("/"), Op("%"),                                                                                      Ltr, 
+    Op("="), Op("+="), Op("-="), Op("*="), Op("/="), Op("%="), Op("&="), Op("|="), Op("^="), Op("<<="), Op(">>="),  Rtl,
+    Op("|?"),                                                                                                       Ltr,
+    Op("&?"),                                                                                                       Ltr,
+    Op("|"),                                                                                                        Ltr,
+    Op("^"),                                                                                                        Ltr,
+    Op("&"),                                                                                                        Ltr,
+    Op("=="), Op("!="),                                                                                             Ltr,
+    Op("<"), Op(">"), Op("<="), Op(">="),                                                                           Ltr,
+    Op("<<"), Op(">>"),                                                                                             Ltr,
+    Op("+"), Op("-"),                                                                                               Ltr,
+    Op("*"), Op("/"), Op("%"),                                                                                      Ltr,
     Op("^^"),                                                                                                       Rtl
 ];
 pub const COBALT_PRE_OPS: &[&'static str] = &["++", "--", "+", "-", "~", "*", "&", "!"];

--- a/src/cobalt/parser/ops.rs
+++ b/src/cobalt/parser/ops.rs
@@ -15,8 +15,7 @@ pub const COBALT_BIN_OPS: &[OpType] = &[
     Op("<"), Op(">"), Op("<="), Op(">="),                                                                           Ltr,
     Op("<<"), Op(">>"),                                                                                             Ltr,
     Op("+"), Op("-"),                                                                                               Ltr,
-    Op("*"), Op("/"), Op("%"),                                                                                      Ltr,
-    Op("^^"),                                                                                                       Rtl
+    Op("*"), Op("/"), Op("%"),                                                                                      Ltr
 ];
 pub const COBALT_PRE_OPS: &[&'static str] = &["++", "--", "+", "-", "~", "*", "&", "!"];
 pub const COBALT_POST_OPS: &[&'static str] = &["?", "!"];

--- a/src/cobalt/varmap.rs
+++ b/src/cobalt/varmap.rs
@@ -136,6 +136,7 @@ impl<'ctx> Value<'ctx> {
     pub fn metaval(inter_val: InterData, data_type: Type) -> Self {Value {comp_val: None, inter_val: Some(inter_val), data_type}}
     pub fn make_type(type_: Type) -> Self {Value {comp_val: None, inter_val: Some(InterData::Type(Box::new(type_))), data_type: Type::TypeData}}
     pub fn value(&self, ctx: &CompCtx<'ctx>) -> Option<BasicValueEnum<'ctx>> {self.comp_val.clone().or_else(|| self.inter_val.as_ref().and_then(|v| v.into_compiled(ctx)))}
+    pub fn into_value(self, ctx: &CompCtx<'ctx>) -> Option<BasicValueEnum<'ctx>> {self.comp_val.clone().or_else(|| self.inter_val.as_ref().and_then(|v| v.into_compiled(ctx)))}
 }
 #[derive(Clone, PartialEq, Eq)]
 pub struct VariableData {


### PR DESCRIPTION
The lexer had to merge `&&`, `||`, and `^^`, which was a problem when they weren't being used that way.
Now, short-circuiting operators are `&?` and `|?`, and exponentiation will likely be implemented with a function.
Commits:
- Changed `&&` and `||` to `&?` and `|?`
- Implemented short-circuiting operators
- Removed ambiguous double operators
