### PR TITLE
Improve support for first-class types

### DIFF
--- a/src/cobalt/parser/ast.rs
+++ b/src/cobalt/parser/ast.rs
@@ -423,7 +423,7 @@ fn parse_calls(mut toks: &[Token], flags: &Flags) -> (Box<dyn AST>, Vec<Diagnost
             else {
                 let (target, ts) = toks.split_at(idx);
                 toks = &ts[1..(ts.len() - 1)];
-                let (idx, _, mut errs) = parse_expr(toks, "", flags);
+                let (idx, _, mut errs) = if toks.len() == 0 {(Box::new(NullAST::new((ts[0].loc.0, ts[0].loc.1.end..ts[0].loc.1.end))) as Box<dyn AST>, 0usize, vec![])} else {parse_expr(toks, "", flags)};
                 let (target, _, mut es) = parse_expr(target, "", flags);
                 errs.append(&mut es);
                 (Box::new(SubAST::new((target.loc().0, target.loc().1.start..ts.last().unwrap().loc.1.end), target, idx)), errs)
@@ -1208,7 +1208,7 @@ fn parse_binary<'a, F: Clone + for<'r> FnMut(&'r parser::ops::OpType) -> bool>(t
     }
 }
 fn parse_splits(toks: &[Token], flags: &Flags) -> (Box<dyn AST>, Vec<Diagnostic>) {
-    if toks.len() == 0 {return (null(), vec![Diagnostic::error((0, 0..0), 290, None)])}
+    if toks.len() == 0 {return (null(), vec![Diagnostic::error(unsafe {(*toks.as_ptr().offset(-1)).loc.clone()}, 290, None)])}
     let mut start = toks[0].loc.clone();
     start.1.end = toks.last().unwrap().loc.1.end;
     let len = toks.len();

--- a/src/cobalt/parser/ops.rs
+++ b/src/cobalt/parser/ops.rs
@@ -19,4 +19,4 @@ pub const COBALT_BIN_OPS: &[OpType] = &[
     Op("^^"),                                                                                                       Rtl
 ];
 pub const COBALT_PRE_OPS: &[&'static str] = &["++", "--", "+", "-", "~", "*", "&", "!"];
-pub const COBALT_POST_OPS: &[&'static str] = &["?", "!"];
+pub const COBALT_POST_OPS: &[&'static str] = &["?", "!", "^"];

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -508,7 +508,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l + r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), lu && ru)            }),
+                data_type: Type::Int(max(ls, rs), lu && ru)
+            }),
             "-" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_sub(l, r, ""))),
@@ -518,7 +519,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l - r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), lu && ru)            }),
+                data_type: Type::Int(max(ls, rs), lu && ru)
+            }),
             "*" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_mul(l, r, ""))),
@@ -528,7 +530,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l * r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), lu && ru)            }),
+                data_type: Type::Int(max(ls, rs), lu && ru)
+            }),
             "/" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(if ru {ctx.builder.build_int_unsigned_div(l, r, "")} else {ctx.builder.build_int_signed_div(l, r, "")})),
@@ -538,7 +541,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l / r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), ru)            }),
+                data_type: Type::Int(max(ls, rs), ru)
+            }),
             "%" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(if ru {ctx.builder.build_int_unsigned_rem(l, r, "")} else {ctx.builder.build_int_signed_rem(l, r, "")})),
@@ -548,7 +552,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l % r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), ru)            }),
+                data_type: Type::Int(max(ls, rs), ru)
+            }),
             "&" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_and(l, r, ""))),
@@ -558,7 +563,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l & r)),
                     _ => None
                 },
-                data_type: Type::Int(min(ls, rs), lu || ru)            }),
+                data_type: Type::Int(min(ls, rs), lu || ru)
+            }),
             "|" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_or(l, r, ""))),
@@ -568,7 +574,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l | r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), lu || ru)            }),
+                data_type: Type::Int(max(ls, rs), lu || ru)
+            }),
             "^" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_xor(l, r, ""))),
@@ -578,7 +585,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l ^ r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), lu || ru)            }),
+                data_type: Type::Int(max(ls, rs), lu || ru)
+            }),
             ">>" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_left_shift(l, r, ""))),
@@ -588,7 +596,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l << r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), lu || ru)            }),
+                data_type: Type::Int(max(ls, rs), lu || ru)
+            }),
             "<<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_right_shift(l, r, false, ""))),
@@ -598,7 +607,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l >> r)),
                     _ => None
                 },
-                data_type: Type::Int(max(ls, rs), lu || ru)            }),
+                data_type: Type::Int(max(ls, rs), lu || ru)
+            }),
             "<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {ULT} else {SLT}, l, r, ""))),
@@ -608,7 +618,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l < r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             ">" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {UGT} else {SGT}, l, r, ""))),
@@ -618,7 +629,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l > r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             "<=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {ULE} else {SLE}, l, r, ""))),
@@ -628,7 +640,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l <= r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             ">=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {UGE} else {SGE}, l, r, ""))),
@@ -638,7 +651,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l >= r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             "==" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(EQ, l, r, ""))),
@@ -648,7 +662,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l == r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             "!=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(NE, l, r, ""))),
@@ -658,7 +673,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l < r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             "^^" => None, // TODO: implement exponents
             _ => None
         },
@@ -779,7 +795,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l < r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             ">" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(SGT, l, r, ""))),
@@ -789,7 +806,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l > r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             "<=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(SLE, l, r, ""))),
@@ -799,7 +817,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l <= r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             ">=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(SGE, l, r, ""))),
@@ -809,7 +828,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l >= r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             "==" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(EQ, l, r, ""))),
@@ -819,7 +839,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l == r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             "!=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(NE, l, r, ""))),
@@ -829,7 +850,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(if l < r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             _ => None
         },
         (Type::Pointer(b, s), Type::Int(..) | Type::IntLiteral) => match op {
@@ -839,7 +861,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Pointer(b, s)            }),
+                data_type: Type::Pointer(b, s)
+            }),
             "-" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, b.size(), ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) => Some(unsafe {
@@ -849,7 +872,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Pointer(b, s)            }),
+                data_type: Type::Pointer(b, s)
+    }),
             _ => None
         },
         (Type::Int(..) | Type::IntLiteral, Type::Pointer(b, s)) => match op {
@@ -859,7 +883,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Pointer(b, s)            }),
+                data_type: Type::Pointer(b, s)
+            }),
             _ => None
         },
         (l @ Type::Pointer(..), r @ Type::Pointer(..)) => match op {
@@ -874,7 +899,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Int(64, false)            }),
+                data_type: Type::Int(64, false)
+            }),
             "<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
@@ -886,7 +912,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             ">" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
@@ -898,7 +925,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             "<=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
@@ -910,7 +938,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             ">=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
@@ -922,7 +951,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             "==" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
@@ -934,7 +964,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             "!=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
@@ -946,7 +977,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     _ => None
                 },
                 inter_val: None,
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             _ => None
         },
         (l @ (Type::Float16 | Type::Float32 | Type::Float64), r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128)) if l.size() < r.size() => {
@@ -1027,7 +1059,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l.powf(r))),
                     _ => None
                 },
-                data_type: bin_type(l, r, op)            }),
+                data_type: bin_type(l, r, op)
+            }),
             "<" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OLT, l, r, ""))),
@@ -1037,7 +1070,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(if l < r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             ">" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OGT, l, r, ""))),
@@ -1047,7 +1081,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(if l > r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             "<=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OLE, l, r, ""))),
@@ -1057,7 +1092,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(if l <= r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             ">=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OGE, l, r, ""))),
@@ -1067,7 +1103,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(if l >= r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             "==" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OEQ, l, r, ""))),
@@ -1077,7 +1114,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(if l == r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             "!=" => Some(Value {
                 comp_val: match (lhs.comp_val, rhs.comp_val, ctx.is_const.get()) {
                     (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(ONE, l, r, ""))),
@@ -1087,7 +1125,8 @@ pub fn bin_op<'ctx>(mut lhs: Value<'ctx>, mut rhs: Value<'ctx>, op: &str, ctx: &
                     (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(if l != r {1} else {0})),
                     _ => None
                 },
-                data_type: Type::Int(1, false)            }),
+                data_type: Type::Int(1, false)
+            }),
             _ => None
         },
         (l @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128), r @ (Type::IntLiteral | Type::Int(..))) => {
@@ -1276,11 +1315,13 @@ pub fn pre_op<'ctx>(mut val: Value<'ctx>, op: &str, ctx: &CompCtx<'ctx>) -> Opti
             "-" => Some(Value {
                 comp_val: if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(IntValue(ctx.builder.build_int_neg(v, "")))} else {None},
                 inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(-v))} else {None},
-                data_type: Type::Int(s, u)            }),
+                data_type: Type::Int(s, u)
+            }),
             "~" => Some(Value {
                 comp_val: if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(IntValue(ctx.builder.build_xor(v, ctx.context.custom_width_int_type(s as u32).const_all_ones(), "")))} else {None},
                 inter_val: if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(!v))} else {None},
-                data_type: Type::Int(s, u)            }),
+                data_type: Type::Int(s, u)
+            }),
             _ => None
         },
         x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => match op {

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -1360,6 +1360,7 @@ pub fn post_op<'ctx>(val: Value<'ctx>, op: &str, _ctx: &CompCtx<'ctx>) -> Option
             "mut*" => if let Some(InterData::Type(t)) = val.inter_val {Some(Value::make_type(Type::Pointer(t, true)))} else {None},
             "const&" => if let Some(InterData::Type(t)) = val.inter_val {Some(Value::make_type(Type::Reference(t, false)))} else {None},
             "const*" => if let Some(InterData::Type(t)) = val.inter_val {Some(Value::make_type(Type::Pointer(t, false)))} else {None},
+            "^" => if let Some(InterData::Type(t)) = val.inter_val {Some(Value::make_type(Type::Borrow(t)))} else {None},
             _ => None
         },
         _ => None

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -112,6 +112,10 @@ pub fn sub_type(val: Type, idx: Type) -> Type {
                 Type::Array(b, _) => match i {Type::IntLiteral | Type::Int(..) => Type::Reference(b, m), _ => Type::Error},
                 x => sub_type(x, i)
             },
+            Type::TypeData => match i {
+                Type::Int(..) | Type::IntLiteral | Type::Null => Type::TypeData,
+                _ => Type::Error
+            },
             _ => Type::Error
         }
     }
@@ -1524,6 +1528,11 @@ pub fn subscript<'ctx>(mut val: Value<'ctx>, mut idx: Value<'ctx>, ctx: &CompCtx
                         val.data_type = x;
                         subscript(val, idx, ctx)
                     }
+                },
+                Type::TypeData => match idx.data_type {
+                    Type::Null => if let Some(InterData::Type(t)) = val.inter_val {Some(Value::make_type(Type::Array(t, None)))} else {None},
+                    Type::Int(..) | Type::IntLiteral => if let (Some(InterData::Type(t)), Some(InterData::Int(v))) = (val.inter_val, idx.inter_val) {Some(Value::make_type(Type::Array(t, Some(v as u32))))} else {None},
+                    _ => None
                 },
                 _ => None
             }


### PR DESCRIPTION
Types are now fully representable as ASTs. This means that `const` and `type` aliases now allow for the full type to be used, rather than a small subset.
Commits:
- Fixed formatting issue in types/utils.rs
- Allowed empty subscripts
- Partially implemented type suffixes
- Fixed parsing of trailing types
- Added postfix operator for borrows
