### PR TITLE
Generate errors in type utilitiy functions

### DIFF
--- a/src/cobalt/ast/flow.rs
+++ b/src/cobalt/ast/flow.rs
@@ -41,18 +41,16 @@ impl AST for IfAST {
                         Type::Error
                     };
                     ctx.builder.position_at_end(itb);
-                    let err = format!("cannot convert value of type {} to {ty}", if_true.data_type);
-                    let if_true = if let Some(v) = types::utils::impl_convert(if_true, ty.clone(), ctx) {v} else {
-                        errs.push(Diagnostic::error(self.cond.loc(), 311, Some(err)));
+                    let if_true = types::utils::impl_convert(self.if_true.loc(), (if_true, None), (ty.clone(), None), ctx).unwrap_or_else(|e| {
+                        errs.push(e);
                         Value::error()
-                    };
+                    });
                     ctx.builder.build_unconditional_branch(mb);
                     ctx.builder.position_at_end(ifb);
-                    let err = format!("cannot convert value of type {} to {ty}", if_false.data_type);
-                    let if_false= if let Some(v) = types::utils::impl_convert(if_false, ty.clone(), ctx) {v} else {
-                        errs.push(Diagnostic::error(self.cond.loc(), 311, Some(err)));
+                    let if_false = types::utils::impl_convert(self.if_false.as_ref().unwrap().loc(), (if_false, None), (ty.clone(), None), ctx).unwrap_or_else(|e| {
+                        errs.push(e);
                         Value::error()
-                    };
+                    });
                     ctx.builder.build_unconditional_branch(mb);
                     ctx.builder.position_at_end(mb);
                     if let Some(llt) = ty.llvm_type(ctx) {

--- a/src/cobalt/ast/flow.rs
+++ b/src/cobalt/ast/flow.rs
@@ -19,12 +19,11 @@ impl AST for IfAST {
         let mut errs = vec![];
         let (cond, mut es) = self.cond.codegen(ctx);
         errs.append(&mut es);
-        let err = format!("cannot convert value of type {} to i1", cond.data_type);
-        let v = if let Some(v) = types::utils::expl_convert(cond, Type::Int(1, false), ctx) {v} else {
-            errs.push(Diagnostic::error(self.cond.loc(), 312, Some(err)));
-            Value::compiled(ctx.context.custom_width_int_type(1).const_int(0, false).into(), Type::Int(1, false))
-        };
-        if let Some(inkwell::values::BasicValueEnum::IntValue(v)) = v.comp_val {
+        let v = types::utils::expl_convert(self.cond.loc(), (cond, None), (Type::Int(1, false), None), ctx).unwrap_or_else(|e| {
+            errs.push(e);
+            Value::compiled(ctx.context.bool_type().const_int(0, false).into(), Type::Int(1, false))
+        });
+        if let Some(inkwell::values::BasicValueEnum::IntValue(v)) = v.value(ctx) {
             (if let Some(if_false) = self.if_false.as_ref() {
                 if let Some(f) = ctx.builder.get_insert_block().and_then(|bb| bb.get_parent()) {
                     let itb = ctx.context.append_basic_block(f, "if_true");
@@ -130,11 +129,10 @@ impl AST for WhileAST {
             ctx.builder.build_unconditional_branch(cond);
             ctx.builder.position_at_end(cond);
             let (c, mut errs) = self.cond.codegen(ctx);
-            let err = format!("cannot convert value of type {} to i1", c.data_type);
-            let val = types::utils::expl_convert(c, Type::Int(1, false), ctx).and_then(|v| v.value(ctx)).unwrap_or_else(|| {
-                errs.push(Diagnostic::error(self.cond.loc(), 312, Some(err)));
-                ctx.context.custom_width_int_type(1).const_int(0, false).into()
-            });
+            let val = types::utils::expl_convert(self.cond.loc(), (c, None), (Type::Int(1, false), None), ctx).unwrap_or_else(|e| {
+                errs.push(e);
+                Value::compiled(ctx.context.bool_type().const_int(0, false).into(), Type::Int(1, false))
+            }).into_value(ctx).unwrap_or(ctx.context.bool_type().const_int(0, false).into());
             ctx.builder.build_conditional_branch(val.into_int_value(), body, exit);
             ctx.builder.position_at_end(body);
             let (_, mut es) = self.body.codegen(ctx);

--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -299,20 +299,20 @@ impl AST for FnDefAST {
                             defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
                                 let old_const = ctx.is_const.replace(true);
                                 let (val, mut es) = a.codegen(ctx);
-                                let err = format!("cannot convert value of type {} to {t}", val.data_type);
-                                let val = types::utils::impl_convert(val, t.clone(), ctx);
+                                let val = types::utils::impl_convert(a.loc(), (val, None), (t.clone(), None), ctx);
                                 ctx.is_const.set(old_const);
                                 errs.append(&mut es);
-                                if let Some(val) = val {
-                                    if let Some(val) = val.inter_val {val}
-                                    else {
-                                        errs.push(Diagnostic::error(a.loc(), 314, None));
+                                match val {
+                                    Ok(val) => 
+                                        if let Some(val) = val.inter_val {val}
+                                        else {
+                                            errs.push(Diagnostic::error(a.loc(), 314, None));
+                                            InterData::Null
+                                        }
+                                    Err(e) => {
+                                        errs.push(e);
                                         InterData::Null
                                     }
-                                }
-                                else {
-                                    errs.push(Diagnostic::error(a.loc(), 311, Some(err)));
-                                    InterData::Null
                                 }
                             })).collect()
                         })),
@@ -354,11 +354,7 @@ impl AST for FnDefAST {
                         let (body, mut es) = self.body.codegen(ctx);
                         errs.append(&mut es);
                         ctx.map_vars(|v| v.parent.unwrap());
-                        let err = format!("cannot convert value of type {} to {}", body.data_type, *ret);
-                        ctx.builder.build_return(Some(&types::utils::impl_convert(body, (&**ret).clone(), ctx).and_then(|v| v.comp_val).unwrap_or_else(|| {
-                            errs.push(Diagnostic::error(self.body.loc(), 311, Some(err)));
-                            llt.const_zero()
-                        })));
+                        ctx.builder.build_return(Some(&types::utils::impl_convert(self.body.loc(), (body, None), ((&**ret).clone(), None), ctx).map_err(|e| errs.push(e)).ok().and_then(|v| v.value(ctx)).unwrap_or(llt.const_zero())));
                         ctx.restore_scope(old_scope);
                     }
                     var
@@ -371,20 +367,20 @@ impl AST for FnDefAST {
                             defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
                                 let old_const = ctx.is_const.replace(true);
                                 let (val, mut es) = a.codegen(ctx);
-                                let err = format!("cannot convert value of type {} to {t}", val.data_type);
-                                let val = types::utils::impl_convert(val, t.clone(), ctx);
+                                let val = types::utils::impl_convert(a.loc(), (val, None), (t.clone(), None), ctx);
                                 ctx.is_const.set(old_const);
                                 errs.append(&mut es);
-                                if let Some(val) = val {
-                                    if let Some(val) = val.inter_val {val}
-                                    else {
-                                        errs.push(Diagnostic::error(a.loc(), 314, None));
+                                match val {
+                                    Ok(val) => 
+                                        if let Some(val) = val.inter_val {val}
+                                        else {
+                                            errs.push(Diagnostic::error(a.loc(), 314, None));
+                                            InterData::Null
+                                        }
+                                    Err(e) => {
+                                        errs.push(e);
                                         InterData::Null
                                     }
-                                }
-                                else {
-                                    errs.push(Diagnostic::error(a.loc(), 311, Some(err)));
-                                    InterData::Null
                                 }
                             })).collect()
                         })),
@@ -414,20 +410,20 @@ impl AST for FnDefAST {
                             defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
                                 let old_const = ctx.is_const.replace(true);
                                 let (val, mut es) = a.codegen(ctx);
-                                let err = format!("cannot convert value of type {} to {t}", val.data_type);
-                                let val = types::utils::impl_convert(val, t.clone(), ctx);
+                                let val = types::utils::impl_convert(a.loc(), (val, None), (t.clone(), None), ctx);
                                 ctx.is_const.set(old_const);
                                 errs.append(&mut es);
-                                if let Some(val) = val {
-                                    if let Some(val) = val.inter_val {val}
-                                    else {
-                                        errs.push(Diagnostic::error(a.loc(), 314, None));
+                                match val {
+                                    Ok(val) => 
+                                        if let Some(val) = val.inter_val {val}
+                                        else {
+                                            errs.push(Diagnostic::error(a.loc(), 314, None));
+                                            InterData::Null
+                                        }
+                                    Err(e) => {
+                                        errs.push(e);
                                         InterData::Null
                                     }
-                                }
-                                else {
-                                    errs.push(Diagnostic::error(a.loc(), 311, Some(err)));
-                                    InterData::Null
                                 }
                             })).collect()
                         })),
@@ -482,20 +478,20 @@ impl AST for FnDefAST {
                             defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
                                 let old_const = ctx.is_const.replace(true);
                                 let (val, mut es) = a.codegen(ctx);
-                                let err = format!("cannot convert value of type {} to {t}", val.data_type);
-                                let val = types::utils::impl_convert(val, t.clone(), ctx);
+                                let val = types::utils::impl_convert(a.loc(), (val, None), (t.clone(), None), ctx);
                                 ctx.is_const.set(old_const);
                                 errs.append(&mut es);
-                                if let Some(val) = val {
-                                    if let Some(val) = val.inter_val {val}
-                                    else {
-                                        errs.push(Diagnostic::error(a.loc(), 314, None));
+                                match val {
+                                    Ok(val) => 
+                                        if let Some(val) = val.inter_val {val}
+                                        else {
+                                            errs.push(Diagnostic::error(a.loc(), 314, None));
+                                            InterData::Null
+                                        }
+                                    Err(e) => {
+                                        errs.push(e);
                                         InterData::Null
                                     }
-                                }
-                                else {
-                                    errs.push(Diagnostic::error(a.loc(), 311, Some(err)));
-                                    InterData::Null
                                 }
                             })).collect()
                         })),
@@ -511,20 +507,20 @@ impl AST for FnDefAST {
                         defaults: self.params.iter().zip(cloned).filter_map(|((_, _, _, d), (t, _))| d.as_ref().map(|a| {
                             let old_const = ctx.is_const.replace(true);
                             let (val, mut es) = a.codegen(ctx);
-                            let err = format!("cannot convert value of type {} to {t}", val.data_type);
-                            let val = types::utils::impl_convert(val, t.clone(), ctx);
+                            let val = types::utils::impl_convert(a.loc(), (val, None), (t.clone(), None), ctx);
                             ctx.is_const.set(old_const);
                             errs.append(&mut es);
-                            if let Some(val) = val {
-                                if let Some(val) = val.inter_val {val}
-                                else {
-                                    errs.push(Diagnostic::error(a.loc(), 314, None));
+                            match val {
+                                Ok(val) => 
+                                    if let Some(val) = val.inter_val {val}
+                                    else {
+                                        errs.push(Diagnostic::error(a.loc(), 314, None));
+                                        InterData::Null
+                                    }
+                                Err(e) => {
+                                    errs.push(e);
                                     InterData::Null
                                 }
-                            }
-                            else {
-                                errs.push(Diagnostic::error(a.loc(), 311, Some(err)));
-                                InterData::Null
                             }
                         })).collect()
                     })),

--- a/src/cobalt/ast/literals.rs
+++ b/src/cobalt/ast/literals.rs
@@ -255,7 +255,7 @@ impl AST for ArrayLiteralAST {
             errs.push(Diagnostic::error(self.loc(), 300, Some(format!("this array has {} elements, the max is 4294967295", elems.len()))));
             elems.truncate(u32::MAX as usize);
         }
-        let elems = elems.into_iter().filter_map(|v| types::utils::impl_convert(v, ty.clone(), ctx)).collect::<Vec<_>>();
+        let elems = elems.into_iter().enumerate().filter_map(|(n, v)| types::utils::impl_convert(self.vals[n].loc(), (v, None), (ty.clone(), None), ctx).map_err(|e| errs.push(e)).ok()).collect::<Vec<_>>();
         (Value {
             comp_val: if let (Some(llt), false) = (ty.llvm_type(ctx), ctx.is_const.get()) {
                 let arr_ty = llt.array_type(elems.len() as u32);

--- a/src/cobalt/ast/misc.rs
+++ b/src/cobalt/ast/misc.rs
@@ -39,14 +39,10 @@ impl AST for CastAST {
                 Type::Error
             }
         };
-        let l = format!("source type is {}", val.data_type);
-        let r = format!("target type is {t}");
-        let err = format!("cannot convert value of type {} to {t}", val.data_type);
-        if let Some(val) = types::utils::expl_convert(val, t, ctx) {(val, errs)}
-        else {
-            errs.push(Diagnostic::error(self.loc.clone(), 312, Some(err)).note(self.val.loc(), l).note(self.target_loc.clone(), r));
-            (Value::error(), errs)
-        }
+        (types::utils::expl_convert(self.loc.clone(), (val, Some(self.val.loc())), (t, Some(self.target_loc.clone())), ctx).unwrap_or_else(|e| {
+            errs.push(e);
+            Value::error()
+        }), errs)
     }
     fn to_code(&self) -> String {
         format!("{}: {}", self.val.to_code(), self.target)

--- a/src/cobalt/ast/ops.rs
+++ b/src/cobalt/ast/ops.rs
@@ -169,10 +169,8 @@ impl AST for SubAST {
         let (index, mut es) = self.index.codegen(ctx);
         errs.append(&mut es);
         if target.data_type == Type::Error || index.data_type == Type::Error {return (Value::error(), errs)}
-        let t = target.data_type.to_string();
-        let i = index.data_type.to_string();
-        (types::utils::subscript(target, index, ctx).unwrap_or_else(|| {
-            errs.push(Diagnostic::error(self.loc.clone(), 318, None).note(self.target.loc(), format!("target type is {t}")).note(self.index.loc(), format!("index type is {i}")));
+        (types::utils::subscript((target, self.target.loc()), (index, self.index.loc()), ctx).unwrap_or_else(|e| {
+            errs.push(e);
             Value::error()
         }), errs)
     }

--- a/src/cobalt/ast/ops.rs
+++ b/src/cobalt/ast/ops.rs
@@ -85,15 +85,10 @@ impl AST for BinOpAST {
                 let (rhs, mut es) = self.rhs.codegen(ctx);
                 errs.append(&mut es);
                 if lhs.data_type == Type::Error || rhs.data_type == Type::Error {return (Value::error(), errs)}
-                let ln = format!("{}", lhs.data_type);
-                let rn = format!("{}", rhs.data_type);
-                let val = types::utils::bin_op(lhs, rhs, x, ctx);
-                if val.is_none() {
-                    errs.push(Diagnostic::error(self.loc.clone(), 310, Some(format!("binary operator {} is not defined for values of types {ln} and {rn}", self.op)))
-                        .note(self.lhs.loc(), format!("left value is of type {ln}"))
-                        .note(self.rhs.loc(), format!("right value is of type {rn}")));
-                }
-                (val.unwrap_or_else(Value::error), errs)
+                (types::utils::bin_op(self.loc.clone(), (lhs, self.lhs.loc()), (rhs, self.rhs.loc()), x, ctx).unwrap_or_else(|e| {
+                    errs.push(e);
+                    Value::error()
+                }), errs)
             }
         }
     }

--- a/src/cobalt/ast/ops.rs
+++ b/src/cobalt/ast/ops.rs
@@ -117,13 +117,10 @@ impl AST for PostfixAST {
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         let (v, mut errs) = self.val.codegen(ctx);
         if v.data_type == Type::Error {return (Value::error(), errs)}
-        let n = format!("{}", v.data_type);
-        let val = types::utils::post_op(v, self.op.as_str(), ctx);
-        if val.is_none() {
-            errs.push(Diagnostic::error(self.loc.clone(), 310, Some(format!("postfix operator {} is not defined for value of type {n}", self.op)))
-                .note(self.val.loc(), format!("value is of type {n}")));
-        }
-        (val.unwrap_or_else(Value::error), errs)
+        (types::utils::post_op(self.loc.clone(), (v, self.val.loc()), self.op.as_str(), ctx).unwrap_or_else(|e| {
+            errs.push(e);
+            Value::error()
+        }), errs)
     }
     fn to_code(&self) -> String {
         format!("{}{}", self.val.to_code(), self.op)
@@ -149,13 +146,10 @@ impl AST for PrefixAST {
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         let (v, mut errs) = self.val.codegen(ctx);
         if v.data_type == Type::Error {return (Value::error(), errs)}
-        let n = format!("{}", v.data_type);
-        let val = types::utils::pre_op(v, self.op.as_str(), ctx);
-        if val.is_none() {
-            errs.push(Diagnostic::error(self.loc.clone(), 310, Some(format!("prefix operator {} is not defined for value of type {n}", self.op)))
-                .note(self.val.loc(), format!("value is of type {n}")));
-        }
-        (val.unwrap_or_else(Value::error), errs)
+        (types::utils::pre_op(self.loc.clone(), (v, self.val.loc()), self.op.as_str(), ctx).unwrap_or_else(|e| {
+            errs.push(e);
+            Value::error()
+        }), errs)
     }
     fn to_code(&self) -> String {
         format!("{}{}", self.op, self.val.to_code())

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -309,9 +309,8 @@ impl AST for VarDefAST {
                                 x => x
                             }
                         };
-                        let err = format!("cannot convert value of type {} into {dt}", val.data_type);
-                        let val = types::utils::impl_convert(val, dt.clone(), ctx).unwrap_or_else(|| {
-                            errs.push(Diagnostic::error(self.val.loc(), 311, Some(err)));
+                        let val = types::utils::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
+                            errs.push(e);
                             Value::error()
                         });
                         ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(val, VariableData::new(self.loc.clone()))))
@@ -374,9 +373,8 @@ impl AST for VarDefAST {
                                 x => x
                             }
                         };
-                        let err = format!("cannot convert value of type {} into {dt}", val.data_type);
-                        let val = types::utils::impl_convert(val, dt.clone(), ctx).unwrap_or_else(|| {
-                            errs.push(Diagnostic::error(self.val.loc(), 311, Some(err)));
+                        let val = types::utils::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
+                            errs.push(e);
                             Value::error()
                         });
                         ctx.restore_scope(old_scope);
@@ -443,9 +441,8 @@ impl AST for VarDefAST {
                             x => x
                         }
                     };
-                    let err = format!("cannot convert value of type {} into {dt}", val.data_type);
-                    let val = types::utils::impl_convert(val, dt.clone(), ctx).unwrap_or_else(|| {
-                        errs.push(Diagnostic::error(self.val.loc(), 311, Some(err)));
+                    let val = types::utils::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
+                        errs.push(e);
                         Value::error()
                     });
                     ctx.restore_scope(old_scope);
@@ -517,9 +514,8 @@ impl AST for VarDefAST {
                     x => x
                 }
             };
-            let err = format!("cannot convert value of type {} into {dt}", val.data_type);
-            let val = types::utils::impl_convert(val, dt.clone(), ctx).unwrap_or_else(|| {
-                errs.push(Diagnostic::error(self.val.loc(), 311, Some(err)));
+            let val = types::utils::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
+                errs.push(e);
                 Value::error()
             });
             ctx.restore_scope(old_scope);
@@ -879,9 +875,8 @@ impl AST for MutDefAST {
                                 x => x
                             }
                         };
-                        let err = format!("cannot convert value of type {} into {dt}", val.data_type);
-                        let val = types::utils::impl_convert(val, dt.clone(), ctx).unwrap_or_else(|| {
-                            errs.push(Diagnostic::error(self.val.loc(), 311, Some(err)));
+                        let val = types::utils::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
+                            errs.push(e);
                             Value::error()
                         });
                         ctx.with_vars(|v| v.insert(&self.name, Symbol::Variable(val, VariableData::new(self.loc.clone()))))
@@ -944,9 +939,8 @@ impl AST for MutDefAST {
                                 x => x
                             }
                         };
-                        let err = format!("cannot convert value of type {} into {dt}", val.data_type);
-                        let val = types::utils::impl_convert(val, dt.clone(), ctx).unwrap_or_else(|| {
-                            errs.push(Diagnostic::error(self.val.loc(), 311, Some(err)));
+                        let val = types::utils::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
+                            errs.push(e);
                             Value::error()
                         });
                         ctx.restore_scope(old_scope);
@@ -1013,9 +1007,8 @@ impl AST for MutDefAST {
                             x => x
                         }
                     };
-                    let err = format!("cannot convert value of type {} into {dt}", val.data_type);
-                    let val = types::utils::impl_convert(val, dt.clone(), ctx).unwrap_or_else(|| {
-                        errs.push(Diagnostic::error(self.val.loc(), 311, Some(err)));
+                    let val = types::utils::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
+                        errs.push(e);
                         Value::error()
                     });
                     ctx.restore_scope(old_scope);
@@ -1086,9 +1079,8 @@ impl AST for MutDefAST {
                     x => x
                 }
             };
-            let err = format!("cannot convert value of type {} into {dt}", val.data_type);
-            let val = types::utils::impl_convert(val, dt.clone(), ctx).unwrap_or_else(|| {
-                errs.push(Diagnostic::error(self.val.loc(), 311, Some(err)));
+            let val = types::utils::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
+                errs.push(e);
                 Value::error()
             });
             ctx.restore_scope(old_scope);
@@ -1192,9 +1184,8 @@ impl AST for ConstDefAST {
                 x => x
             }
         };
-        let err = format!("cannot convert value of type {} into {dt}", val.data_type);
-        let val = types::utils::impl_convert(val, dt.clone(), ctx).unwrap_or_else(|| {
-            errs.push(Diagnostic::error(self.val.loc(), 311, Some(err)));
+        let val = types::utils::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
+            errs.push(e);
             Value::error()
         });
         ctx.restore_scope(old_scope);

--- a/src/cobalt/parsed_type.rs
+++ b/src/cobalt/parsed_type.rs
@@ -65,7 +65,7 @@ impl ParsedType {
                 let (var, mut es) = size.codegen(ctx);
                 errs.append(&mut es);
                 let err = format!("{}", var.data_type);
-                let var = types::utils::impl_convert(var, Type::Int(64, false), ctx);
+                let var = types::utils::impl_convert((0, 0..0), (var, None), (Type::Int(64, false), None), ctx).ok();
                 ctx.is_const.set(old_const);
                 return (if var.is_none() {Err(IntoTypeError::NotAnInt(err, size.loc()))}
                 else if let Some(InterData::Int(val)) = var.unwrap().inter_val {Ok(Type::Array(Box::new(base), Some(val as u32)))}
@@ -79,7 +79,7 @@ impl ParsedType {
             },
             Other(name) => match ctx.lookup(name) {
                 Ok(s) => match s {
-                    Symbol::Variable(v, _) => if let Some(Value {data_type: Type::TypeData, inter_val: Some(InterData::Type(t)), ..}) = types::utils::impl_convert(v.clone(), Type::TypeData, ctx) {Ok(*t)} else {
+                    Symbol::Variable(v, _) => if let Ok(Value {data_type: Type::TypeData, inter_val: Some(InterData::Type(t)), ..}) = types::utils::impl_convert((0, 0..0), (v.clone(), None), (Type::TypeData, None), ctx) {Ok(*t)} else {
                         let (n, l) = name.ids.last().cloned().unwrap_or((String::new(), (0, 0..0)));
                         Err(IntoTypeError::NotAType(n, l))
                     },


### PR DESCRIPTION
Rather than generating error strings before a conversion and matching the result, it's a lot simpler to generate the errors in the function itself and then add an `unwrap_or_else` or `map_err`.
Commits:
- Began conversion to `types::utils` functions returning `Result` instead of `Option`
- Continued change by refactoring `pre_op` and `post_op`
- Changed `expl_convert` to return a `Result`
- Continued by changing `expl_convert`
- Continued the pattern with subscripts
