### PR TITLE
Improve import semantics

### DIFF
--- a/src/cobalt/ast/scope.rs
+++ b/src/cobalt/ast/scope.rs
@@ -160,7 +160,11 @@ impl AST for ImportAST {
             }
         }
         if target_match == 0 {return (Value::null(), errs)}
-        ctx.with_vars(|v| v.imports.push((self.name.clone(), vis_spec.map_or(ctx.export.get(), |(v, _)| v))));
+        ctx.with_vars(|v| {
+            let vec = v.verify(&self.name);
+            errs.extend(vec.into_iter().map(|l| Diagnostic::warning(l, 90, None)));
+            v.imports.push((self.name.clone(), vis_spec.map_or(ctx.export.get(), |(v, _)| v)))
+        });
         (Value::null(), errs)
     }
     fn to_code(&self) -> String {

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -1141,11 +1141,11 @@ impl VarGetAST {
 impl AST for VarGetAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
-        if let Some(Symbol(x, _)) = ctx.lookup_one(&self.name, &self.loc, self.global) {x.data_type.clone()}
+        if let Some(Symbol(x, _)) = ctx.lookup(&self.name, self.global) {x.data_type.clone()}
         else {Type::Error}
     }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
-        match ctx.lookup_one(&self.name, &self.loc, self.global) {
+        match ctx.lookup(&self.name, self.global) {
             Some(Symbol(x, _)) => (x.clone(), vec![]),
             None => (Value::error(), vec![Diagnostic::error(self.loc.clone(), 320, Some(format!("{} does not exist", self.name)))])
         }

--- a/src/cobalt/context.rs
+++ b/src/cobalt/context.rs
@@ -132,8 +132,8 @@ impl<'ctx> CompCtx<'ctx> {
             out
         }
     }
-    pub fn lookup_one(&self, name: &str, loc: &Location, global: bool) -> Option<&Symbol<'ctx>> {
-        self.with_vars(|v| v.lookup_one(name, loc, global)).or_else(|| match name {
+    pub fn lookup(&self, name: &str, global: bool) -> Option<&Symbol<'ctx>> {
+        self.with_vars(|v| v.lookup(name, global)).or_else(|| match name {
             x if x.as_bytes()[0] == 0x69 && x[1..].chars().all(char::is_numeric) => Some(self.get_int_symbol(x[1..].parse().unwrap_or(64), false)),
             x if x.as_bytes()[0] == 0x75 && x[1..].chars().all(char::is_numeric) => Some(self.get_int_symbol(x[1..].parse().unwrap_or(64), true)),
             _ => None

--- a/src/cobalt/dottedname.rs
+++ b/src/cobalt/dottedname.rs
@@ -33,6 +33,13 @@ pub enum CompoundDottedNameSegment {
     Group(Vec<Vec<CompoundDottedNameSegment>>)
 }
 impl CompoundDottedNameSegment {
+    pub fn ends_with(&self, name: &str) -> bool {
+        match self {
+            Self::Identifier(n, _) => n == name,
+            Self::Glob(_) => true,
+            Self::Group(v) => v.iter().any(|v| if let Some(s) = v.last() {s.ends_with(name)} else {false})
+        }
+    }
     pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {
         use CompoundDottedNameSegment::*;
         match self {
@@ -112,6 +119,7 @@ impl CompoundDottedName {
     pub fn absolute(ids: Vec<CompoundDottedNameSegment>) -> Self {Self::new(ids, true)}
     pub fn relative(ids: Vec<CompoundDottedNameSegment>) -> Self {Self::new(ids, false)}
     pub fn local(id: CompoundDottedNameSegment) -> Self {Self::new(vec![id], false)}
+    pub fn ends_with(&self, name: &str) -> bool {if let Some(s) = self.ids.last() {s.ends_with(name)} else {false}}
     pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {
         out.write_all(&[if self.global {2} else {1}])?;
         self.ids.iter().try_for_each(|i| i.save(out))?;

--- a/src/cobalt/errors/info.rs
+++ b/src/cobalt/errors/info.rs
@@ -17,7 +17,7 @@ pub static ERR_REGISTRY: &[(u64, &[Option<ErrorInfo>])] = &[
     /*031*/ ErrorInfo::new("respecifying @static does nothing", ""),
     /*032*/ ErrorInfo::new("respecifying @extern does nothing", "")]),
     (90, &[
-    /*090*/ ErrorInfo::new("value has been moved from and is in an indeterminate state", "")]),
+    /*090*/ ErrorInfo::new("import does not refer to anything", "")]),
     (101, &[
     /*101*/ ErrorInfo::new("invalid character in source file", ""),
     /*102*/ ErrorInfo::new("unterminated multiline comment", include_str!("help/E0102.md")),


### PR DESCRIPTION
Changes:
- Transitive imports are possible. For example, this works:
  ```
  module a {
    module b {
      let c = 0; # a.b.c
    }
    import b.c; # now accessible as a.c
  }
  import a.c; # this didn't work before
  let d = c;
  ```
  - Note that a module can't import from *parent* directories, so the following code does not work:
    ```
    module a {
      let c = 0;
    }
    module b {
      import a.c; # Either add `import .*` before this or change it `import .a.c;`
    }
    let d = b.c;
    ```
- Imports now give errors if they don't refer to anything.
Commits:
- Rewrote import resolution code, allowing transitive imports
- Changed `VarMap::root` to not reference builtin scope
- Added check that imports actually refer to something
