### PR TITLE
Change intrinsics to use ASTs as arguments

### DIFF
--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -647,7 +647,7 @@ impl AST for IntrinsicAST {
                                     Value {inter_val: Some(InterData::Str(b)), ..}
                                 ) => (Value::metaval(InterData::InlineAsm(c, b), Type::InlineAsm(Box::new(Type::Null))), errs),
                                 (a0, a1) => {
-                                    errs.push(Diagnostic::error(self.loc.clone(), 1000, None)
+                                    errs.push(Diagnostic::error(self.loc.clone(), 430, None)
                                         .note(self.args[0].loc(), format!("first argument type is {} ({})", a0.data_type, if a0.inter_val.is_some() {"constant"} else {"runtime-only"}))
                                         .note(self.args[1].loc(), format!("second argument type is {} ({})", a1.data_type, if a1.inter_val.is_some() {"constant"} else {"runtime-only"}))
                                         .info("both arguments should be constant strings (i8 const*)".to_string()));
@@ -656,7 +656,7 @@ impl AST for IntrinsicAST {
                             }
                         }
                         else {
-                            errs.push(Diagnostic::error(self.loc.clone(), 1000, None)
+                            errs.push(Diagnostic::error(self.loc.clone(), 430, None)
                                 .note(self.args[0].loc(), format!("first argument type is {} ({})", a0.data_type, if a0.inter_val.is_some() {"constant"} else {"runtime-only"}))
                                 .note(self.args[1].loc(), format!("second argument type is {} ({})", a1.data_type, if a1.inter_val.is_some() {"constant"} else {"runtime-only"}))
                                 .info("both arguments should be constant strings (i8 const*)".to_string()));
@@ -675,7 +675,7 @@ impl AST for IntrinsicAST {
                                         Value {inter_val: Some(InterData::Str(b)), ..}
                                     ) => (Value::metaval(InterData::InlineAsm(c, b), Type::InlineAsm(r)), errs),
                                     (a1, a2) => {
-                                        errs.push(Diagnostic::error(self.loc.clone(), 1000, None)
+                                        errs.push(Diagnostic::error(self.loc.clone(), 430, None)
                                             .note(self.args[1].loc(), format!("second argument type is {} ({})", a1.data_type, if a1.inter_val.is_some() {"constant"} else {"runtime-only"}))
                                             .note(self.args[2].loc(), format!("third argument type is {} ({})", a2.data_type, if a2.inter_val.is_some() {"constant"} else {"runtime-only"}))
                                             .info("arguments should be a type, then two constant strings (i8 const*)".to_string()));
@@ -684,7 +684,7 @@ impl AST for IntrinsicAST {
                                 }
                             }
                             else {
-                                errs.push(Diagnostic::error(self.loc.clone(), 1000, None)
+                                errs.push(Diagnostic::error(self.loc.clone(), 430, None)
                                     .note(self.args[1].loc(), format!("second argument type is {} ({})", a1.data_type, if a1.inter_val.is_some() {"constant"} else {"runtime-only"}))
                                     .note(self.args[2].loc(), format!("third argument type is {} ({})", a2.data_type, if a2.inter_val.is_some() {"constant"} else {"runtime-only"}))
                                     .info("arguments should be a type, then two constant strings (i8 const*)".to_string()));
@@ -692,7 +692,7 @@ impl AST for IntrinsicAST {
                             }
                         }
                         else {
-                            errs.push(Diagnostic::error(self.loc.clone(), 1000, None)
+                            errs.push(Diagnostic::error(self.loc.clone(), 430, None)
                                 .note(self.args[0].loc(), format!("first argument type is {} ({})", a0.data_type, if a0.inter_val.is_some() {"constant"} else {"runtime-only"}))
                                 .note(self.args[1].loc(), format!("second argument type is {} ({})", a1.data_type, if a1.inter_val.is_some() {"constant"} else {"runtime-only"}))
                                 .note(self.args[2].loc(), format!("third argument type is {} ({})", a2.data_type, if a2.inter_val.is_some() {"constant"} else {"runtime-only"}))
@@ -701,7 +701,7 @@ impl AST for IntrinsicAST {
                         }
                     },
                     x => {
-                        errs.push(Diagnostic::error(self.loc.clone(), 1000, Some(format!("expected 2 or 3 arguments, got {x}")))
+                        errs.push(Diagnostic::error(self.loc.clone(), 430, Some(format!("expected 2 or 3 arguments, got {x}")))
                             .info("acceptable forms are:".to_string())
                             .info("constraint, body".to_string())
                             .info("return, constraint, body".to_string()));
@@ -712,7 +712,7 @@ impl AST for IntrinsicAST {
             "alloca" => {
                 let mut errs = vec![];
                 let mut args = self.args.iter().map(|a| a.codegen_errs(ctx, &mut errs)).collect::<LinkedList<_>>();
-                if args.is_empty() {return (Value::error(), vec![Diagnostic::error(self.loc.clone(), 1004, None)]);}
+                if args.is_empty() {return (Value::error(), vec![Diagnostic::error(self.loc.clone(), 435, None)]);}
                 let ty = if args.front().unwrap().data_type == Type::TypeData {if let Some(InterData::Type(t)) = args.pop_front().unwrap().inter_val {Some(t)} else {None}} else {None};
                 if args.is_empty() {
                     if let Some(ty) = ty {
@@ -720,11 +720,11 @@ impl AST for IntrinsicAST {
                             (Value::compiled(ctx.builder.build_alloca(llt, "").into(), Type::Pointer(ty, true)), vec![])
                         }
                         else {
-                            (Value {comp_val: None, inter_val: None, data_type: Type::Pointer(Box::new(Type::Null), true)}, vec![Diagnostic::error(self.loc.clone(), 1002, Some(format!("type is {}", *ty)))])
+                            (Value {comp_val: None, inter_val: None, data_type: Type::Pointer(Box::new(Type::Null), true)}, vec![Diagnostic::error(self.loc.clone(), 431, Some(format!("type is {}", *ty)))])
                         }
                     }
                     else {
-                        (Value::compiled(ctx.builder.build_alloca(ctx.context.i8_type(), "").into(), Type::Pointer(Box::new(Type::Null), true)), vec![Diagnostic::error(self.loc.clone(), 1001, None)])
+                        unreachable!()
                     }
                 }
                 else {
@@ -756,7 +756,7 @@ impl AST for IntrinsicAST {
                                     break;
                                 },
                                 x => {
-                                    errs.push(Diagnostic::error(self.args[n + usize::from(ty.is_some())].loc(), 1003, Some(format!("argument type is {x}"))));
+                                    errs.push(Diagnostic::error(self.args[n + usize::from(ty.is_some())].loc(), 434, Some(format!("argument type is {x}"))));
                                     break;
                                 }
                             }
@@ -767,7 +767,7 @@ impl AST for IntrinsicAST {
                             (Value::compiled(ctx.builder.build_array_alloca(llt, val.unwrap(), "").into(), Type::Pointer(ty, true)), errs)
                         }
                         else {
-                            errs.push(Diagnostic::error(self.loc.clone(), 1002, Some(format!("type is {}", *ty))));
+                            errs.push(Diagnostic::error(self.loc.clone(), 431, Some(format!("type is {}", *ty))));
                             (Value {comp_val: None, inter_val: None, data_type: Type::Pointer(ty, true)}, errs)
                         }
                     }

--- a/src/cobalt/errors/info.rs
+++ b/src/cobalt/errors/info.rs
@@ -138,10 +138,12 @@ pub static ERR_REGISTRY: &[(u64, &[Option<ErrorInfo>])] = &[
     /*427*/ ErrorInfo::new("error in target glob", ""),
     /*428*/ ErrorInfo::new("invalid visibility specifier", ""),
     /*429*/ ErrorInfo::new("visibility cannot be specified for local variables", ""),
-    /*430*/ ErrorInfo::new("@asm intrinsic requires arguments", ""),
-    /*431*/ ErrorInfo::new("@asm intrinsic requires a constraint, delimited by a semicolon, and a body", ""),
+    /*430*/ ErrorInfo::new("invalid arguments to @asm intrinsic", ""),
+    /*431*/ ErrorInfo::new("@alloca must create runtime type", ""),
     /*432*/ ErrorInfo::new("invalid call to inline assembly", ""),
-    /*433*/ ErrorInfo::new("invalid return specification for @asm intrinsic", "")]),
+    /*433*/ ErrorInfo::new("invalid return specification for @asm intrinsic", ""),
+    /*434*/ ErrorInfo::new("@alloca requires all arguments except for the first to be integral", ""),
+    /*435*/ ErrorInfo::new("@alloca intrinsic requires arguments", "")]),
     (900, &[
     /*900*/ ErrorInfo::new("const function parameters aren't implemented yet", "")])
 ];

--- a/src/cobalt/parser/ast.rs
+++ b/src/cobalt/parser/ast.rs
@@ -152,9 +152,10 @@ fn parse_literals(toks: &[Token], flags: &Flags) -> (Box<dyn AST>, Vec<Diagnosti
             let mut args = vec![];
             while !atoks.is_empty() {
                 let (ast, i, mut es) = parse_expr(atoks, ",", flags);
-                atoks = &atoks[(i - 1)..];
                 errs.append(&mut es);
                 args.push(ast);
+                if i > atoks.len() {break}
+                atoks = &atoks[i..];
             }
             (Box::new(IntrinsicAST::new(toks[0].loc.clone(), name.clone(), args)), errs)
         },

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -2068,7 +2068,7 @@ pub fn call<'ctx>(mut target: Value<'ctx>, loc: Location, cparen: Location, mut 
                 inter_val: None,
                 data_type: *ret            })
         },
-        Type::InlineAsm => if let (Some(InterData::InlineAsm(r, c, b)), false) = (target.inter_val, ctx.is_const.get()) {
+        Type::InlineAsm(r) => if let (Some(InterData::InlineAsm(c, b)), false) = (target.inter_val, ctx.is_const.get()) {
             let mut params = Vec::with_capacity(args.len());
             let mut comp_args = Vec::with_capacity(args.len());
             let suffixes = ["st", "nd", "rd", "th", "th", "th", "th", "th", "th", "th"]; // 1st, 2nd, 3rd, 4th, 5th, 6th, 7th, 8th, 9th, 0th

--- a/src/cobalt/varmap.rs
+++ b/src/cobalt/varmap.rs
@@ -26,7 +26,7 @@ pub enum InterData<'ctx> {
     Str(String),
     Array(Vec<InterData<'ctx>>),
     Function(FnData<'ctx>),
-    InlineAsm(Box<Type>, String, String),
+    InlineAsm(String, String),
     Type(Box<Type>),
     Module(HashMap<String, Symbol<'ctx>>, Vec<(CompoundDottedName, bool)>)
 }
@@ -62,13 +62,12 @@ impl<'ctx> InterData<'ctx> {
                 out.write_all(&v.cconv.to_be_bytes())?;
                 Ok(())
             },
-            InterData::InlineAsm(r, c, b) => {
+            InterData::InlineAsm(c, b) => {
                 out.write_all(&[7])?;
                 out.write_all(c.as_bytes())?;
                 out.write_all(&[0])?;
                 out.write_all(b.as_bytes())?;
-                out.write_all(&[0])?;
-                r.save(out)
+                out.write_all(&[0])
             },
             InterData::Type(t) => {
                 out.write_all(&[8])?;
@@ -134,7 +133,7 @@ impl<'ctx> InterData<'ctx> {
                 let mut body = Vec::new();
                 buf.read_until(0, &mut constraint)?;
                 buf.read_until(0, &mut body)?;
-                Some(InterData::InlineAsm(Box::new(Type::load(buf)?), String::from_utf8(constraint).expect("Inline assmebly constraint should be valid UTF-8"), String::from_utf8(body).expect("Inline assembly should be valid UTF-8")))
+                Some(InterData::InlineAsm(String::from_utf8(constraint).expect("Inline assmebly constraint should be valid UTF-8"), String::from_utf8(body).expect("Inline assembly should be valid UTF-8")))
             },
             8 => Some(InterData::Type(Box::new(Type::load(buf)?))),
             9 => {


### PR DESCRIPTION
Changes:
- Intrinsics can now have more complex expressions, which will allow for them to do more.
- `@asm` takes its arguments as a type and two strings, and they can be more complex in their computation.
- `@alloca` has been added, which can has three flavors:
  - It can take a type and return a typed pointer to an uninitialized value on stack.
  - It can take any number of integers, which are multiplied to get a size in bytes to allocate.
  - These can be combined to dynamically allocate an array on stack.
Commits:
- Changed lexing to also generate tokens for macro body
- Changed `IntrinsicAST` to take ASTs instead of a string
- Fixed parsing for intrinsics
- Changed inline assembly to use expressions
- Added `@alloca` intrinsic
- Filled in placeholder error codes
