### PR TITLE
Fix location-related issues

### DIFF
--- a/src/cobalt/ast/misc.rs
+++ b/src/cobalt/ast/misc.rs
@@ -101,4 +101,18 @@ impl AST for ErrorTypeAST {
     fn to_code(&self) -> String {"<error type>".to_string()}
     fn print_impl(&self, f: &mut std::fmt::Formatter, _pre: &mut TreePrefix) -> std::fmt::Result {writeln!(f, "error type")}
 }
-
+pub struct ParenAST {
+    pub loc: Location,
+    pub base: Box<dyn AST>
+}
+impl ParenAST {
+    pub fn new(loc: Location, base: Box<dyn AST>) -> Self {ParenAST {loc, base}}
+}
+impl AST for ParenAST {
+    fn loc(&self) -> Location {self.loc.clone()}
+    fn is_const(&self) -> bool {self.base.is_const()}
+    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.base.res_type(ctx)}
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {self.base.codegen(ctx)}
+    fn to_code(&self) -> String {format!("({})", self.base.to_code())}
+    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix) -> std::fmt::Result {self.base.print_impl(f, pre)}
+}

--- a/src/cobalt/parser/ast.rs
+++ b/src/cobalt/parser/ast.rs
@@ -103,42 +103,62 @@ fn parse_literals(toks: &[Token], flags: &Flags) -> (Box<dyn AST>, Vec<Diagnosti
         Int(x) => {
             if toks.len() == 1 {return (Box::new(IntLiteralAST::new(toks[0].loc.clone(), *x, None)), vec![])}
             let mut errs = vec![];
-            let suf = if let Identifier(s) = &toks[1].data {Some(s)} else {
+            let mut loc = toks[0].loc.clone();
+            let suf = if let Identifier(s) = &toks[1].data {
+                loc.1.end = toks[1].loc.1.end;
+                Some(s)
+            }
+            else {
                 errs.push(Diagnostic::error(toks[1].loc.clone(), 270, Some(format!("unexpected {:#} after integer literal", toks[1].data))));
                 None
             };
             errs.extend(toks.iter().skip(2).map(|tok| Diagnostic::error(tok.loc.clone(), 270, Some(format!("unexpected {:#} after integer literal", tok.data)))));
-            (Box::new(IntLiteralAST::new(toks[0].loc.clone(), *x, suf.map(|suf| (suf.clone(), toks[1].loc.clone())))), errs)
+            (Box::new(IntLiteralAST::new(loc, *x, suf.map(|suf| (suf.clone(), toks[1].loc.clone())))), errs)
         },
         Float(x) => {
             if toks.len() == 1 {return (Box::new(FloatLiteralAST::new(toks[0].loc.clone(), *x, None)), vec![])}
             let mut errs = vec![];
-            let suf = if let Identifier(s) = &toks[1].data {Some(s)} else {
+            let mut loc = toks[0].loc.clone();
+            let suf = if let Identifier(s) = &toks[1].data {
+                loc.1.end = toks[1].loc.1.end;
+                Some(s)
+            }
+            else {
                 errs.push(Diagnostic::error(toks[1].loc.clone(), 270, Some(format!("unexpected {:#} after floating-point literal", toks[1].data))));
                 None
             };
             errs.extend(toks.iter().skip(2).map(|tok| Diagnostic::error(tok.loc.clone(), 270, Some(format!("unexpected {:#} after floating-point literal", tok.data)))));
-            (Box::new(FloatLiteralAST::new(toks[0].loc.clone(), *x, suf.map(|suf| (suf.clone(), toks[1].loc.clone())))), errs)
+            (Box::new(FloatLiteralAST::new(loc, *x, suf.map(|suf| (suf.clone(), toks[1].loc.clone())))), errs)
         },
         Char(x) => {
             if toks.len() == 1 {return (Box::new(CharLiteralAST::new(toks[0].loc.clone(), *x, None)), vec![])}
             let mut errs = vec![];
-            let suf = if let Identifier(s) = &toks[1].data {Some(s)} else {
-                errs.push(Diagnostic::error(toks[1].loc.clone(), 270, Some(format!("unexpected {:#} after integer literal", toks[1].data))));
+            let mut loc = toks[0].loc.clone();
+            let suf = if let Identifier(s) = &toks[1].data {
+                loc.1.end = toks[1].loc.1.end;
+                Some(s)
+            }
+            else {
+                errs.push(Diagnostic::error(toks[1].loc.clone(), 270, Some(format!("unexpected {:#} after character literal", toks[1].data))));
                 None
             };
             errs.extend(toks.iter().skip(2).map(|tok| Diagnostic::error(tok.loc.clone(), 270, Some(format!("unexpected {:#} after character literal", tok.data)))));
-            (Box::new(CharLiteralAST::new(toks[0].loc.clone(), *x, suf.map(|suf| (suf.clone(), toks[1].loc.clone())))), errs)
+            (Box::new(CharLiteralAST::new(loc, *x, suf.map(|suf| (suf.clone(), toks[1].loc.clone())))), errs)
         },
         Str(x) => {
             if toks.len() == 1 {return (Box::new(StringLiteralAST::new(toks[0].loc.clone(), x.clone(), None)), vec![])}
             let mut errs = vec![];
-            let suf = if let Identifier(s) = &toks[1].data {Some(s)} else {
+            let mut loc = toks[0].loc.clone();
+            let suf = if let Identifier(s) = &toks[1].data {
+                loc.1.end = toks[1].loc.1.end;
+                Some(s)
+            }
+            else {
                 errs.push(Diagnostic::error(toks[1].loc.clone(), 270, Some(format!("unexpected {:#} after integer literal", toks[1].data))));
                 None
             };
             errs.extend(toks.iter().skip(2).map(|tok| Diagnostic::error(tok.loc.clone(), 270, Some(format!("unexpected {:#} after string literal", tok.data)))));
-            (Box::new(StringLiteralAST::new(toks[0].loc.clone(), x.clone(), suf.map(|suf| (suf.clone(), toks[1].loc.clone())))), errs)
+            (Box::new(StringLiteralAST::new(loc, x.clone(), suf.map(|suf| (suf.clone(), toks[1].loc.clone())))), errs)
         },
         Identifier(x) if x == "null" => (Box::new(NullAST::new(toks[0].loc.clone())), toks.iter().skip(1).map(|tok| Diagnostic::error(tok.loc.clone(), 273, Some(format!("unexpected {:#} after null", tok.data)))).collect()),
         Identifier(name) => (Box::new(VarGetAST::new(toks[0].loc.clone(), name.clone(), false)), toks.iter().skip(1).map(|tok| Diagnostic::error(tok.loc.clone(), 273, Some(format!("got {:#}", tok.data)))).collect()),

--- a/src/cobalt/parser/ast.rs
+++ b/src/cobalt/parser/ast.rs
@@ -185,11 +185,13 @@ fn parse_literals(toks: &[Token], flags: &Flags) -> (Box<dyn AST>, Vec<Diagnosti
 fn parse_groups(mut toks: &[Token], flags: &Flags) -> (Box<dyn AST>, Vec<Diagnostic>) {
     match toks.get(0).map(|x| &x.data) {
         Some(Special('(')) => {
+            let mut loc = toks[0].loc.clone();
+            loc.1.end = toks.last().unwrap().loc.1.end;
             if toks.last().unwrap().data == Special(')') {toks = &toks[..(toks.len() - 1)];}
             toks = &toks[1..];
             if toks.is_empty() {return (Box::new(NullAST::new(unsafe {(*toks.as_ptr().offset(-1)).loc.clone()})), vec![])}
             let (ast, _, errs) = parse_expr(toks, "", flags);
-            (ast, errs)
+            (Box::new(ParenAST::new(loc, ast)), errs)
         },
         Some(Special('{')) => {
             let mut start = toks[0].loc.clone();

--- a/src/cobalt/parser/lexer.rs
+++ b/src/cobalt/parser/lexer.rs
@@ -686,10 +686,12 @@ pub fn lex(data: &str, mut loc: (FileId, usize), flags: &Flags) -> (Vec<Token>, 
                 let mut s = c.to_string();
                 if it.peek() == Some(&c) {
                     s.push(c);
+                    it.next();
                     if flags.up {loc.1 += 1;}
                 }
                 if it.peek() == Some(&'=') {
                     s.push('=');
+                    it.next();
                     if flags.up {loc.1 += 1;}
                 }
                 outs.push(Token::new((loc.0, (start..(loc.1 + 1))), Operator(s)));

--- a/src/cobalt/parser/lexer.rs
+++ b/src/cobalt/parser/lexer.rs
@@ -698,8 +698,8 @@ pub fn lex(data: &str, mut loc: (FileId, usize), flags: &Flags) -> (Vec<Token>, 
             },
             '&' | '|' => { // operator of the form @, @=, @?
                 match it.peek() {
-                    Some(&'=') => {it.next(); outs.push(Token::new((loc.0, loc.1..(loc.1 + 2)), Operator(format!("{c}="))))},
-                    Some(&'?') => {it.next(); outs.push(Token::new((loc.0, loc.1..(loc.1 + 2)), Operator(format!("{c}?"))))},
+                    Some(&'=') => {it.next(); if flags.up {loc.1 += 1;} outs.push(Token::new((loc.0, loc.1..(loc.1 + 2)), Operator(format!("{c}="))))},
+                    Some(&'?') => {it.next(); if flags.up {loc.1 += 1;} outs.push(Token::new((loc.0, loc.1..(loc.1 + 2)), Operator(format!("{c}?"))))},
                     _ => outs.push(Token::new((loc.0, loc.1..(loc.1 + 1)), Operator(c.to_string())))
                 }
             },


### PR DESCRIPTION
Changes:
- Lexer issues:
  - With `<<`, `<=`, `<<=`, and their right-angled counterparts, the iterator wasn't incremented, leading to characters being duplicated.
  - With `&?` and `|?`, the location wasn't updated.
- Literals now include the location of their suffix.
- Parentheses add another AST node with updated location.
Commits:
- Fix lexer causing problems with `<<`, `<=`, `<<=`, `>>`, `>=`, and `>>=`
- Fix parser messing up locations with `&?` and `|?`
- Include suffix in location of literals
- Add transparent AST node to change location of node
