### PR TITLE
Add tuples

### DIFF
--- a/src/cobalt/ast.rs
+++ b/src/cobalt/ast.rs
@@ -19,6 +19,7 @@ impl Display for TreePrefix {
 pub trait AST {
     fn loc(&self) -> Location;
     fn is_const(&self) -> bool {false}
+    fn expl_type<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> bool {false}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type;
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>);
     fn to_code(&self) -> String;

--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -573,11 +573,7 @@ impl CallAST {
 impl AST for CallAST {
     fn loc(&self) -> Location {(self.loc.0, self.loc.1.start..self.cparen.1.end)}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
-        match self.target.res_type(ctx) {
-            Type::Function(ret, _) => *ret,
-            Type::InlineAsm(b) => *b,
-            _ => Type::Error
-        }
+        types::utils::call_type(self.target.res_type(ctx), self.args.iter().map(|a| a.const_codegen(ctx).0).collect::<Vec<_>>())
     }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         let (val, mut errs) = self.target.codegen(ctx);

--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -572,6 +572,7 @@ impl CallAST {
 }
 impl AST for CallAST {
     fn loc(&self) -> Location {(self.loc.0, self.loc.1.start..self.cparen.1.end)}
+    fn expl_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> bool {matches!(self.target.res_type(ctx), Type::InlineAsm(..))}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
         types::utils::call_type(self.target.res_type(ctx), self.args.iter().map(|a| a.const_codegen(ctx).0).collect::<Vec<_>>())
     }

--- a/src/cobalt/ast/literals.rs
+++ b/src/cobalt/ast/literals.rs
@@ -310,15 +310,20 @@ impl AST for ArrayLiteralAST {
     }
 }
 pub struct TupleLiteralAST {
-    pub start: Location,
-    pub end: Location,
-    pub vals: Vec<Box<dyn AST>>,
+    pub vals: Vec<Box<dyn AST>>
 }
 impl TupleLiteralAST {
-    pub fn new(start: Location, end: Location, vals: Vec<Box<dyn AST>>) -> Self {TupleLiteralAST {start, end, vals}}
+    pub fn new(vals: Vec<Box<dyn AST>>) -> Self {
+        assert_ne!(vals.len(), 0);
+        TupleLiteralAST {vals}
+    }
 }
 impl AST for TupleLiteralAST {
-    fn loc(&self) -> Location {(self.start.0, self.start.1.start..self.end.1.end)}
+    fn loc(&self) -> Location {
+        let start = self.vals.first().unwrap().loc();
+        let end = self.vals.last().unwrap().loc();
+        (start.0, start.1.start..end.1.end)
+    }
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
         Type::Tuple(self.vals.iter().map(|x| x.res_type(ctx)).collect())
     }

--- a/src/cobalt/ast/misc.rs
+++ b/src/cobalt/ast/misc.rs
@@ -9,6 +9,7 @@ impl CastAST {
 }
 impl AST for CastAST {
     fn loc(&self) -> Location {(self.target.loc().0, self.val.loc().1.start..self.target.loc().1.end)}
+    fn expl_type<'ctx>(&self, _: &CompCtx<'ctx>) -> bool {true}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {if let Some(InterData::Type(ty)) = types::utils::impl_convert((0, 0..0), (self.target.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(|t| t.inter_val) {*ty} else {Type::Error}}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         let (val, mut errs) = self.val.codegen(ctx);
@@ -40,6 +41,7 @@ impl BitCastAST {
 }
 impl AST for BitCastAST {
     fn loc(&self) -> Location {(self.target.loc().0, self.val.loc().1.start..self.target.loc().1.end)}
+    fn expl_type<'ctx>(&self, _: &CompCtx<'ctx>) -> bool {true}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {if let Some(InterData::Type(ty)) = types::utils::impl_convert((0, 0..0), (self.target.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(|t| t.inter_val) {*ty} else {Type::Error}}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         let (mut val, mut errs) = self.val.codegen(ctx);

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -434,8 +434,11 @@ impl AST for VarDefAST {
                 ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData::with_vis(self.loc.clone(), false))))
             } 
             else if let (Some(t), Some(v)) = (val.data_type.llvm_type(ctx), val.comp_val) {
-                let a = ctx.builder.build_alloca(t, self.name.ids.last().map_or("", |(x, _)| x.as_str()));
-                ctx.builder.build_store(a, v);
+                let a = val.addr(ctx).unwrap_or_else(|| {
+                    let a = ctx.builder.build_alloca(t, self.name.ids.last().map_or("", |(x, _)| x.as_str()));
+                    ctx.builder.build_store(a, v);
+                    a
+                });
                 ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::new(
                     Some(PointerValue(a)),
                     val.inter_val,
@@ -898,8 +901,11 @@ impl AST for MutDefAST {
                 ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData::with_vis(self.loc.clone(), false))))
             } 
             else if let (Some(t), Some(v)) = (val.data_type.llvm_type(ctx), val.comp_val) {
-                let a = ctx.builder.build_alloca(t, self.name.ids.last().map_or("", |(x, _)| x.as_str()));
-                ctx.builder.build_store(a, v);
+                let a = val.addr(ctx).unwrap_or_else(|| {
+                    let a = ctx.builder.build_alloca(t, self.name.ids.last().map_or("", |(x, _)| x.as_str()));
+                    ctx.builder.build_store(a, v);
+                    a
+                });
                 ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::new(
                     Some(PointerValue(a)),
                     val.inter_val,

--- a/src/cobalt/errors/info.rs
+++ b/src/cobalt/errors/info.rs
@@ -114,6 +114,9 @@ pub static ERR_REGISTRY: &[(u64, &[Option<ErrorInfo>])] = &[
     /*326*/ ErrorInfo::new("value is not a type", ""),
     /*327*/ ErrorInfo::new("variable must not have a const-only type", ""),
     /*328*/ ErrorInfo::new("value does not have this attribute", "")]),
+    (380, &[
+    /*380*/ ErrorInfo::new("tuple element access requires a constant index", ""),
+    /*381*/ ErrorInfo::new("tuple index out of bounds", "")]),
     (390, &[
     /*390*/ ErrorInfo::new("unknown literal suffix", ""),
     /*391*/ ErrorInfo::new("unknown intrinisc", ""),

--- a/src/cobalt/types.rs
+++ b/src/cobalt/types.rs
@@ -184,6 +184,7 @@ impl Type {
         match self {
             IntLiteral | Int(_, _) | Char | Float16 | Float32 | Float64 | Float128 | Null | Function(..) | Pointer(..) | Reference(..) => true,
             Borrow(b) => b.register(),
+            Tuple(v) => v.iter().all(Type::register),
             Nominal(n) => NOMINAL_TYPES.read().expect("Value should not be poisoned!")[n].0.register(),
             _ => false
         }
@@ -191,6 +192,7 @@ impl Type {
     pub fn copyable(&self) -> bool {
         match self {
             IntLiteral | Int(_, _) | Char | Float16 | Float32 | Float64 | Float128 | Null | Function(..) | Pointer(..) | Reference(..) | Borrow(_) => true,
+            Tuple(v) => v.iter().all(Type::copyable),
             Nominal(n) => NOMINAL_TYPES.read().expect("Value should not be poisoned!")[n].0.copyable(),
             _ => false
         }

--- a/src/cobalt/types.rs
+++ b/src/cobalt/types.rs
@@ -28,6 +28,16 @@ impl Display for SizeType {
         }
     }
 }
+impl std::ops::Add for SizeType {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        match (self, rhs) {
+            (SizeType::Meta, _) | (_, SizeType::Meta) => SizeType::Meta,
+            (SizeType::Dynamic, _) | (_, SizeType::Dynamic) => SizeType::Dynamic,
+            (SizeType::Static(l), SizeType::Static(r)) => SizeType::Static(l + r)
+        }
+    }
+}
 lazy_static::lazy_static! {
     pub static ref NOMINAL_TYPES: RwLock<HashMap<String, (Type, bool)>> = RwLock::new(HashMap::new());
 }
@@ -39,6 +49,7 @@ pub enum Type {
     Pointer(Box<Type>, bool), Reference(Box<Type>, bool), Borrow(Box<Type>),
     Null, Module, TypeData, InlineAsm(Box<Type>), Array(Box<Type>, Option<u32>),
     Function(Box<Type>, Vec<(Type, bool)>), Nominal(String),
+    Tuple(Vec<Type>),
     Error
 }
 impl Display for Type {
@@ -78,6 +89,15 @@ impl Display for Type {
                 write!(f, "): {}", *ret)
             },
             Nominal(n) => write!(f, "{n}"),
+            Tuple(v) => {
+                write!(f, "(")?;
+                let mut it = v.iter().peekable();
+                while let Some(v) = it.next() {
+                    write!(f, "{v}")?;
+                    if it.peek().is_some() {write!(f, ", ")?;}
+                }
+                write!(f, ")")
+            }
             Error => write!(f, "<error>")
         }
     }
@@ -98,6 +118,14 @@ impl Type {
             Function(..) | Module | TypeData | InlineAsm(_) | Error => Meta,
             Pointer(..) | Reference(..) => Static(8),
             Borrow(b) => b.size(),
+            Tuple(v) => v.iter().fold(Static(0), |v, t| if let Static(bs) = v {
+                let n = t.size();
+                if let Static(ns) = n {
+                    let a = t.align() as u32;
+                    if a == 0 || a == 1 {Static(bs + ns)}
+                    else {Static((bs + a - 1) / a + ns)}
+                } else {n}
+            } else {v}),
             Nominal(n) => NOMINAL_TYPES.read().expect("Value should not be poisoned!")[n].0.size()
         }
     }
@@ -119,6 +147,7 @@ impl Type {
             Function(..) | Module | TypeData | InlineAsm(_) | Error => 0,
             Pointer(..) | Reference(..) => 8,
             Borrow(b) => b.align(),
+            Tuple(v) => v.iter().map(Type::align).max().unwrap_or(1),
             Nominal(n) => NOMINAL_TYPES.read().expect("Value should not be poisoned!")[n].0.align()
         }
     }
@@ -140,6 +169,11 @@ impl Type {
                 b => if b.size() == Static(0) {Some(PointerType(ctx.null_type.ptr_type(Default::default())))} else {Some(PointerType(b.llvm_type(ctx)?.ptr_type(Default::default())))}
             },
             Borrow(b) => b.llvm_type(ctx),
+            Tuple(v) => {
+                let mut vec = Vec::with_capacity(v.len());
+                for t in v {vec.push(t.llvm_type(ctx)?);}
+                Some(ctx.context.struct_type(&vec, false).into())
+            },
             Nominal(n) => NOMINAL_TYPES.read().expect("Value should not be poisoned!")[n].0.llvm_type(ctx)
         }
     }
@@ -208,7 +242,6 @@ impl Type {
                 b.save(out)
             },
             Error => panic!("error values shouldn't be serialized!"),
-            Module => out.write_all(&[19]),
             Array(b, None) => {
                 out.write_all(&[15])?;
                 b.save(out)
@@ -224,6 +257,13 @@ impl Type {
                 out.write_all(&[18])?;
                 out.write_all(n.as_bytes())?;
                 out.write_all(&[0])
+            },
+            Module => out.write_all(&[19]),
+            Tuple(v) => {
+                let mut buf = [20u8, 0, 0, 0, 0];
+                buf[1..].copy_from_slice(&(v.len() as u32).to_be_bytes());
+                out.write_all(&buf)?;
+                v.iter().try_for_each(|t| t.save(out))
             }
         }
     }
@@ -276,6 +316,17 @@ impl Type {
                 Type::Nominal(String::from_utf8(vec).expect("Type names should be valid UTF-8!"))
             },
             19 => Type::Module,
+            20 => {
+                let mut bytes = [0; 4];
+                buf.read_exact(&mut bytes)?;
+                let mut count = u32::from_be_bytes(bytes);
+                let mut vec = Vec::with_capacity(count as usize);
+                while count > 0 {
+                    vec.push(Type::load(buf)?);
+                    count -= 1;
+                }
+                Type::Tuple(vec)
+            },
             x => panic!("read type value expecting value in 1..=19, got {x}")
         })
     }


### PR DESCRIPTION
Tuples! Yay!
Commits:
- Add tuple literal AST
- Add parsing for tuples
- Change `TupleLiteralAST` to use alloca and GEP
- Reuse stored address for `VarDefAST` and `MutDefAST`
- Add operators to make tuples of types acts as types
- Fix size calculation for tuples and fat pointers
- Add accessor for tuple elements
- Implement copyability and register checks for tuples
- Unwrap integer literals and references in tuple literals
- Allow tuple assignment
