### PR TITLE
Improve support for libraries on non-Linux OSes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ ureq = "2.6.2"
 path-calculate = "0.1.3"
 termcolor = "1.2.0"
 owned_chars = "0.3.2"
+object = { version = "0.31.0", features = ["write"] }
 
 [build-dependencies]
 lazy_static = "1.0"

--- a/src/cobalt/ast/funcs.rs
+++ b/src/cobalt/ast/funcs.rs
@@ -32,8 +32,8 @@ impl AST for FnDefAST {
     fn loc(&self) -> Location {self.loc.clone()}
     fn fwddef_prepass<'ctx>(&self, ctx: &CompCtx<'ctx>) {
         let oic = ctx.is_const.replace(true);
-        let ret = types::utils::impl_convert((0, 0..0), (self.ret.codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
-        let params = self.params.iter().map(|(_, pt, ty, _)| (types::utils::impl_convert((0, 0..0), (ty.codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error), pt == &ParamType::Constant)).collect::<Vec<_>>();
+        let ret = types::utils::impl_convert(Default::default(), (self.ret.codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
+        let params = self.params.iter().map(|(_, pt, ty, _)| (types::utils::impl_convert(Default::default(), (ty.codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error), pt == &ParamType::Constant)).collect::<Vec<_>>();
         ctx.is_const.set(oic);
         let mut link_type = None;
         let mut linkas = None;
@@ -255,8 +255,8 @@ impl AST for FnDefAST {
     }
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
         let oic = ctx.is_const.replace(true);
-        let ret = types::utils::impl_convert((0, 0..0), (self.ret.codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
-        let out = Type::Function(Box::new(ret), self.params.iter().map(|(_, pt, ty, _)| (types::utils::impl_convert((0, 0..0), (ty.codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error), pt == &ParamType::Constant)).collect());
+        let ret = types::utils::impl_convert(Default::default(), (self.ret.codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
+        let out = Type::Function(Box::new(ret), self.params.iter().map(|(_, pt, ty, _)| (types::utils::impl_convert(Default::default(), (ty.codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error), pt == &ParamType::Constant)).collect());
         ctx.is_const.set(oic);
         out
     }
@@ -560,7 +560,7 @@ impl AST for FnDefAST {
                                 if !is_const {
                                     let param = f.get_nth_param(param_count).unwrap();
                                     param.set_name(name.as_str());
-                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), (0, 0..0))), Symbol(Value::new(
+                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), Default::default())), Symbol(Value::new(
                                         Some(param),
                                         None,
                                         ty.clone(),
@@ -568,7 +568,7 @@ impl AST for FnDefAST {
                                     param_count += 1;
                                 }
                                 else {
-                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), (0, 0..0))), Symbol(Value::new(
+                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), Default::default())), Symbol(Value::new(
                                         None,
                                         None,
                                         ty.clone(),
@@ -675,7 +675,7 @@ impl AST for FnDefAST {
                                 if !is_const {
                                     let param = f.get_nth_param(param_count).unwrap();
                                     param.set_name(name.as_str());
-                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), (0, 0..0))), Symbol(Value::new(
+                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), Default::default())), Symbol(Value::new(
                                         Some(param),
                                         None,
                                         ty.clone()
@@ -683,7 +683,7 @@ impl AST for FnDefAST {
                                     param_count += 1;
                                 }
                                 else {
-                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), (0, 0..0))), Symbol(Value::new(
+                                    ctx.with_vars(|v| v.insert(&DottedName::local((name.clone(), Default::default())), Symbol(Value::new(
                                         None,
                                         None,
                                         ty.clone()

--- a/src/cobalt/ast/literals.rs
+++ b/src/cobalt/ast/literals.rs
@@ -234,7 +234,7 @@ impl AST for ArrayLiteralAST {
         let mut elems = vec![];
         let mut ty = Type::Null;
         let mut first = true;
-        let mut elem_loc: Location = (0, 0..0);
+        let mut elem_loc: Location = Default::default();
         let mut errs = vec![];
         for val in self.vals.iter() {
             let (v, mut es) = val.codegen(ctx);

--- a/src/cobalt/ast/misc.rs
+++ b/src/cobalt/ast/misc.rs
@@ -11,7 +11,7 @@ impl CastAST {
 impl AST for CastAST {
     fn loc(&self) -> Location {(self.target.loc().0, self.val.loc().1.start..self.target.loc().1.end)}
     fn expl_type<'ctx>(&self, _: &CompCtx<'ctx>) -> bool {true}
-    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {if let Some(InterData::Type(ty)) = types::utils::impl_convert((0, 0..0), (self.target.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(|t| t.inter_val) {*ty} else {Type::Error}}
+    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {if let Some(InterData::Type(ty)) = types::utils::impl_convert(Default::default(), (self.target.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(|t| t.inter_val) {*ty} else {Type::Error}}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         let (val, mut errs) = self.val.codegen(ctx);
         if val.data_type == Type::Error {return (Value::error(), errs)}
@@ -44,7 +44,7 @@ impl BitCastAST {
 impl AST for BitCastAST {
     fn loc(&self) -> Location {(self.target.loc().0, self.val.loc().1.start..self.target.loc().1.end)}
     fn expl_type<'ctx>(&self, _: &CompCtx<'ctx>) -> bool {true}
-    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {if let Some(InterData::Type(ty)) = types::utils::impl_convert((0, 0..0), (self.target.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(|t| t.inter_val) {*ty} else {Type::Error}}
+    fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {if let Some(InterData::Type(ty)) = types::utils::impl_convert(Default::default(), (self.target.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(|t| t.inter_val) {*ty} else {Type::Error}}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<Diagnostic>) {
         let (mut val, mut errs) = self.val.codegen(ctx);
         if val.data_type == Type::Error {return (Value::error(), errs)}

--- a/src/cobalt/ast/vars.rs
+++ b/src/cobalt/ast/vars.rs
@@ -1392,7 +1392,7 @@ impl AST for TypeDefAST {
             Box::new(vm)
         });
         let old_scope = ctx.push_scope(&self.name);
-        let ty = types::utils::impl_convert((0, 0..0), (self.val.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
+        let ty = types::utils::impl_convert(Default::default(), (self.val.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
         ctx.with_vars(|v| {
             v.symbols.insert("base_t".to_string(), Value::make_type(ty.clone()).into());
             v.symbols.insert("self_t".to_string(), Value::make_type(Type::Nominal(mangled.clone())).into());

--- a/src/cobalt/context.rs
+++ b/src/cobalt/context.rs
@@ -186,7 +186,7 @@ impl<'ctx> CompCtx<'ctx> {
                         return None
                     }
                 }
-                x => types::utils::attr((x, (0, 0..0)), (&name.0, (0, 0..0)), self).ok()?
+                x => types::utils::attr((x, Default::default()), (&name.0, Default::default()), self).ok()?
             };
         }
         Some(v)

--- a/src/cobalt/dottedname.rs
+++ b/src/cobalt/dottedname.rs
@@ -69,9 +69,9 @@ impl CompoundDottedNameSegment {
                 let mut name = vec![];
                 buf.read_until(0, &mut name)?;
                 if name.last() == Some(&0) {name.pop();}
-                Ok(Some(Identifier(std::str::from_utf8(&name).expect("Cobalt symbols should be valid UTF-8").to_string(), (0, 0..0))))
+                Ok(Some(Identifier(std::str::from_utf8(&name).expect("Cobalt symbols should be valid UTF-8").to_string(), Default::default())))
             },
-            2 => Ok(Some(Glob((0, 0..0)))),
+            2 => Ok(Some(Glob(Default::default()))),
             3 => {
                 let mut out = vec![];
                 loop {

--- a/src/cobalt/errors.rs
+++ b/src/cobalt/errors.rs
@@ -1,16 +1,8 @@
-use codespan_reporting::{diagnostic::{self, *}, files::*};
+use codespan_reporting::{diagnostic::{self, *}};
 use std::ops::Range;
-use std::sync::RwLock;
-pub mod files {
-    use super::*;
-    lazy_static::lazy_static! {
-        pub static ref FILES: RwLock<SimpleFiles<String, String>> = RwLock::new(SimpleFiles::new());
-    }
-    pub fn add_file(name: String, source: String) -> FileId {
-        FILES.write().expect("FILES should not be poisoned").add(name, source)
-    }
-}
-pub type FileId = usize;
+pub mod files;
+pub use files::FILES;
+pub type FileId = (usize, usize);
 pub type Location = (FileId, Range<usize>);
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Diagnostic(pub diagnostic::Diagnostic<FileId>, pub u64);

--- a/src/cobalt/parser/ast.rs
+++ b/src/cobalt/parser/ast.rs
@@ -69,7 +69,7 @@ fn parse_paths(toks: &[Token], is_nested: bool) -> (CompoundDottedName, usize, V
 fn parse_path(toks: &[Token], terminators: &'static str) -> (DottedName, usize, Vec<Diagnostic>) {
     let mut idx = 1;
     let mut errs = vec![];
-    if toks.is_empty() {return (DottedName::local((String::new(), (0, 0..0))), 0, vec![])}
+    if toks.is_empty() {return (DottedName::local((String::new(), Default::default())), 0, vec![])}
     let (mut name, mut lwp) = match &toks[0].data {
         Special('.') => (DottedName::new(vec![], true), true),
         Identifier(s) => (DottedName::new(vec![(s.clone(), toks[0].loc.clone())], false), false),
@@ -103,7 +103,7 @@ fn parse_path(toks: &[Token], terminators: &'static str) -> (DottedName, usize, 
     (name, idx + 1, errs)
 }
 fn parse_literals(toks: &[Token], flags: &Flags) -> (Box<dyn AST>, Vec<Diagnostic>) {
-    if toks.is_empty() {return (Box::new(NullAST::new((0, 0..0))), vec![])}
+    if toks.is_empty() {return (Box::new(NullAST::new(Default::default())), vec![])}
     match &toks[0].data {
         Int(x) => {
             if toks.len() == 1 {return (Box::new(IntLiteralAST::new(toks[0].loc.clone(), *x, None)), vec![])}
@@ -2340,7 +2340,7 @@ fn parse_tl(mut toks: &[Token], flags: &Flags, is_tl: bool) -> (Vec<Box<dyn AST>
 }
 pub fn parse(toks: &[Token], flags: &Flags) -> (TopLevelAST, Vec<Diagnostic>) {
     if toks.is_empty() {
-        return (TopLevelAST::new((0, 0..0), vec![]), vec![])
+        return (TopLevelAST::new(Default::default(), vec![]), vec![])
     }
     let start = toks[0].loc.clone(); // already bounds checked
     let (out, _, errs) = parse_tl(toks, flags, true);

--- a/src/cobalt/types/utils.rs
+++ b/src/cobalt/types/utils.rs
@@ -852,11 +852,11 @@ pub fn bin_op<'ctx>(loc: Location, (mut lhs, lloc): (Value<'ctx>, Location), (mu
             )),
             _ => Err(err)
         },
-        (x @ Type::Int(..), Type::IntLiteral) => bin_op(loc, (Value {data_type: x.clone(), ..lhs}, lloc), (impl_convert((0, 0..0), (Value {data_type: Type::IntLiteral, ..rhs}, None), (x, None), ctx).unwrap(), rloc), op, ctx),
+        (x @ Type::Int(..), Type::IntLiteral) => bin_op(loc, (Value {data_type: x.clone(), ..lhs}, lloc), (impl_convert(Default::default(), (Value {data_type: Type::IntLiteral, ..rhs}, None), (x, None), ctx).unwrap(), rloc), op, ctx),
         (Type::IntLiteral, x @ Type::Int(..)) => {
             let t = x.clone();
             lhs.data_type = Type::IntLiteral;
-            bin_op(loc, (impl_convert((0, 0..0), (lhs, None), (x, None), ctx).unwrap(), lloc), (Value {data_type: t, ..rhs}, rloc), op, ctx)
+            bin_op(loc, (impl_convert(Default::default(), (lhs, None), (x, None), ctx).unwrap(), lloc), (Value {data_type: t, ..rhs}, rloc), op, ctx)
         },
         (Type::IntLiteral, Type::IntLiteral) => match op {
             "+" => Ok(Value::new(
@@ -2458,7 +2458,7 @@ pub fn call<'ctx>(mut target: Value<'ctx>, loc: Location, cparen: Option<Locatio
                 ), cparen.as_ref().unwrap_or(&loc).clone())).collect()
             } else {vec![]}).zip(params.iter()).enumerate().map(|(n, ((v, l), (t, c)))| {
                 let e = format!("expected value of type {t} in {}{} argument, got {}", n + 1, if  n % 100 / 10 == 1 {"th"} else {suffixes[n % 10]}, v.data_type);
-                (if let Ok(val) = impl_convert((0, 0..0), (v.clone(), None), (t.clone(), None), ctx) {
+                (if let Ok(val) = impl_convert(Default::default(), (v.clone(), None), (t.clone(), None), ctx) {
                     if *c && val.inter_val.is_none() {
                         good = false;
                         err.add_note(l, format!("{}{} argument must be const, but argument is not", n + 1, if  n % 100 / 10 == 1 {"th"} else {suffixes[n % 10]}));

--- a/src/libs.rs
+++ b/src/libs.rs
@@ -16,10 +16,10 @@ pub fn find_libs(mut libs: Vec<String>, dirs: &[&str], ctx: Option<&cobalt::Comp
                     if let Some(ctx) = ctx {
                         use object::read::{Object, ObjectSection};
                         let mut buf = Vec::new();
-                        let mut file = std::fs::File::open(lib)?;
+                        let mut file = std::fs::File::open(&path)?;
                         file.read_to_end(&mut buf)?;
                         match object::File::parse(buf.as_slice()) {
-                            Ok(obj) => if let Some(colib) = obj.section_by_name("colib").and_then(|v| v.uncompressed_data().ok()) {
+                            Ok(obj) => if let Some(colib) = obj.section_by_name(".colib").and_then(|v| v.uncompressed_data().ok()) {
                                 for c in ctx.load(&mut &*colib)? {
                                     error!("conflicting definitions for {c}");
                                     failed = true;
@@ -93,7 +93,7 @@ pub fn new_object<'a>(triple: &inkwell::targets::TargetTriple) -> Object<'a> {
 pub fn populate_header(obj: &mut Object, ctx: &cobalt::CompCtx) {
     let mut buf = Vec::<u8>::new();
     ctx.save(&mut buf).unwrap();
-    let colib = obj.add_section(vec![], b"colib".to_vec(), SectionKind::Other);
+    let colib = obj.add_section(vec![], b".colib".to_vec(), SectionKind::Note);
     let colib = obj.section_mut(colib);
     colib.set_data(buf, 1);
 }

--- a/src/libs.rs
+++ b/src/libs.rs
@@ -90,6 +90,21 @@ pub fn new_object<'a>(triple: &inkwell::targets::TargetTriple) -> Object<'a> {
     };
     Object::new(format, arch, endian)
 }
+pub fn format_lib(base: &str, triple: &inkwell::targets::TargetTriple) -> String {
+    let triple = triple.as_str().to_str().unwrap();
+    let components = triple.split("-");
+    if matches!(components.next().copied(), "wasm" | "wasm32") {format!("{base}.wasm")} else {
+        match components.next(1).copied() {
+            Some("apple") => format!("lib{base}.dylib"),
+            Some("linux") => format!("lib{base}.so"),
+            _ => match components.next(2).copied() {
+                Some("apple" | "ios" | "darwin") => format!("lib{base}.dylib"),
+                Some("windows") => format!("{base}.dylib"),
+                _ => format!("lib{base}.so")
+            }
+        }
+    }
+}
 pub fn populate_header(obj: &mut Object, ctx: &cobalt::CompCtx) {
     let mut buf = Vec::<u8>::new();
     ctx.save(&mut buf).unwrap();

--- a/src/libs.rs
+++ b/src/libs.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 use std::ffi::OsStr;
-use std::io;
-use std::process::{Command, Output};
+use std::io::{self, Read};
+use object::{SectionKind, write::Object};
+use super::error;
 pub fn find_libs(mut libs: Vec<String>, dirs: &[&str], ctx: Option<&cobalt::CompCtx>) -> io::Result<(Vec<(PathBuf, String)>, Vec<String>, bool)> {
     let mut out = vec![];
     let mut failed = false;
@@ -11,15 +12,20 @@ pub fn find_libs(mut libs: Vec<String>, dirs: &[&str], ctx: Option<&cobalt::Comp
         if let Some(stem) = path.file_stem().and_then(|x| x.to_str()) {
             for lib in libs.iter_mut().filter(|x| !x.is_empty()) {
                 if lib == stem || (stem.starts_with("lib") && lib == &stem[3..]) {
-                    let mut val = String::new();
-                    std::mem::swap(&mut val, lib);
+                    let val = std::mem::take(lib);
                     if let Some(ctx) = ctx {
-                        match Command::new("objcopy").arg(&path).args(["--dump-section", ".colib=/dev/stdout"]).output() { // TODO: use ELF parser library
-                            Ok(Output {status, stdout, ..}) if status.success() => for conflict in ctx.load(&mut stdout.as_slice())? {
-                                eprintln!("redefinition of {conflict} in {}", path.display());
-                                failed = true;
+                        use object::read::{Object, ObjectSection};
+                        let mut buf = Vec::new();
+                        let mut file = std::fs::File::open(lib)?;
+                        file.read_to_end(&mut buf)?;
+                        match object::File::parse(buf.as_slice()) {
+                            Ok(obj) => if let Some(colib) = obj.section_by_name("colib").and_then(|v| v.uncompressed_data().ok()) {
+                                for c in ctx.load(&mut &*colib)? {
+                                    error!("conflicting definitions for {c}");
+                                    failed = true;
+                                }
                             },
-                            _ => {}
+                            Err(err) => error!("{err}")
                         }
                     }
                     out.push((path.clone(), val));
@@ -44,4 +50,50 @@ pub fn find_libs(mut libs: Vec<String>, dirs: &[&str], ctx: Option<&cobalt::Comp
         }
     }
     Ok((out, libs.into_iter().filter(|x| !x.is_empty()).collect(), failed))
+}
+pub fn new_object<'a>(triple: &inkwell::targets::TargetTriple) -> Object<'a> {
+    let triple = triple.as_str().to_str().unwrap();
+    let components = triple.split("-").collect::<Vec<&str>>();
+    use object::Architecture::*;
+    use object::Endianness::*;
+    use object::BinaryFormat::*;
+    let mut wasm = false;
+    let arch = match components.get(0).copied() {
+        Some("aarch64") => Aarch64,
+        Some(x) if x.starts_with("arm") => Arm,
+        Some("x86" | "i386" | "i586" | "i686") => I386,
+        Some("mips" | "mipsel") => Mips,
+        Some("mips64" | "mips64el") => Mips64,
+        Some("powerpc") => PowerPc,
+        Some("powerpc64") => PowerPc64,
+        Some(x) if x.starts_with("riscv32") => Riscv32,
+        Some(x) if x.starts_with("riscv64") => Riscv64,
+        Some("x86_64") => X86_64,
+        Some("wasm" | "wasm32") => {wasm = true; Wasm32}
+        _ => Unknown
+    };
+    let endian = match arch {
+        Mips | Mips64 => Big,
+        PowerPc | PowerPc64 | Arm | Aarch64 | Wasm32 | X86_64 | I386 => Little,
+        _ => if 1i16.to_be_bytes()[0] == 1 {Little} else {Big}
+    };
+    let format = if wasm {Wasm} else {
+        match components.get(1).copied() {
+            Some("apple") => MachO,
+            Some("linux") => Elf,
+            _ => match components.get(2).copied() {
+                Some("apple" | "ios" | "darwin") => MachO,
+                Some("windows") => Pe,
+                _ => Elf
+            }
+        }
+    };
+    Object::new(format, arch, endian)
+}
+pub fn populate_header(obj: &mut Object, ctx: &cobalt::CompCtx) {
+    let mut buf = Vec::<u8>::new();
+    ctx.save(&mut buf).unwrap();
+    let colib = obj.add_section(vec![], b"colib".to_vec(), SectionKind::Other);
+    let colib = obj.section_mut(colib);
+    colib.set_data(buf, 1);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -459,7 +459,7 @@ fn driver() -> Result<(), Box<dyn std::error::Error>> {
             let triple = triple.unwrap_or_else(TargetMachine::get_default_triple);
             let out_file = out_file.map(String::from).unwrap_or_else(|| match output_type {
                 OutputType::Executable => format!("{}{}", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file), if triple.as_str().to_str().unwrap_or("").contains("windows") {".exe"} else {""}),
-                OutputType::Library => format!("lib{}.so", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file)),
+                OutputType::Library => libs::format_lib(in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file), &triple),
                 OutputType::Object => format!("{}.o", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file)),
                 OutputType::Assembly => format!("{}.s", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file)),
                 OutputType::Llvm => format!("{}.ll", in_file.rfind('.').map(|i| &in_file[..i]).unwrap_or(in_file)),


### PR DESCRIPTION
Header data is now added and read using the `object` crate instead of externally calling `objcopy`. This not only improves speed but also makes things work on more platforms.
## Commits
- Create new file manager to handle modules
- Improve cross-platform support for libraries
- Make library build targets emit a header object file
- Add `HeaderObj` emit type
- Format library to have corrent name on non-Linux OSes
