### PR TITLE
Add more project utilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ path-calculate = "0.1.3"
 termcolor = "1.2.0"
 owned_chars = "0.3.2"
 object = { version = "0.31.0", features = ["write"] }
+os_str_bytes = "6.5.0"
 
 [build-dependencies]
 lazy_static = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ path-calculate = "0.1.3"
 termcolor = "1.2.0"
 owned_chars = "0.3.2"
 object = { version = "0.31.0", features = ["write"] }
-os_str_bytes = "6.5.0"
 
 [build-dependencies]
 lazy_static = "1.0"

--- a/src/build.rs
+++ b/src/build.rs
@@ -45,8 +45,20 @@ impl Project {
             Target {target_type: TargetType::Meta, files: None, name, deps}
         }))
     }
+    pub fn target_type(&self, name: &str) -> Option<TargetType> {
+        self.targets.as_ref().and_then(|v| v.iter().find_map(|x| (x.name == name).then_some(x.target_type)))
+        .or_else(|| self.executable.as_ref().and_then(|v| v.iter().any(|x| x.name == name).then_some(TargetType::Executable)))
+        .or_else(|| self.library.as_ref().and_then(|v| v.iter().any(|x| x.name == name).then_some(TargetType::Library)))
+        .or_else(|| self.meta.as_ref().and_then(|v| v.iter().any(|x| x.name == name).then_some(TargetType::Meta)))
+    }
+    pub fn get_exe<'a>(&'a self) -> Vec<&'a str> {
+        let mut out = Vec::with_capacity(self.targets.as_ref().map_or(0, |v| v.len()) + self.executable.as_ref().map_or(0, |v| v.len()));
+        if let Some(ref v) = self.targets {out.extend(v.iter().filter_map(|x| (x.target_type == TargetType::Executable).then_some(x.name.as_str())))}
+        if let Some(ref v) = self.executable {out.extend(v.iter().map(|x| x.name.as_str()))}
+        out
+    }
 }
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 pub enum TargetType {
     #[serde(rename = "exe", alias = "executable", alias = "bin", alias = "binary")]
     Executable,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn load_projects() -> io::Result<Vec<[String; 2]>> {
     let mut it = buf.split('\0');
     let len = it.size_hint();
     let mut vec = Vec::<[String; 2]>::with_capacity(len.1.unwrap_or(len.0));
-    while let (Some(name), Some(path)) = (it.next(), it.next()) {vec.push([name.to_string(), path.to_string()])}
+    while let (Some(name), Some(path)) = (it.next(), it.next()) {if Path::new(path).exists() {vec.push([name.to_string(), path.to_string()])}}
     Ok(vec)
 }
 fn track_project(name: &str, path: PathBuf, vec: &mut Vec<[String; 2]>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1290,7 +1290,29 @@ fn driver() -> Result<(), Box<dyn std::error::Error>> {
                                     exit(100)
                                 }
                                 let cfg;
-                                match std::fs::read_to_string(path) {
+                                match std::fs::read_to_string(&path) {
+                                    Ok(c) => cfg = c,
+                                    Err(e) => {
+                                        eprintln!("error when reading project file: {e}");
+                                        exit(100)
+                                    }
+                                }
+                                let cfg = match toml::from_str::<build::Project>(&cfg) {
+                                    Ok(proj) => proj,
+                                    Err(e) => {
+                                        eprintln!("error when parsing project file: {e}");
+                                        exit(100)
+                                    }
+                                };
+                                track_project(&cfg.name, path, &mut vecs);
+                                save_projects(vecs)?;
+                                (cfg , PathBuf::from(x))
+                            },
+                            Ok(false) => {
+                                let mut path = std::path::PathBuf::from(&x);
+                                path.pop();
+                                let cfg;
+                                match std::fs::read_to_string(&x) {
                                     Ok(c) => cfg = c,
                                     Err(e) => {
                                         eprintln!("error when reading project file: {e}");
@@ -1305,28 +1327,6 @@ fn driver() -> Result<(), Box<dyn std::error::Error>> {
                                     }
                                 };
                                 track_project(&cfg.name, x.clone().into(), &mut vecs);
-                                save_projects(vecs)?;
-                                (cfg , PathBuf::from(x))
-                            },
-                            Ok(false) => {
-                                let mut path = std::path::PathBuf::from(&x);
-                                path.pop();
-                                let cfg;
-                                match std::fs::read_to_string(x) {
-                                    Ok(c) => cfg = c,
-                                    Err(e) => {
-                                        eprintln!("error when reading project file: {e}");
-                                        exit(100)
-                                    }
-                                }
-                                let cfg = match toml::from_str::<build::Project>(&cfg) {
-                                    Ok(proj) => proj,
-                                    Err(e) => {
-                                        eprintln!("error when parsing project file: {e}");
-                                        exit(100)
-                                    }
-                                };
-                                track_project(&cfg.name, path.clone(), &mut vecs);
                                 save_projects(vecs)?;
                                 (cfg, path)
                             },
@@ -1541,7 +1541,7 @@ fn driver() -> Result<(), Box<dyn std::error::Error>> {
                                     exit(100)
                                 }
                                 let cfg;
-                                match std::fs::read_to_string(path) {
+                                match std::fs::read_to_string(&path) {
                                     Ok(c) => cfg = c,
                                     Err(e) => {
                                         eprintln!("error when reading project file: {e}");
@@ -1555,7 +1555,7 @@ fn driver() -> Result<(), Box<dyn std::error::Error>> {
                                         exit(100)
                                     }
                                 };
-                                track_project(&cfg.name, x.clone().into(), &mut vecs);
+                                track_project(&cfg.name, path, &mut vecs);
                                 save_projects(vecs)?;
                                 (cfg , PathBuf::from(x))
                             },
@@ -1563,7 +1563,7 @@ fn driver() -> Result<(), Box<dyn std::error::Error>> {
                                 let mut path = std::path::PathBuf::from(&x);
                                 path.pop();
                                 let cfg;
-                                match std::fs::read_to_string(x) {
+                                match std::fs::read_to_string(&x) {
                                     Ok(c) => cfg = c,
                                     Err(e) => {
                                         eprintln!("error when reading project file: {e}");
@@ -1577,7 +1577,7 @@ fn driver() -> Result<(), Box<dyn std::error::Error>> {
                                         exit(100)
                                     }
                                 };
-                                track_project(&cfg.name, path.clone(), &mut vecs);
+                                track_project(&cfg.name, x.into(), &mut vecs);
                                 save_projects(vecs)?;
                                 (cfg, path)
                             },


### PR DESCRIPTION
This completely overhauls the CLI for the build system. The following subcommands have been added:
- `co proj[ect] build`-- build the project like `co build` used to
- `co proj[ect] exec|run`-- build an executable target and run it
- `co proj[ect] track`-- track a project
- `co proj[ect] untrack`-- untrack a project

Once a project is being tracked, it can be built or run using `:name` in place of a project directory. Note that this assumes the standard layout of source and build directories.

## Commits
- Move `build` to `proj` subcommand and add `track`
- Make `co proj build` automatically track projects
- Change project tracker to store and update the names of projects
- Add subcommand to list active projects
- Automatically untrack deleted projects
- Add option to build project by name
- Add subcommand to build and run project
- Fix incorrect path being stored when building project
