### PR TITLE
Fix issues around lexer and comments

### DIFF
--- a/src/cobalt/parser/lexer.rs
+++ b/src/cobalt/parser/lexer.rs
@@ -224,6 +224,7 @@ pub fn lex(data: &str, mut loc: (FileId, usize), flags: &Flags) -> (Vec<Token>, 
                                 Some('=') => {count += 1;},
                                 _ => break
                             }
+                            if flags.up {loc.1 += 1};
                         }
                         loop {
                             while let Some(c) = it.next_if(|&x| x != '=') { // skip characters that aren't '='

--- a/src/cobalt/parser/lexer.rs
+++ b/src/cobalt/parser/lexer.rs
@@ -235,14 +235,14 @@ pub fn lex(data: &str, mut loc: (FileId, usize), flags: &Flags) -> (Vec<Token>, 
                                 break 'main;
                             }
                             let mut rem = count;
-                            while rem > 0 && it.peek() == Some(&'=') { // the number of consecutive '='s
+                            while it.peek() == Some(&'=') { // the number of consecutive '='s
                                 if flags.up {loc.1 += 1};
                                 if rem > 0 { // it's ok if there's extra '='s
                                     rem -= 1;
                                 }
                                 it.next();
                             }
-                            if it.peek() == Some(&'#') { // check to make sure that it's actually ended
+                            if rem == 0 && it.peek() == Some(&'#') { // check to make sure that it's actually ended
                                 if flags.up {loc.1 += 1};
                                 break;
                             }


### PR DESCRIPTION
The lexer had issues in two places:
1. When a multiline comment opening had more than two `=`s, not all of them were counted.
2. The checks for valid multiline closing were done incorrectly, so errors appeared at the wrong times.
## Commits
- Fix lexer incorrectly updating position when lexing multiline comments
- Fix errors appearing in the wrong places when opening and closing sequences are different
