### PR TITLE
Add better debug utilities

### DIFF
--- a/cobalt-ast/src/ast.rs
+++ b/cobalt-ast/src/ast.rs
@@ -25,6 +25,7 @@ impl<T: AST + Clone + 'static> ASTClone for T {
 }
 pub trait AST: ASTClone + std::fmt::Debug {
     fn loc(&self) -> SourceSpan;
+    fn nodes(&self) -> usize {1}
     // AST properties
     fn is_const(&self) -> bool {false}
     fn expl_type<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> bool {false}
@@ -57,8 +58,6 @@ pub trait AST: ASTClone + std::fmt::Debug {
         val
     }
 }
-#[repr(transparent)]
-pub struct FileAST<T: AST>(T);
 impl Display for dyn AST {
     fn fmt(&self, f: &mut Formatter) -> Result {
         let mut pre = TreePrefix::new();

--- a/cobalt-ast/src/ast/flow.rs
+++ b/cobalt-ast/src/ast/flow.rs
@@ -11,6 +11,7 @@ impl IfAST {
 }
 impl AST for IfAST {
     fn loc(&self) -> SourceSpan {self.loc}
+    fn nodes(&self) -> usize {self.cond.nodes() + self.if_true.nodes() + self.if_false.as_ref().map_or(0, |x| x.nodes()) + 1}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
         if let Some(val) = self.if_false.as_ref() {types::utils::common(&self.if_true.res_type(ctx), &val.res_type(ctx)).unwrap_or(Type::Null)}
         else {self.if_true.res_type(ctx)}
@@ -135,6 +136,7 @@ impl WhileAST {
 }
 impl AST for WhileAST {
     fn loc(&self) -> SourceSpan {self.loc}
+    fn nodes(&self) -> usize {self.cond.nodes() + self.body.nodes() + 1}
     fn res_type<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> Type {Type::Null}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         if ctx.is_const.get() {return (Value::null(), vec![])}

--- a/cobalt-ast/src/ast/funcs.rs
+++ b/cobalt-ast/src/ast/funcs.rs
@@ -29,6 +29,7 @@ impl FnDefAST {
 }
 impl AST for FnDefAST {
     fn loc(&self) -> SourceSpan {self.loc}
+    fn nodes(&self) -> usize {self.ret.nodes() + self.body.nodes() + self.params.iter().map(|(_, _, ty, def)| ty.nodes() + def.as_ref().map_or(0, |x| x.nodes())).sum::<usize>() + 1}
     fn fwddef_prepass<'ctx>(&self, ctx: &CompCtx<'ctx>) {
         let oic = ctx.is_const.replace(true);
         let ret = types::utils::impl_convert(unreachable_span(), (self.ret.codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
@@ -961,6 +962,7 @@ impl CallAST {
 }
 impl AST for CallAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.target.loc(), self.cparen)}
+    fn nodes(&self) -> usize {self.target.nodes() + self.args.iter().map(|x| x.nodes()).sum::<usize>() + 1}
     fn expl_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> bool {matches!(self.target.res_type(ctx), Type::InlineAsm(..))}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
         types::utils::call_type(self.target.res_type(ctx), self.args.iter().map(|a| a.const_codegen(ctx).0).collect::<Vec<_>>())

--- a/cobalt-ast/src/ast/groups.rs
+++ b/cobalt-ast/src/ast/groups.rs
@@ -9,6 +9,7 @@ impl BlockAST {
 }
 impl AST for BlockAST {
     fn loc(&self) -> SourceSpan {self.loc}
+    fn nodes(&self) -> usize {self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.vals.last().map(|x| x.res_type(ctx)).unwrap_or(Type::Null)}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         ctx.map_vars(|v| Box::new(VarMap::new(Some(v))));
@@ -50,6 +51,7 @@ impl GroupAST {
 }
 impl AST for GroupAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.vals[0].loc(), self.vals.last().unwrap().loc())}
+    fn nodes(&self) -> usize {self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.vals.last().map(|x| x.res_type(ctx)).unwrap_or(Type::Null)}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let mut out = Value::null();
@@ -84,6 +86,7 @@ pub struct TopLevelAST {
 }
 impl AST for TopLevelAST {
     fn loc(&self) -> SourceSpan {unreachable_span()}
+    fn nodes(&self) -> usize {self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1}
     fn res_type<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> Type {Type::Null}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         if ctx.flags.prepass {

--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -210,6 +210,7 @@ impl ArrayLiteralAST {
 }
 impl AST for ArrayLiteralAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.start, self.end)}
+    fn nodes(&self) -> usize {self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
         let mut elem = self.vals.get(0).map_or(Type::Null, |x| match x.res_type(ctx) {
             Type::IntLiteral => Type::Int(64, false),
@@ -340,6 +341,7 @@ impl AST for TupleLiteralAST {
         let end = self.vals.last().unwrap().loc();
         merge_spans(start, end)
     }
+    fn nodes(&self) -> usize {self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
         Type::Tuple(self.vals.iter().map(|x| match x.res_type(ctx) {
             Type::IntLiteral => Type::Int(64, false),

--- a/cobalt-ast/src/ast/misc.rs
+++ b/cobalt-ast/src/ast/misc.rs
@@ -12,6 +12,7 @@ impl CastAST {
 }
 impl AST for CastAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.val.loc(), self.target.loc())}
+    fn nodes(&self) -> usize {self.val.nodes() + self.target.nodes() + 1}
     fn expl_type<'ctx>(&self, _: &CompCtx<'ctx>) -> bool {true}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {if let Some(InterData::Type(ty)) = types::utils::impl_convert(unreachable_span(), (self.target.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(|t| t.inter_val) {*ty} else {Type::Error}}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
@@ -45,6 +46,7 @@ impl BitCastAST {
 }
 impl AST for BitCastAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.val.loc(), self.target.loc())}
+    fn nodes(&self) -> usize {self.val.nodes() + self.target.nodes() + 1}
     fn expl_type<'ctx>(&self, _: &CompCtx<'ctx>) -> bool {true}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {if let Some(InterData::Type(ty)) = types::utils::impl_convert(unreachable_span(), (self.target.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(|t| t.inter_val) {*ty} else {Type::Error}}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
@@ -165,6 +167,7 @@ impl ParenAST {
 }
 impl AST for ParenAST {
     fn loc(&self) -> SourceSpan {self.loc}
+    fn nodes(&self) -> usize {self.base.nodes() + 1}
     fn is_const(&self) -> bool {self.base.is_const()}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.base.res_type(ctx)}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {self.base.codegen(ctx)}

--- a/cobalt-ast/src/ast/ops.rs
+++ b/cobalt-ast/src/ast/ops.rs
@@ -11,6 +11,7 @@ impl BinOpAST {
 }
 impl AST for BinOpAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.lhs.loc(), self.rhs.loc())}
+    fn nodes(&self) -> usize {self.lhs.nodes() + self.rhs.nodes() + 1}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
         if self.op == "&?" || self.op == "|?" {
             let t = self.rhs.res_type(ctx);
@@ -142,6 +143,7 @@ impl PostfixAST {
 }
 impl AST for PostfixAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.val.loc(), self.loc)}
+    fn nodes(&self) -> usize {self.val.nodes() + 1}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
         types::utils::post_type(self.val.res_type(ctx), self.op.as_str())
     }
@@ -172,6 +174,7 @@ impl PrefixAST {
 }
 impl AST for PrefixAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.loc, self.val.loc())}
+    fn nodes(&self) -> usize {self.val.nodes() + 1}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {
         types::utils::pre_type(self.val.res_type(ctx), self.op.as_str())
     }
@@ -202,6 +205,7 @@ impl SubAST {
 }
 impl AST for SubAST {
     fn loc(&self) -> SourceSpan {self.loc}
+    fn nodes(&self) -> usize {self.target.nodes() + self.index.nodes() + 1}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {types::utils::sub_type(self.target.res_type(ctx), self.index.res_type(ctx))}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let (target, mut errs) = self.target.codegen(ctx);
@@ -231,6 +235,7 @@ impl DotAST {
 }
 impl AST for DotAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.obj.loc(), self.name.1)}
+    fn nodes(&self) -> usize {self.obj.nodes() + 1}
     fn res_type(&self, ctx: &CompCtx) -> Type {
         match self.obj.res_type(ctx) {
             Type::Module => if let Some((s, i, _)) = self.obj.const_codegen(ctx).0.as_mod() {ctx.with_vars(|v| VarMap::lookup_in_mod((&s, &i), &self.name.0, v)).map_or(Type::Error, |x| x.0.data_type.clone())} else {Type::Error},

--- a/cobalt-ast/src/ast/scope.rs
+++ b/cobalt-ast/src/ast/scope.rs
@@ -9,6 +9,7 @@ pub struct ModuleAST {
 }
 impl AST for ModuleAST {
     fn loc(&self) -> SourceSpan {self.loc}
+    fn nodes(&self) -> usize {self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1}
     fn res_type<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> Type {Type::Null}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let mut errs = Vec::<CobaltError>::new();

--- a/cobalt-ast/src/ast/vars.rs
+++ b/cobalt-ast/src/ast/vars.rs
@@ -17,6 +17,7 @@ impl VarDefAST {
 }
 impl AST for VarDefAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.loc, self.val.loc())}
+    fn nodes(&self) -> usize {self.val.nodes() + self.type_.as_ref().map_or(0, |x| x.nodes()) + 1}
     fn fwddef_prepass<'ctx>(&self, ctx: &CompCtx<'ctx>) {
         let mut errs = vec![];
         let mut link_type = None;
@@ -667,6 +668,7 @@ impl MutDefAST {
 }
 impl AST for MutDefAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.loc, self.val.loc())}
+    fn nodes(&self) -> usize {self.val.nodes() + self.type_.as_ref().map_or(0, |x| x.nodes()) + 1}
     fn fwddef_prepass<'ctx>(&self, ctx: &CompCtx<'ctx>) {
         let mut errs = vec![];
         let mut link_type = None;
@@ -1293,6 +1295,7 @@ impl ConstDefAST {
 }
 impl AST for ConstDefAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.loc, self.val.loc())}
+    fn nodes(&self) -> usize {self.val.nodes() + self.type_.as_ref().map_or(0, |x| x.nodes()) + 1}
     fn res_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Type {self.val.res_type(ctx)}
     fn varfwd_prepass<'ctx>(&self, ctx: &CompCtx<'ctx>) {let _ = ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::error(), VariableData::uninit(self.loc))));}
     fn constinit_prepass<'ctx>(&self, ctx: &CompCtx<'ctx>, needs_another: &mut bool) {
@@ -1452,6 +1455,7 @@ impl TypeDefAST {
 }
 impl AST for TypeDefAST {
     fn loc(&self) -> SourceSpan {self.loc}
+    fn nodes(&self) -> usize {self.val.nodes() + self.methods.iter().map(|x| x.nodes()).sum::<usize>() + 1}
     fn res_type(&self, _ctx: &CompCtx) -> Type {Type::TypeData}
     fn varfwd_prepass<'ctx>(&self, ctx: &CompCtx<'ctx>) {
         let _ = ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::error(), VariableData::uninit(self.loc))));

--- a/cobalt-cli/Cargo.toml
+++ b/cobalt-cli/Cargo.toml
@@ -18,6 +18,7 @@ termcolor = "1.2.0"
 miette = { version = "5.9.0", features = ["fancy"] }
 clap = { version = "4.3.0", features = ["derive"] }
 const_format = "0.2.31"
+human-repr = "1.1.0"
 
 [build-dependencies]
 lazy_static = "1.4"

--- a/cobalt-cli/src/main.rs
+++ b/cobalt-cli/src/main.rs
@@ -282,8 +282,8 @@ fn driver() -> anyhow::Result<()> {
                 let (mut ast, errs) = parse_tl(&code);
                 ast.file = Some(file);
                 for err in errs {eprintln!("{:?}", Report::from(err).with_source_code(file));}
-                if locs {print!("{:#}", ast)}
-                else {print!("{}", ast)}
+                if locs {print!("({} nodes)\n{ast:#}", ast.nodes())}
+                else {print!("({} nodes)\n{ast}", ast.nodes())}
             }
             for arg in files {
                 let code = Path::new(&arg).read_to_string_anyhow()?;
@@ -291,8 +291,8 @@ fn driver() -> anyhow::Result<()> {
                 let (mut ast, errs) = parse_tl(&code);
                 ast.file = Some(file);
                 for err in errs {eprintln!("{:?}", Report::from(err).with_source_code(file));}
-                if locs {print!("{:#}", ast)}
-                else {print!("{}", ast)}
+                if locs {print!("({} nodes)\n{ast:#}", ast.nodes())}
+                else {print!("({} nodes)\n{ast}", ast.nodes())}
             }
         },
         #[cfg(debug_assertions)]

--- a/cobalt-cli/src/main.rs
+++ b/cobalt-cli/src/main.rs
@@ -1,6 +1,7 @@
+use inkwell::module::Module;
 use inkwell::targets::*;
 use inkwell::execution_engine::FunctionLookupError;
-use std::process::{Command, exit};
+use std::process::Command;
 use std::io::{prelude::*, BufReader};
 use std::path::{Path, PathBuf};
 use std::fmt;
@@ -8,6 +9,8 @@ use anyhow::Context;
 use anyhow_std::*;
 use const_format::{formatcp, str_index};
 use clap::{Parser, Subcommand, ValueEnum};
+use std::time::{Instant, Duration};
+use human_repr::*;
 
 use cobalt_ast::{CompCtx, AST};
 use cobalt_errors::*;
@@ -105,7 +108,10 @@ enum Cli {
         debug_mangle: bool,
         /// don't search default directories for libraries
         #[arg(long)]
-        no_default_link: bool
+        no_default_link: bool,
+        /// print timings
+        #[arg(long)]
+        timings: bool
     },
     /// JIT compile and run a file
     Jit {
@@ -151,7 +157,10 @@ enum Cli {
         headers: Vec<String>,
         /// don't search default directories for libraries
         #[arg(long)]
-        no_default_link: bool
+        no_default_link: bool,
+        /// print timings
+        #[arg(long)]
+        timings: bool
     },
     /// project-related utilities
     #[command(subcommand, alias = "proj")]
@@ -179,7 +188,10 @@ enum DbgSubcommand {
     #[cfg(debug_assertions)]
     Llvm {
         /// input file to compile
-        input: String
+        input: String,
+        /// print timings
+        #[arg(long)]
+        timings: bool
     },
     /// Parse a Cobalt header
     #[cfg(debug_assertions)]
@@ -279,6 +291,38 @@ enum PkgSubcommand {
     },
 }
 
+/// time the execution of a function
+#[inline(always)]
+fn timeit<R, F: FnOnce() -> R>(f: F) -> (R, Duration) {
+    let start = Instant::now();
+    let ret = f();
+    (ret, start.elapsed())
+}
+/// count instructions in a module
+fn insts(m: &Module) -> usize {
+    let mut count = 0;
+    let mut f = m.get_first_function();
+    while let Some(fv) = f {
+        let mut b = fv.get_first_basic_block();
+        while let Some(bb) = b {
+            let mut i = bb.get_first_instruction();
+            while let Some(iv) = i {
+                count += 1;
+                i = iv.get_next_instruction();
+            }
+            b = bb.get_next_basic_block();
+        }
+        f = fv.get_next_function();
+    }
+    count
+}
+#[derive(Debug, Clone, Copy)]
+struct Exit(i32);
+impl std::fmt::Display for Exit {fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {Ok(())}}
+impl std::error::Error for Exit {}
+
+
+
 #[inline(always)]
 fn driver() -> anyhow::Result<()> {
     match Cli::parse() {
@@ -304,25 +348,37 @@ fn driver() -> anyhow::Result<()> {
                     else {print!("({} nodes)\n{ast}", ast.nodes())}
                 }
             },
-            DbgSubcommand::Llvm {input} => {
-                let code = if input == "-" {
-                    let mut s = String::new();
-                    std::io::stdin().read_to_string(&mut s)?;
-                    s
-                } else {Path::new(&input).read_to_string_anyhow()?};
-                let mut flags = Flags::default();
-                flags.dbg_mangle = true;
-                let ink_ctx = inkwell::context::Context::create();
-                let ctx = CompCtx::with_flags(&ink_ctx, &input, flags);
-                let file = FILES.add_file(0, input, code.clone());
-                let (mut ast, errs) = parse_tl(&code);
-                ast.file = Some(file);
-                for err in errs {eprintln!("{:?}", Report::from(err).with_source_code(file));}
-                ctx.module.set_triple(&TargetMachine::get_default_triple());
-                let (_, errs) = ast.codegen(&ctx);
-                for err in errs {eprintln!("{:?}", Report::from(err).with_source_code(file));}
-                if let Err(msg) = ctx.module.verify() {error!("\n{}", msg.to_string())}
-                print!("{}", ctx.module.to_string());
+            DbgSubcommand::Llvm {input, timings} => {
+                let (result, overall) = timeit(|| {
+                    let (code, file_time) = timeit(|| if input == "-" {
+                        let mut s = String::new();
+                        std::io::stdin().read_to_string(&mut s)?;
+                        anyhow::Ok(s)
+                    } else {Path::new(&input).read_to_string_anyhow()});
+                    let code = code?;
+                    let mut flags = Flags::default();
+                    flags.dbg_mangle = true;
+                    let ink_ctx = inkwell::context::Context::create();
+                    let ctx = CompCtx::with_flags(&ink_ctx, &input, flags);
+                    let file = FILES.add_file(0, input, code.clone());
+                    let ((mut ast, errs), parse_time) = timeit(|| parse_tl(&code));
+                    ast.file = Some(file);
+                    for err in errs {eprintln!("{:?}", Report::from(err).with_source_code(file));}
+                    ctx.module.set_triple(&TargetMachine::get_default_triple());
+                    let (errs, comp_time) = timeit(|| ast.codegen(&ctx).1);
+                    for err in errs {eprintln!("{:?}", Report::from(err).with_source_code(file));}
+                    if let Err(msg) = ctx.module.verify() {error!("\n{}", msg.to_string())}
+                    print!("{}", ctx.module.to_string());
+                    anyhow::Ok((file_time, parse_time, comp_time, code.len(), ast.nodes()))
+                });
+                let (file, parse, comp, len, nodes) = result?;
+                if timings {
+                    println!("----------------");
+                    println!("overall time: {:>8}", overall.human_duration().to_string());
+                    println!("reading file: {:>8} ({:6.3}%) @ {:>13}", file .human_duration().to_string(), file .as_secs_f64() / overall.as_secs_f64() * 100.0, (len   as f64 / file .as_secs_f64()).human_throughput_bytes().to_string());
+                    println!("parsing code: {:>8} ({:6.3}%) @ {:>13}", parse.human_duration().to_string(), parse.as_secs_f64() / overall.as_secs_f64() * 100.0, (len   as f64 / parse.as_secs_f64()).human_throughput_bytes().to_string());
+                    println!("LLVM codegen: {:>8} ({:6.3}%) @ {:>13}", comp .human_duration().to_string(), comp .as_secs_f64() / overall.as_secs_f64() * 100.0, (nodes as f64 / comp .as_secs_f64()).human_throughput(" node").to_string());
+                }
             },
             #[cfg(debug_assertions)]
             DbgSubcommand::ParseHeader {inputs} => {
@@ -337,151 +393,205 @@ fn driver() -> anyhow::Result<()> {
                 }
             }
         },
-        Cli::Aot {input, output, linked, mut link_dirs, headers, triple, emit, profile, continue_if_err, debug_mangle, no_default_link} => {
-            if !no_default_link {
-                if let Some(pwd) = std::env::current_dir().ok().and_then(|pwd| pwd.to_str().map(String::from)) {link_dirs.insert(0, pwd);}
-                if let Ok(home) = std::env::var("HOME") {link_dirs.extend_from_slice(&[format!("{home}/.cobalt/packages"), format!("{home}/.local/lib/cobalt"), "/usr/local/lib/cobalt/packages".to_string(), "/usr/lib/cobalt/packages".to_string(), "/lib/cobalt/packages".to_string(), "/usr/local/lib".to_string(), "/usr/lib".to_string(), "/lib".to_string()]);}
-                else {link_dirs.extend(["/usr/local/lib/cobalt/packages", "/usr/lib/cobalt/packages", "/lib/cobalt/packages", "/usr/local/lib", "/usr/lib", "/lib"].into_iter().map(String::from));}
-            }
-            let code = if input == "-" {
-                let mut s = String::new();
-                std::io::stdin().read_to_string(&mut s)?;
-                s
-            } else {Path::new(&input).read_to_string_anyhow()?};
-            if triple.is_some() {Target::initialize_all(&INIT_NEEDED)}
-            else {Target::initialize_native(&INIT_NEEDED).map_err(anyhow::Error::msg)?}
-            let triple = triple.unwrap_or_else(|| TargetMachine::get_default_triple().as_str().to_string_lossy().into_owned());
-            let trip = TargetTriple::create(&triple);
-            let output = output.map(String::from).unwrap_or_else(|| match emit {
-                OutputType::Executable => format!("{}{}", input.rfind('.').map_or(input.as_str(), |i| &input[..i]), if triple.contains("windows") {".exe"} else {""}),
-                OutputType::Library => libs::format_lib(input.rfind('.').map_or(input.as_str(), |i| &input[..i]), &trip),
-                OutputType::Object => format!("{}.o", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
-                OutputType::Assembly => format!("{}.s", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
-                OutputType::Llvm => format!("{}.ll", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
-                OutputType::Bitcode => format!("{}.bc", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
-                OutputType::Header => format!("{}.coh", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
-                OutputType::HeaderObj => format!("{}.coh.o", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
-            });
-            let output = if output == "-" {None} else {Some(output)};
-            let target_machine = Target::from_triple(&trip).unwrap().create_target_machine(
-                &trip,
-                "",
-                "",
-                inkwell::OptimizationLevel::None,
-                inkwell::targets::RelocMode::PIC,
-                inkwell::targets::CodeModel::Small
-            ).expect("failed to create target machine");
-            let mut flags = Flags::default();
-            flags.dbg_mangle = debug_mangle;
-            let ink_ctx = inkwell::context::Context::create();
-            if let Some(size) = ink_ctx.ptr_sized_int_type(&target_machine.get_target_data(), None).size_of().get_zero_extended_constant() {flags.word_size = size as u16;}
-            let ctx = CompCtx::with_flags(&ink_ctx, &input, flags);
-            ctx.module.set_triple(&trip);
-            let libs = if !linked.is_empty() {
-                let (libs, notfound) = libs::find_libs(linked.iter().map(|x| x.to_string()).collect::<Vec<_>>(), &link_dirs.iter().map(|x| x.as_str()).collect::<Vec<_>>(), Some(&ctx))?;
-                notfound.iter().for_each(|nf| error!("couldn't find library {nf}"));
-                if !notfound.is_empty() {exit(102)}
-                libs
-            } else {vec![]};
-            for head in headers {
-                let mut file = BufReader::new(std::fs::File::open(head)?);
-                ctx.load(&mut file)?;
-            }
-            let mut fail = false;
-            let mut overall_fail = false;
-            let file = FILES.add_file(0, input.to_string(), code.clone());
-            let (mut ast, errs) = parse_tl(&code);
-            ast.file = Some(file);
-            for err in errs {fail |= err.is_err(); eprintln!("{:?}", Report::from(err).with_source_code(file));}
-            overall_fail |= fail;
-            fail = false;
-            if fail && !continue_if_err {anyhow::bail!(CompileErrors)}
-            let (_, errs) = ast.codegen(&ctx);
-            overall_fail |= fail;
-            fail = false;
-            for err in errs {fail |= err.is_err(); eprintln!("{:?}", Report::from(err).with_source_code(file));}
-            if fail && !continue_if_err {anyhow::bail!(CompileErrors)}
-            if let Err(msg) = ctx.module.verify() {
-                error!("\n{}", msg.to_string());
-                exit(101)
-            }
-            if fail || overall_fail {anyhow::bail!(CompileErrors)}
-            let pm = inkwell::passes::PassManager::create(());
-            opt::load_profile(profile.as_deref(), &pm);
-            pm.run_on(&ctx.module);
-            match emit {
-                OutputType::Header =>
-                    if let Some(out) = output {
-                        let mut file = std::fs::File::create(out)?;
-                        ctx.save(&mut file)?;
-                    }
-                    else {ctx.save(&mut std::io::stdout())?}
-                OutputType::HeaderObj => {
-                    let mut obj = libs::new_object(&trip);
-                    libs::populate_header(&mut obj, &ctx);
-                    let vec = obj.write()?;
-                    if let Some(out) = output {
-                        let mut file = std::fs::File::create(out)?;
-                        file.write_all(&vec)?;
-                    }
-                    else {std::io::stdout().write_all(&vec)?}
+        Cli::Aot {input, output, linked, mut link_dirs, headers, triple, emit, profile, continue_if_err, debug_mangle, no_default_link, timings} => {
+            let (result, overall) = timeit(|| {
+                if !no_default_link {
+                    if let Some(pwd) = std::env::current_dir().ok().and_then(|pwd| pwd.to_str().map(String::from)) {link_dirs.insert(0, pwd);}
+                    if let Ok(home) = std::env::var("HOME") {link_dirs.extend_from_slice(&[format!("{home}/.cobalt/packages"), format!("{home}/.local/lib/cobalt"), "/usr/local/lib/cobalt/packages".to_string(), "/usr/lib/cobalt/packages".to_string(), "/lib/cobalt/packages".to_string(), "/usr/local/lib".to_string(), "/usr/lib".to_string(), "/lib".to_string()]);}
+                    else {link_dirs.extend(["/usr/local/lib/cobalt/packages", "/usr/lib/cobalt/packages", "/lib/cobalt/packages", "/usr/local/lib", "/usr/lib", "/lib"].into_iter().map(String::from));}
                 }
-                OutputType::Llvm =>
-                    if let Some(out) = output {std::fs::write(out, ctx.module.to_string().as_bytes())?}
-                    else {println!("{}", ctx.module.to_string())},
-                OutputType::Bitcode =>
-                    if let Some(out) = output {std::fs::write(out, ctx.module.write_bitcode_to_memory().as_slice())?}
-                    else {std::io::stdout().write_all(ctx.module.write_bitcode_to_memory().as_slice())?},
-                OutputType::Assembly => {
-                    let code = target_machine.write_to_memory_buffer(&ctx.module, inkwell::targets::FileType::Assembly).unwrap();
-                    if let Some(out) = output {std::fs::write(out, code.as_slice())?}
-                    else {std::io::stdout().write_all(code.as_slice())?}
+                let (code, file_time) = timeit(|| if input == "-" {
+                    let mut s = String::new();
+                    std::io::stdin().read_to_string(&mut s)?;
+                    anyhow::Ok(s)
+                } else {Path::new(&input).read_to_string_anyhow()});
+                let code = code?;
+                if triple.is_some() {Target::initialize_all(&INIT_NEEDED)}
+                else {Target::initialize_native(&INIT_NEEDED).map_err(anyhow::Error::msg)?}
+                let triple = triple.unwrap_or_else(|| TargetMachine::get_default_triple().as_str().to_string_lossy().into_owned());
+                let trip = TargetTriple::create(&triple);
+                let output = output.map(String::from).unwrap_or_else(|| match emit {
+                    OutputType::Executable => format!("{}{}", input.rfind('.').map_or(input.as_str(), |i| &input[..i]), if triple.contains("windows") {".exe"} else {""}),
+                    OutputType::Library => libs::format_lib(input.rfind('.').map_or(input.as_str(), |i| &input[..i]), &trip),
+                    OutputType::Object => format!("{}.o", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
+                    OutputType::Assembly => format!("{}.s", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
+                    OutputType::Llvm => format!("{}.ll", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
+                    OutputType::Bitcode => format!("{}.bc", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
+                    OutputType::Header => format!("{}.coh", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
+                    OutputType::HeaderObj => format!("{}.coh.o", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
+                });
+                let output = if output == "-" {None} else {Some(output)};
+                let target_machine = Target::from_triple(&trip).unwrap().create_target_machine(
+                    &trip,
+                    "",
+                    "",
+                    inkwell::OptimizationLevel::None,
+                    inkwell::targets::RelocMode::PIC,
+                    inkwell::targets::CodeModel::Small
+                ).expect("failed to create target machine");
+                let mut flags = Flags::default();
+                flags.dbg_mangle = debug_mangle;
+                let ink_ctx = inkwell::context::Context::create();
+                if let Some(size) = ink_ctx.ptr_sized_int_type(&target_machine.get_target_data(), None).size_of().get_zero_extended_constant() {flags.word_size = size as u16;}
+                let ctx = CompCtx::with_flags(&ink_ctx, &input, flags);
+                ctx.module.set_triple(&trip);
+                let (libs, libs_time) = timeit(|| {
+                    let libs = if !linked.is_empty() {
+                        let (libs, notfound) = libs::find_libs(linked.iter().map(|x| x.to_string()).collect::<Vec<_>>(), &link_dirs.iter().map(|x| x.as_str()).collect::<Vec<_>>(), Some(&ctx))?;
+                        notfound.iter().for_each(|nf| error!("couldn't find library {nf}"));
+                        if !notfound.is_empty() {Err(Exit(102))?}
+                        libs
+                    } else {vec![]};
+                    for head in headers {
+                        let mut file = BufReader::new(std::fs::File::open(head)?);
+                        ctx.load(&mut file)?;
+                    }
+                    anyhow::Ok(libs)
+                });
+                let libs = libs?;
+                let mut fail = false;
+                let mut overall_fail = false;
+                let file = FILES.add_file(0, input.to_string(), code.clone());
+                let ((mut ast, errs), parse_time) = timeit(|| parse_tl(&code));
+                ast.file = Some(file);
+                for err in errs {fail |= err.is_err(); eprintln!("{:?}", Report::from(err).with_source_code(file));}
+                overall_fail |= fail;
+                fail = false;
+                if fail && !continue_if_err {anyhow::bail!(CompileErrors)}
+                let (errs, comp_time) = timeit(||ast.codegen(&ctx).1);
+                overall_fail |= fail;
+                fail = false;
+                for err in errs {fail |= err.is_err(); eprintln!("{:?}", Report::from(err).with_source_code(file));}
+                if fail && !continue_if_err {anyhow::bail!(CompileErrors)}
+                if let Err(msg) = ctx.module.verify() {
+                    error!("\n{}", msg.to_string());
+                    Err(Exit(101))?
                 }
-                _ => {
-                    let mb = target_machine.write_to_memory_buffer(&ctx.module, inkwell::targets::FileType::Object).unwrap();
-                    match emit {
-                        OutputType::Executable => {
-                            if output.is_none() {
-                                eprintln!("cannot output executable to stdout");
-                                exit(4)
-                            }
-                            let tmp = temp_file::with_contents(mb.as_slice());
-                            let mut cc = cc::CompileCommand::new();
-                            cc.obj(tmp.path());
-                            cc.output(output.unwrap());
-                            cc.link_libs(libs.into_iter().map(|(l, _)| l));
-                            cc.target(&triple);
-                            let res = cc.build()?.status_anyhow()?;
-                            std::mem::drop(tmp);
-                            exit(res.code().unwrap_or(-1));
-                        },
-                        OutputType::Library => {
-                            if let Some(output) = output {
-                                let mut obj = libs::new_object(&trip);
-                                libs::populate_header(&mut obj, &ctx);
-                                let tmp1 = temp_file::with_contents(&obj.write()?);
-                                let tmp2 = temp_file::with_contents(mb.as_slice());
+                if fail || overall_fail {anyhow::bail!(CompileErrors)}
+                let pre_len = insts(&ctx.module);
+                let opt_time = timeit(|| {
+                    let pm = inkwell::passes::PassManager::create(());
+                    opt::load_profile(profile.as_deref(), &pm);
+                    pm.run_on(&ctx.module);
+                }).1;
+                let post_len = insts(&ctx.module);
+                let (cg_time, cmdtime) = match emit {
+                    OutputType::Header => {
+                        let mut buf = vec![];
+                        let (res, cg_time) = timeit(|| ctx.save(&mut buf));
+                        res?;
+                        if let Some(out) = output {
+                            let mut file = std::fs::File::create(out)?;
+                            file.write_all(&buf)?;
+                        }
+                        else {std::io::stdout().write_all(&buf)?}
+                        (cg_time, None)
+                    }
+                    OutputType::HeaderObj => {
+                        let mut obj = libs::new_object(&trip);
+                        let (vec, cg_time) = timeit(|| {
+                            libs::populate_header(&mut obj, &ctx);
+                            obj.write()
+                        });
+                        let vec = vec?;
+                        if let Some(out) = output {
+                            let mut file = std::fs::File::create(out)?;
+                            file.write_all(&vec)?;
+                        }
+                        else {std::io::stdout().write_all(&vec)?}
+                        (cg_time, None)
+                    }
+                    OutputType::Llvm => {
+                        let (m, cg_time) = timeit(|| ctx.module.to_string());
+                        if let Some(out) = output {std::fs::write(out, &m)?}
+                        else {println!("{m}")}
+                        (cg_time, None)
+                    },
+                    OutputType::Bitcode => {
+                        let (m, cg_time) = timeit(|| ctx.module.write_bitcode_to_memory());
+                        if let Some(out) = output {std::fs::write(out, m.as_slice())?}
+                        else {std::io::stdout().write_all(m.as_slice())?}
+                        (cg_time, None)
+                    },
+                    OutputType::Assembly => {
+                        let (m, cg_time) = timeit(|| target_machine.write_to_memory_buffer(&ctx.module, inkwell::targets::FileType::Assembly).unwrap());
+                        if let Some(out) = output {std::fs::write(out, m.as_slice())?}
+                        else {std::io::stdout().write_all(m.as_slice())?}
+                        (cg_time, None)
+                    }
+                    _ => {
+                        let (mb, cg_time) = timeit(|| target_machine.write_to_memory_buffer(&ctx.module, inkwell::targets::FileType::Object).unwrap());
+                        let cmd_time = match emit {
+                            OutputType::Executable => {
+                                if output.is_none() {
+                                    eprintln!("cannot output executable to stdout");
+                                    Err(Exit(4))?;
+                                }
+                                let tmp = temp_file::with_contents(mb.as_slice());
                                 let mut cc = cc::CompileCommand::new();
-                                cc.lib(true);
-                                cc.objs([tmp1.path(), tmp2.path()]);
-                                cc.output(&output);
+                                cc.obj(tmp.path());
+                                cc.output(output.unwrap());
                                 cc.link_libs(libs.into_iter().map(|(l, _)| l));
                                 cc.target(&triple);
-                                let res = cc.build()?.status_anyhow()?;
-                                std::mem::drop(tmp1);
-                                std::mem::drop(tmp2);
-                                exit(res.code().unwrap_or(-1))
+                                let mut cmd = cc.build()?;
+                                let (res, cmdtime) = timeit(|| cmd.status_anyhow());
+                                let res = res?;
+                                std::mem::drop(tmp);
+                                let code = res.code().unwrap_or(-1);
+                                if code != 0 {Err(Exit(code))?}
+                                Some(cmdtime)
+                            },
+                            OutputType::Library => {
+                                if let Some(output) = output {
+                                    let mut obj = libs::new_object(&trip);
+                                    libs::populate_header(&mut obj, &ctx);
+                                    let tmp1 = temp_file::with_contents(&obj.write()?);
+                                    let tmp2 = temp_file::with_contents(mb.as_slice());
+                                    let mut cc = cc::CompileCommand::new();
+                                    cc.lib(true);
+                                    cc.objs([tmp1.path(), tmp2.path()]);
+                                    cc.output(&output);
+                                    cc.link_libs(libs.into_iter().map(|(l, _)| l));
+                                    cc.target(&triple);
+                                    let mut cmd = cc.build()?;
+                                    let (res, cmdtime) = timeit(|| cmd.status_anyhow());
+                                    let res = res?;
+                                    std::mem::drop(tmp1);
+                                    std::mem::drop(tmp2);
+                                    let code = res.code().unwrap_or(-1);
+                                    if code != 0 {Err(Exit(code))?}
+                                    Some(cmdtime)
+                                }
+                                else {error!("cannot output library to stdout!"); Err(Exit(4))?}
+                            },
+                            OutputType::Object => {
+                                if let Some(out) = output {std::fs::write(out, mb.as_slice())?}
+                                else {std::io::stdout().write_all(mb.as_slice())?}
+                                None
                             }
-                            else {error!("cannot output library to stdout!"); exit(4)}
-                        },
-                        OutputType::Object =>
-                            if let Some(out) = output {std::fs::write(out, mb.as_slice())?}
-                            else {std::io::stdout().write_all(mb.as_slice())?}
-                        x => unreachable!("{x:?} has already been handled")
+                            x => unreachable!("{x:?} has already been handled")
+                        };
+                        (cg_time, cmd_time)
                     }
+                };
+                anyhow::Ok((file_time, parse_time, libs_time, comp_time, opt_time, cg_time, cmdtime, code.len(), ast.nodes(), linked.len(), pre_len, post_len))
+            });
+            let (file, parse, comp, libs, opt, cg, cmd, len, nodes, nlibs, blen, alen) = result?;
+            if timings {
+                println!("----------------");
+                println!("overall time: {:>8}", overall.human_duration().to_string());
+                println!("reading file: {:>8} ({:6.3}%) @ {:>13}", file .human_duration().to_string(), file .as_secs_f64() / overall.as_secs_f64() * 100.0, (len   as f64 / file .as_secs_f64()).human_throughput_bytes().to_string());
+                println!("parsing code: {:>8} ({:6.3}%) @ {:>13}", parse.human_duration().to_string(), parse.as_secs_f64() / overall.as_secs_f64() * 100.0, (len   as f64 / parse.as_secs_f64()).human_throughput_bytes().to_string());
+                println!("LLVM codegen: {:>8} ({:6.3}%) @ {:>13}", comp .human_duration().to_string(), comp .as_secs_f64() / overall.as_secs_f64() * 100.0, (nodes as f64 / comp .as_secs_f64()).human_throughput(" node").to_string());
+                println!("optimization: {:>8} ({:6.3}%) @ {:>13}", opt  .human_duration().to_string(), opt  .as_secs_f64() / overall.as_secs_f64() * 100.0, (blen  as f64 / opt  .as_secs_f64()).human_throughput(" inst").to_string());
+                println!("output gen:   {:>8} ({:6.3}%) @ {:>13}", cg   .human_duration().to_string(), cg   .as_secs_f64() / overall.as_secs_f64() * 100.0, (alen  as f64 / cg   .as_secs_f64()).human_throughput(" inst").to_string());
+                if nlibs != 0 {
+                    println!("lib lookup:   {:>8} ({:6.3}%) @ {:>13}", libs.human_duration().to_string(), libs.as_secs_f64() / overall.as_secs_f64() * 100.0, (nlibs as f64 / libs.as_secs_f64()).human_throughput(" libs").to_string());
+                }
+                if let Some(cmd) = cmd {
+                    println!("external cmd: {:>8} ({:6.3}%)", cmd.human_duration().to_string(), cmd.as_secs_f64() / overall.as_secs_f64() * 100.0);
                 }
             }
-
         },
         Cli::Jit {input, linked, mut link_dirs, headers, profile, continue_if_err, no_default_link, this, mut args} => {
             if !no_default_link {
@@ -508,7 +618,7 @@ fn driver() -> anyhow::Result<()> {
             let libs = if !linked.is_empty() {
                 let (libs, notfound) = libs::find_libs(linked.iter().map(|x| x.to_string()).collect(), &link_dirs.iter().map(|x| x.as_str()).collect::<Vec<_>>(), Some(&ctx))?;
                 notfound.iter().for_each(|nf| error!("couldn't find library {nf}"));
-                if !notfound.is_empty() {exit(102)}
+                if !notfound.is_empty() {Err(Exit(102))?}
                 libs
             } else {vec![]};
             for head in headers {
@@ -531,7 +641,7 @@ fn driver() -> anyhow::Result<()> {
             if fail && !continue_if_err {anyhow::bail!(CompileErrors)}
             if let Err(msg) = ctx.module.verify() {
                 error!("\n{}", msg.to_string());
-                exit(101)
+                Err(Exit(101))?
             }
             if fail || overall_fail {anyhow::bail!(CompileErrors)}
             let pm = inkwell::passes::PassManager::create(());
@@ -551,63 +661,83 @@ fn driver() -> anyhow::Result<()> {
                     Err(FunctionLookupError::JITNotEnabled) => panic!("JIT not enabled here"),
                     Err(FunctionLookupError::FunctionNotFound) => {
                         eprintln!("couldn't find symbol 'main'");
-                        exit(255)
+                        Err(Exit(255))?
                     }
                 };
                 ee.run_static_constructors();
                 let ec = ee.run_function_as_main(main_fn, &args.iter().map(String::as_str).collect::<Vec<_>>());
                 ee.run_static_destructors();
-                exit(ec);
+                if ec != 0 {Err(Exit(ec))?}
             }
         },
-        Cli::Check {input, linked, mut link_dirs, headers, no_default_link} => {
-            if !no_default_link {
-                if let Some(pwd) = std::env::current_dir().ok().and_then(|pwd| pwd.to_str().map(String::from)) {link_dirs.insert(0, pwd);}
-                if let Ok(home) = std::env::var("HOME") {link_dirs.extend_from_slice(&[format!("{home}/.cobalt/packages"), format!("{home}/.local/lib/cobalt"), "/usr/local/lib/cobalt/packages".to_string(), "/usr/lib/cobalt/packages".to_string(), "/lib/cobalt/packages".to_string(), "/usr/local/lib".to_string(), "/usr/lib".to_string(), "/lib".to_string()]);}
-                else {link_dirs.extend(["/usr/local/lib/cobalt/packages", "/usr/lib/cobalt/packages", "/lib/cobalt/packages", "/usr/local/lib", "/usr/lib", "/lib"].into_iter().map(String::from));}
+        Cli::Check {input, linked, mut link_dirs, headers, no_default_link, timings} => {
+            let (result, overall) = timeit(|| {
+                if !no_default_link {
+                    if let Some(pwd) = std::env::current_dir().ok().and_then(|pwd| pwd.to_str().map(String::from)) {link_dirs.insert(0, pwd);}
+                    if let Ok(home) = std::env::var("HOME") {link_dirs.extend_from_slice(&[format!("{home}/.cobalt/packages"), format!("{home}/.local/lib/cobalt"), "/usr/local/lib/cobalt/packages".to_string(), "/usr/lib/cobalt/packages".to_string(), "/lib/cobalt/packages".to_string(), "/usr/local/lib".to_string(), "/usr/lib".to_string(), "/lib".to_string()]);}
+                    else {link_dirs.extend(["/usr/local/lib/cobalt/packages", "/usr/lib/cobalt/packages", "/lib/cobalt/packages", "/usr/local/lib", "/usr/lib", "/lib"].into_iter().map(String::from));}
+                }
+                
+                let (res, file_time) = timeit(|| anyhow::Ok(if input != "-" {(input.as_str(), Path::new(&input).read_to_string_anyhow()?)}
+                else {
+                    let mut s = String::new();
+                    std::io::stdin().read_to_string(&mut s)?;
+                    ("<stdin>", s)
+                }));
+                let (input, code) = res?;
+                Target::initialize_native(&INIT_NEEDED).map_err(anyhow::Error::msg)?;
+                let triple = TargetMachine::get_default_triple();
+                let target_machine = Target::from_triple(&triple).unwrap().create_target_machine(
+                    &triple,
+                    "",
+                    "",
+                    inkwell::OptimizationLevel::None,
+                    inkwell::targets::RelocMode::PIC,
+                    inkwell::targets::CodeModel::Small
+                ).expect("failed to create target machine");
+                let mut flags = Flags::default();
+                let ink_ctx = inkwell::context::Context::create();
+                if let Some(size) = ink_ctx.ptr_sized_int_type(&target_machine.get_target_data(), None).size_of().get_zero_extended_constant() {flags.word_size = size as u16;}
+                let ctx = CompCtx::with_flags(&ink_ctx, input, flags);
+                ctx.module.set_triple(&triple);
+                let (res, libs_time) = timeit(|| {
+                    if !linked.is_empty() {
+                        let (_, notfound) = libs::find_libs(linked.iter().map(|x| x.to_string()).collect(), &link_dirs.iter().map(|x| x.as_str()).collect::<Vec<_>>(), Some(&ctx))?;
+                        notfound.iter().for_each(|nf| error!("couldn't find library {nf}"));
+                        if !notfound.is_empty() {Err(Exit(102))?}
+                    }
+                    for head in headers {
+                        let mut file = BufReader::new(std::fs::File::open(head)?);
+                        ctx.load(&mut file)?;
+                    }
+                    anyhow::Ok(())
+                });
+                res?;
+                let mut fail = false;
+                let file = FILES.add_file(0, input.to_string(), code.clone());
+                let ((mut ast, errs), parse_time) = timeit(|| parse_tl(&code));
+                ast.file = Some(file);
+                for err in errs {fail |= err.is_err(); eprintln!("{:?}", Report::from(err).with_source_code(file));}
+                let (errs, comp_time) = timeit(|| ast.codegen(&ctx).1);
+                for err in errs {fail |= err.is_err(); eprintln!("{:?}", Report::from(err).with_source_code(file));}
+                if let Err(msg) = ctx.module.verify() {
+                    error!("\n{}", msg.to_string());
+                    anyhow::bail!(CompileErrors)
+                }
+                if fail {anyhow::bail!(CompileErrors)}
+                anyhow::Ok((file_time, parse_time, comp_time, libs_time, code.len(), ast.nodes(), linked.len()))
+            });
+            let (file, parse, comp, libs, len, nodes, nlibs) = result?;
+            if timings {
+                println!("----------------");
+                println!("overall time: {:>8}", overall.human_duration().to_string());
+                println!("reading file: {:>8} ({:6.3}%) @ {:>13}", file .human_duration().to_string(), file .as_secs_f64() / overall.as_secs_f64() * 100.0, (len   as f64 / file .as_secs_f64()).human_throughput_bytes().to_string());
+                println!("parsing code: {:>8} ({:6.3}%) @ {:>13}", parse.human_duration().to_string(), parse.as_secs_f64() / overall.as_secs_f64() * 100.0, (len   as f64 / parse.as_secs_f64()).human_throughput_bytes().to_string());
+                println!("LLVM codegen: {:>8} ({:6.3}%) @ {:>13}", comp .human_duration().to_string(), comp .as_secs_f64() / overall.as_secs_f64() * 100.0, (nodes as f64 / comp .as_secs_f64()).human_throughput(" node").to_string());
+                if nlibs != 0 {
+                    println!("lib lookup:   {:>8} ({:6.3}%) @ {:>13}", libs.human_duration().to_string(), libs.as_secs_f64() / overall.as_secs_f64() * 100.0, (nlibs as f64 / libs.as_secs_f64()).human_throughput(" libs").to_string());
+                }
             }
-            let (input, code) = if input != "-" {(input.as_str(), Path::new(&input).read_to_string_anyhow()?)}
-            else {
-                let mut s = String::new();
-                std::io::stdin().read_to_string(&mut s)?;
-                ("<stdin>", s)
-            };
-            Target::initialize_native(&INIT_NEEDED).map_err(anyhow::Error::msg)?;
-            let triple = TargetMachine::get_default_triple();
-            let target_machine = Target::from_triple(&triple).unwrap().create_target_machine(
-                &triple,
-                "",
-                "",
-                inkwell::OptimizationLevel::None,
-                inkwell::targets::RelocMode::PIC,
-                inkwell::targets::CodeModel::Small
-            ).expect("failed to create target machine");
-            let mut flags = Flags::default();
-            let ink_ctx = inkwell::context::Context::create();
-            if let Some(size) = ink_ctx.ptr_sized_int_type(&target_machine.get_target_data(), None).size_of().get_zero_extended_constant() {flags.word_size = size as u16;}
-            let ctx = CompCtx::with_flags(&ink_ctx, input, flags);
-            ctx.module.set_triple(&triple);
-            if !linked.is_empty() {
-                let (_, notfound) = libs::find_libs(linked.iter().map(|x| x.to_string()).collect(), &link_dirs.iter().map(|x| x.as_str()).collect::<Vec<_>>(), Some(&ctx))?;
-                notfound.iter().for_each(|nf| error!("couldn't find library {nf}"));
-                if !notfound.is_empty() {exit(102)}
-            }
-            for head in headers {
-                let mut file = BufReader::new(std::fs::File::open(head)?);
-                ctx.load(&mut file)?;
-            }
-            let mut fail = false;
-            let file = FILES.add_file(0, input.to_string(), code.clone());
-            let (mut ast, errs) = parse_tl(&code);
-            ast.file = Some(file);
-            for err in errs {fail |= err.is_err(); eprintln!("{:?}", Report::from(err).with_source_code(file));}
-            let (_, errs) = ast.codegen(&ctx);
-            for err in errs {fail |= err.is_err(); eprintln!("{:?}", Report::from(err).with_source_code(file));}
-            if let Err(msg) = ctx.module.verify() {
-                error!("\n{}", msg.to_string());
-                anyhow::bail!(CompileErrors)
-            }
-            if fail {anyhow::bail!(CompileErrors)}
         },
         Cli::Project(cmd) => match cmd {
             ProjSubcommand::Track {projects: None} => {
@@ -817,7 +947,8 @@ fn driver() -> anyhow::Result<()> {
                 let mut exe_path = build_dir;
                 if triple.as_str().to_str().ok().map_or(false, |t| t.contains("windows")) {target.push_str(".exe");}
                 exe_path.push(target);
-                exit(Command::new(exe_path).args(args).status()?.code().unwrap_or(-1))
+                let code = Command::new(exe_path).args(args).status()?.code().unwrap_or(-1);
+                if code != 0 {Err(Exit(code))?}
             },
         },
         Cli::Package(cmd) => match cmd {
@@ -829,7 +960,12 @@ fn driver() -> anyhow::Result<()> {
 }
 fn main() {
     if let Err(err) = driver() {
-        error!("{err:#}");
-        exit(100);
+        match err.downcast() {
+            Ok(Exit(code)) => std::process::exit(code),
+            Err(err) => {
+                error!("{err:#}");
+                std::process::exit(101);
+            }
+        }
     }
 }


### PR DESCRIPTION
This moves all of the debug-only subcommands into a separate subcommand, making it clearer what can and can't be done on a release build. You can also print the timings of some commands using the `--timing` flag.

## Commits
- Add node counter for ASTs
- Move debug-only commands to their own subcommand
- Add utilities for getting compilation time
