### PR TITLE
Improve support for statically-sized arrays

### DIFF
--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -285,7 +285,7 @@ impl AST for ArrayLiteralAST {
                 let arr_ty = llt.array_type(elems.len() as u32);
                 elems.iter().enumerate().try_fold(arr_ty.get_undef(), |val, (n, v)| ctx.builder.build_insert_value(val, v.comp_val?, n as _, "").map(|v| v.into_array_value())).map(Into::into)
             } else {None},
-            Some(InterData::Array(elems.into_iter().map(|v| v.inter_val.unwrap_or(InterData::Null)).collect())),
+            elems.into_iter().map(|v| v.inter_val).collect::<Option<_>>().map(InterData::Array),
             Type::Array(Box::new(ty), Some(len as u32))
         ), errs)
     }

--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -331,10 +331,10 @@ impl AST for TupleLiteralAST {
     fn res_type(&self, ctx: &CompCtx) -> Type {
         Type::Tuple(self.vals.iter().map(|x| match x.res_type(ctx) {
             Type::IntLiteral => Type::Int(64, false),
-            Type::Reference(b, m) => if b.register(ctx) {
+            Type::Reference(b, m) => {
                 if x.expl_type(ctx) {Type::Reference(b, m)}
                 else {*b}
-            } else {Type::Reference(b, m)}
+            },
             x => x
         }).collect())
     }
@@ -344,7 +344,7 @@ impl AST for TupleLiteralAST {
             let mut v = x.codegen_errs(ctx, &mut errs);
             match v.data_type {
                 Type::IntLiteral => Value {data_type: Type::Int(64, false), ..v},
-                Type::Reference(b, m) => if b.register(ctx) {
+                Type::Reference(b, m) => {
                     if x.expl_type(ctx) {Value {data_type: Type::Reference(b, m), ..v}}
                     else {
                         if !ctx.is_const.get() {
@@ -355,7 +355,7 @@ impl AST for TupleLiteralAST {
                         v.data_type = *b;
                         v
                     }
-                } else {Value {data_type: Type::Reference(b, m), ..v}}
+                },
                 x => Value {data_type: x, ..v}
             }
         }).map(|Value {comp_val, inter_val, data_type, ..}| (comp_val, (inter_val, data_type))).unzip();

--- a/cobalt-ast/src/ast/misc.rs
+++ b/cobalt-ast/src/ast/misc.rs
@@ -56,7 +56,7 @@ impl AST for BitCastAST {
         let t = types::utils::impl_convert(self.target.loc(), (self.target.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
         ctx.is_const.set(oic);
         while let Type::Reference(b, _) = val.data_type {
-            if !ctx.is_const.get() && b.register(ctx) {
+            if !ctx.is_const.get() {
                 if let Some(inkwell::values::BasicValueEnum::PointerValue(pv)) = val.comp_val {
                     val.address = Rc::new(Cell::new(Some(pv)));
                     val.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), pv, ""));

--- a/cobalt-ast/src/ast/vars.rs
+++ b/cobalt-ast/src/ast/vars.rs
@@ -599,7 +599,7 @@ impl AST for VarDefAST {
                 Value::error()
             });
             ctx.restore_scope(old_scope);
-            match if ctx.is_const.get() || (val.data_type.register(ctx) && stack.is_none()) {
+            match if ctx.is_const.get() || stack.is_none() {
                 ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData {scope: ctx.var_scope.get().try_into().ok(), ..VariableData::with_vis(self.loc, false)})))
             } 
             else if let (Some(t), Some(v)) = (val.data_type.llvm_type(ctx), val.value(ctx)) {

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -190,14 +190,6 @@ impl Type {
             Nominal(n) => ctx.nominals.borrow()[n].0.llvm_type(ctx)
         }
     }
-    pub fn register(&self, ctx: &CompCtx) -> bool {
-        match self {
-            IntLiteral | Int(_, _) | Float16 | Float32 | Float64 | Float128 | Null | Function(..) | Pointer(..) | Reference(..) | BoundMethod(..) => true,
-            Tuple(v) => v.iter().all(|x| x.register(ctx)),
-            Nominal(n) => ctx.nominals.borrow()[n].0.register(ctx),
-            _ => false
-        }
-    }
     pub fn copyable(&self, ctx: &CompCtx) -> bool {
         match self {
             IntLiteral | Int(_, _) | Float16 | Float32 | Float64 | Float128 | Null | Function(..) | Pointer(..) | Reference(..) | BoundMethod(..) => true,

--- a/cobalt-ast/src/types/utils.rs
+++ b/cobalt-ast/src/types/utils.rs
@@ -234,7 +234,7 @@ pub fn bin_op<'ctx>(loc: SourceSpan, (mut lhs, lloc): (Value<'ctx>, SourceSpan),
     match (lhs.data_type.clone(), rhs.data_type.clone()) {
         (Type::Reference(l, false), _r) => {
             lhs.data_type = *l;
-            if !ctx.is_const.get() && lhs.data_type.register(ctx) {
+            if !ctx.is_const.get() {
                 if let (Some(t), Some(PointerValue(v))) = (lhs.data_type.llvm_type(ctx), lhs.comp_val) {
                     lhs.comp_val = Some(ctx.builder.build_load(t, v, ""));
                 }
@@ -246,7 +246,7 @@ pub fn bin_op<'ctx>(loc: SourceSpan, (mut lhs, lloc): (Value<'ctx>, SourceSpan),
         },
         (_l, Type::Reference(r, _)) => {
             rhs.data_type = *r;
-            if !ctx.is_const.get() && rhs.data_type.register(ctx) {
+            if !ctx.is_const.get() {
                 if let (Some(t), Some(PointerValue(v))) = (rhs.data_type.llvm_type(ctx), rhs.comp_val) {
                     rhs.comp_val = Some(ctx.builder.build_load(t, v, ""));
                 }
@@ -373,7 +373,7 @@ pub fn bin_op<'ctx>(loc: SourceSpan, (mut lhs, lloc): (Value<'ctx>, SourceSpan),
                 },
                 _ => {
                     lhs.data_type = l;
-                    if !ctx.is_const.get() && lhs.data_type.register(ctx) {
+                    if !ctx.is_const.get() {
                         if let Some(PointerValue(v)) = lhs.comp_val {
                             lhs.comp_val = Some(ctx.builder.build_load(lhs.data_type.llvm_type(ctx).unwrap(), v, ""));
                         }
@@ -490,7 +490,7 @@ pub fn bin_op<'ctx>(loc: SourceSpan, (mut lhs, lloc): (Value<'ctx>, SourceSpan),
                     },
                     _ => {
                         lhs.data_type = Type::Int(ls, lu);
-                        if !ctx.is_const.get() && lhs.data_type.register(ctx) {
+                        if !ctx.is_const.get() {
                             if let Some(PointerValue(v)) = lhs.comp_val {
                                 lhs.comp_val = Some(ctx.builder.build_load(ctx.context.custom_width_int_type(ls as u32), v, ""));
                             }
@@ -614,7 +614,7 @@ pub fn bin_op<'ctx>(loc: SourceSpan, (mut lhs, lloc): (Value<'ctx>, SourceSpan),
                 },
                 _ => {
                     lhs.data_type = Type::Pointer(b, m);
-                    if !ctx.is_const.get() && lhs.data_type.register(ctx) {
+                    if !ctx.is_const.get() {
                         if let Some(v) = lhs.comp_val {
                             lhs.comp_val = Some(ctx.builder.build_load(ctx.null_type.ptr_type(Default::default()), v.into_pointer_value(), ""));
                         }
@@ -633,7 +633,7 @@ pub fn bin_op<'ctx>(loc: SourceSpan, (mut lhs, lloc): (Value<'ctx>, SourceSpan),
             },
             (l, _) => {
                 lhs.data_type = l;
-                if !ctx.is_const.get() && lhs.data_type.register(ctx) {
+                if !ctx.is_const.get() {
                     if let Some(PointerValue(v)) = lhs.comp_val {
                         lhs.comp_val = Some(ctx.builder.build_load(lhs.data_type.llvm_type(ctx).unwrap(), v, ""));
                     }
@@ -1331,7 +1331,7 @@ pub fn pre_op<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, SourceSpan),
         }
         else {
             val.data_type = *x;
-            if !ctx.is_const.get() && val.data_type.register(ctx) {
+            if !ctx.is_const.get() {
                 if let Some(v) = val.comp_val {
                     val.comp_val = Some(ctx.builder.build_load(val.data_type.llvm_type(ctx).unwrap(), v.into_pointer_value(), ""));
                 }
@@ -1370,7 +1370,7 @@ pub fn pre_op<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, SourceSpan),
                     },
                     _ => {
                         val.data_type = x;
-                        if !ctx.is_const.get() && val.data_type.register(ctx) {
+                        if !ctx.is_const.get() {
                             if let Some(v) = val.comp_val {
                                 val.comp_val = Some(ctx.builder.build_load(val.data_type.llvm_type(ctx).unwrap(), v.into_pointer_value(), ""));
                             }
@@ -1403,7 +1403,7 @@ pub fn pre_op<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, SourceSpan),
                     },
                     _ => {
                         val.data_type = x;
-                        if !ctx.is_const.get() && val.data_type.register(ctx) {
+                        if !ctx.is_const.get() {
                             if let Some(v) = val.comp_val {
                                 val.comp_val = Some(ctx.builder.build_load(val.data_type.llvm_type(ctx).unwrap(), v.into_pointer_value(), ""));
                             }
@@ -1436,7 +1436,7 @@ pub fn pre_op<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, SourceSpan),
                     },
                     _ => {
                         val.data_type = Type::Pointer(b, m);
-                        if !ctx.is_const.get() && val.data_type.register(ctx) {
+                        if !ctx.is_const.get() {
                             if let Some(v) = val.comp_val {
                                 val.comp_val = Some(ctx.builder.build_load(ctx.null_type.ptr_type(Default::default()), v.into_pointer_value(), ""));
                             }
@@ -1446,7 +1446,7 @@ pub fn pre_op<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, SourceSpan),
                 },
                 x => {
                     val.data_type = x;
-                    if !ctx.is_const.get() && val.data_type.register(ctx) {
+                    if !ctx.is_const.get() {
                         if let Some(v) = val.comp_val {
                             val.comp_val = Some(ctx.builder.build_load(val.data_type.llvm_type(ctx).unwrap(), v.into_pointer_value(), ""));
                         }
@@ -1560,7 +1560,7 @@ pub fn subscript<'ctx>((mut val, vloc): (Value<'ctx>, SourceSpan), (mut idx, ilo
     };
     match idx.data_type {
         Type::Reference(x, _) => {
-            if x.register(ctx) && !ctx.is_const.get() {
+            if !ctx.is_const.get() {
                 if let Some(PointerValue(v)) = idx.comp_val {
                     idx.comp_val = Some(ctx.builder.build_load(x.llvm_type(ctx).unwrap(), v, ""));
                 }
@@ -1724,7 +1724,7 @@ pub fn subscript<'ctx>((mut val, vloc): (Value<'ctx>, SourceSpan), (mut idx, ilo
                         _ => Err(err)
                     },
                     x => {
-                        if !ctx.is_const.get() || x.register(ctx) {
+                        if !ctx.is_const.get()  {
                             if let Some(PointerValue(v)) = val.comp_val {
                                 val.comp_val = Some(ctx.builder.build_load(x.llvm_type(ctx).unwrap(), v, ""));
                             }
@@ -1811,7 +1811,7 @@ pub fn impl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
                         _ => Err(err)
                     },
                     b => {
-                        if !ctx.is_const.get() && b.register(ctx) {
+                        if !ctx.is_const.get() {
                             if let Some(PointerValue(v)) = val.comp_val {
                                 val.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
                                 val.address.set(Some(v));
@@ -1854,7 +1854,7 @@ pub fn impl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
                     _ => Err(err)
                 },
                 b => {
-                    if !ctx.is_const.get() && b.register(ctx) {
+                    if !ctx.is_const.get() {
                         if let Some(PointerValue(v)) = val.comp_val {
                             val.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
                             val.address.set(Some(v));
@@ -2010,7 +2010,7 @@ pub fn expl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
                         _ => Err(err)
                     },
                     b => {
-                        if !ctx.is_const.get() && b.register(ctx) {
+                        if !ctx.is_const.get() {
                             if let Some(PointerValue(v)) = val.comp_val {
                                 val.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
                             }
@@ -2052,7 +2052,7 @@ pub fn expl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
                     _ => Err(err)
                 },
                 b => {
-                    if !ctx.is_const.get() && b.register(ctx) {
+                    if !ctx.is_const.get() {
                         if let Some(PointerValue(v)) = val.comp_val {
                             val.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
                         }
@@ -2251,10 +2251,8 @@ pub fn attr<'ctx>((mut val, vloc): (Value<'ctx>, SourceSpan), (id, iloc): (&str,
             }
             else {
                 val.data_type = (**b).clone();
-                if val.data_type.register(ctx) {
-                    if let Some(PointerValue(v)) = val.value(ctx) {
-                        val.comp_val = Some(ctx.builder.build_load(val.data_type.llvm_type(ctx).unwrap(), v, ""));
-                    }
+                if let Some(PointerValue(v)) = val.value(ctx) {
+                    val.comp_val = Some(ctx.builder.build_load(val.data_type.llvm_type(ctx).unwrap(), v, ""));
                 }
                 attr((val, vloc), (id, iloc), ctx)
             }
@@ -2293,7 +2291,7 @@ fn prep_asm<'ctx>(mut arg: Value<'ctx>, ctx: &CompCtx<'ctx>) -> Option<(BasicMet
     match arg.data_type {
         Type::Reference(b, _) => {
             arg.data_type = *b;
-            if let (Some(PointerValue(val)), true) = (arg.value(ctx), arg.data_type.register(ctx)) {
+            if let Some(PointerValue(val)) = arg.value(ctx) {
                 arg.comp_val = Some(ctx.builder.build_load(arg.data_type.llvm_type(ctx).unwrap(), val, ""));
             }
             prep_asm(arg, ctx)
@@ -2350,7 +2348,7 @@ pub fn call<'ctx>(mut target: Value<'ctx>, loc: SourceSpan, cparen: Option<Sourc
                     }
                 },
                 b => {
-                    if !ctx.is_const.get() && b.register(ctx) {
+                    if !ctx.is_const.get() {
                         if let Some(PointerValue(v)) = target.comp_val {
                             target.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
                         }
@@ -2634,7 +2632,7 @@ pub fn call<'ctx>(mut target: Value<'ctx>, loc: SourceSpan, cparen: Option<Sourc
                         loop {
                             match arg.data_type {
                                 Type::Reference(b, _) => {
-                                    if b.register(ctx) && !ctx.is_const.get() {
+                                    if !ctx.is_const.get() {
                                         if let Some(PointerValue(v)) = arg.comp_val {
                                             arg.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
                                         }


### PR DESCRIPTION
Statically-sized arrays can now be treated as values, and they can be passed around by value. In addition, there are now not any cases in which `let` declarations can create a symbol that's a reference.