### PR TITLE
Cli improvements

### DIFF
--- a/cobalt-build/src/cc.rs
+++ b/cobalt-build/src/cc.rs
@@ -161,7 +161,7 @@ impl CompileCommand {
     pub fn search_libs<L: AsRef<str>, I: IntoIterator<Item = L>, P: AsRef<Path>, D: IntoIterator<Item = P>>(&mut self, libs: I, dirs: D, ctx: Option<&CompCtx>, load: bool) -> Result<Vec<L>, anyhow::Error> {
         let mut lib_dirs = self.lib_dirs()?;
         self.dirs.extend(dirs.into_iter().map(|p| p.as_ref().to_path_buf()));
-        lib_dirs.clone_from(&self.dirs);
+        lib_dirs.extend_from_slice(&self.dirs);
         let mut remaining = libs.into_iter().collect::<Vec<_>>();
         let triple = inkwell::targets::TargetMachine::get_default_triple();
         let triple = self.target_.as_deref().unwrap_or_else(|| triple.as_str().to_str().unwrap());

--- a/cobalt-build/src/lib.rs
+++ b/cobalt-build/src/lib.rs
@@ -6,6 +6,8 @@ pub mod pkg;
 pub mod graph;
 pub mod cc;
 
+pub mod obj;
+
 use thiserror::Error;
 use cobalt_ast::*;
 use std::io::{self, prelude::*, ErrorKind};

--- a/cobalt-build/src/obj.rs
+++ b/cobalt-build/src/obj.rs
@@ -168,13 +168,3 @@ pub fn get_writeable_object_from_file(in_object: object::File) -> object::write:
 
     out_object
 }
-
-pub fn write_object_to_file<P>(path: P, obj: &object::write::Object) -> anyhow::Result<()> 
-where
-    P: AsRef<std::path::Path> 
-{
-    let out_data = obj.write()?;
-    std::fs::write(path, out_data)?;
-
-    Ok(())
-}

--- a/cobalt-build/src/obj.rs
+++ b/cobalt-build/src/obj.rs
@@ -1,0 +1,180 @@
+//! ob
+
+use std::collections::HashMap;
+
+use object::{self, write, Object, ObjectSection, ObjectSymbol, ObjectComdat};
+
+pub fn get_writeable_object_from_file(in_object: object::File) -> object::write::Object {
+    let mut out_object = object::write::Object::new(
+        in_object.format(),
+        in_object.architecture(),
+        in_object.endianness(),
+    );
+    out_object.mangling = object::write::Mangling::None;
+    out_object.flags = in_object.flags();
+
+    // Need to copy over:
+    // - sections
+    // - symbols
+
+    let mut out_sections = HashMap::new();
+    for in_section in in_object.sections() {
+        if in_section.kind() == object::SectionKind::Metadata {
+            continue;
+        }
+
+        let section_id = out_object.add_section(
+            in_section
+                .segment_name()
+                .unwrap()
+                .unwrap_or("")
+                .as_bytes()
+                .to_vec(),
+            in_section.name().unwrap().as_bytes().to_vec(),
+            in_section.kind(),
+        );
+
+        let out_section = out_object.section_mut(section_id);
+        if out_section.is_bss() {
+            out_section.append_bss(in_section.size(), in_section.align());
+        } else {
+            out_section.set_data(in_section.data().unwrap(), in_section.align());
+        }
+        out_section.flags = in_section.flags();
+
+        out_sections.insert(in_section.index(), section_id);
+    }
+
+    let mut out_symbols = HashMap::new();
+    for in_symbol in in_object.symbols() {
+        if in_symbol.kind() == object::SymbolKind::Null {
+            continue;
+        }
+
+        let (section, value) = match in_symbol.section() {
+            object::SymbolSection::None => {
+                (object::write::SymbolSection::None, in_symbol.address())
+            }
+            object::SymbolSection::Undefined => {
+                (object::write::SymbolSection::Undefined, in_symbol.address())
+            }
+            object::SymbolSection::Absolute => {
+                (object::write::SymbolSection::Absolute, in_symbol.address())
+            }
+            object::SymbolSection::Common => {
+                (object::write::SymbolSection::Common, in_symbol.address())
+            }
+            object::SymbolSection::Section(index) => {
+                if let Some(out_section) = out_sections.get(&index) {
+                    (
+                        object::write::SymbolSection::Section(*out_section),
+                        in_symbol.address() - in_object.section_by_index(index).unwrap().address(),
+                    )
+                } else {
+                    // Ignore symbols for sections that we have skipped
+                    assert_eq!(in_symbol.kind(), object::SymbolKind::Section);
+                    continue;
+                }
+            }
+            _ => panic!("unknown symbol section for {:?}", in_symbol),
+        };
+
+        let flags = match in_symbol.flags() {
+            object::SymbolFlags::None => object::SymbolFlags::None,
+            object::SymbolFlags::Elf { st_info, st_other } => object::SymbolFlags::Elf { st_info, st_other },
+            object::SymbolFlags::MachO { n_desc } => object::SymbolFlags::MachO { n_desc },
+            object::SymbolFlags::CoffSection {
+                selection,
+                associative_section,
+            } => {
+                let associative_section =
+                    associative_section.map(|index| *out_sections.get(&index).unwrap());
+                object::SymbolFlags::CoffSection {
+                    selection,
+                    associative_section,
+                }
+            }
+            object::SymbolFlags::Xcoff {
+                n_sclass,
+                x_smtyp,
+                x_smclas,
+                containing_csect,
+            } => {
+                let containing_csect =
+                    containing_csect.map(|index| *out_symbols.get(&index).unwrap());
+                object::SymbolFlags::Xcoff {
+                    n_sclass,
+                    x_smtyp,
+                    x_smclas,
+                    containing_csect,
+                }
+            }
+            _ => panic!("unknown symbol flags for {:?}", in_symbol),
+        };
+
+        let out_symbol = object::write::Symbol {
+            name: in_symbol.name().unwrap_or("").as_bytes().to_vec(),
+            value,
+            size: in_symbol.size(),
+            kind: in_symbol.kind(),
+            scope: in_symbol.scope(),
+            weak: in_symbol.is_weak(),
+            section,
+            flags,
+        };
+
+        let symbol_id = out_object.add_symbol(out_symbol);
+        out_symbols.insert(in_symbol.index(), symbol_id);
+    }
+
+    for in_section in in_object.sections() {
+        if in_section.kind() == object::SectionKind::Metadata {
+            continue;
+        }
+        let out_section = *out_sections.get(&in_section.index()).unwrap();
+        for (offset, in_relocation) in in_section.relocations() {
+            let symbol = match in_relocation.target() {
+                object::RelocationTarget::Symbol(symbol) => *out_symbols.get(&symbol).unwrap(),
+                object::RelocationTarget::Section(section) => {
+                    out_object.section_symbol(*out_sections.get(&section).unwrap())
+                }
+                _ => panic!("unknown relocation target for {:?}", in_relocation),
+            };
+            let out_relocation = write::Relocation {
+                offset,
+                size: in_relocation.size(),
+                kind: in_relocation.kind(),
+                encoding: in_relocation.encoding(),
+                symbol,
+                addend: in_relocation.addend(),
+            };
+            out_object
+                .add_relocation(out_section, out_relocation)
+                .unwrap();
+        }
+    }
+
+    for in_comdat in in_object.comdats() {
+        let mut sections = Vec::new();
+        for in_section in in_comdat.sections() {
+            sections.push(*out_sections.get(&in_section).unwrap());
+        }
+        out_object.add_comdat(write::Comdat {
+            kind: in_comdat.kind(),
+            symbol: *out_symbols.get(&in_comdat.symbol()).unwrap(),
+            sections,
+        });
+    }
+
+    out_object
+}
+
+pub fn write_object_to_file<P>(path: P, obj: &object::write::Object) -> anyhow::Result<()> 
+where
+    P: AsRef<std::path::Path> 
+{
+    let out_data = obj.write()?;
+    std::fs::write(path, out_data)?;
+
+    Ok(())
+}

--- a/cobalt-cli/Cargo.toml
+++ b/cobalt-cli/Cargo.toml
@@ -20,6 +20,8 @@ clap = { version = "4.3.0", features = ["derive"] }
 const_format = "0.2.31"
 human-repr = "1.1.0"
 
+object = { version = "0.31.1", features = ["write"] }
+
 [build-dependencies]
 lazy_static = "1.4"
 regex = "1.8"

--- a/cobalt-cli/src/main.rs
+++ b/cobalt-cli/src/main.rs
@@ -921,9 +921,8 @@ fn driver() -> anyhow::Result<()> {
                 reporter.nlibs = linked.len();
                 let start = Instant::now();
                 if !linked.is_empty() {
-                    let notfound = cc.search_libs(linked, link_dirs, Some(&ctx), false)?;
+                    let notfound = cc.search_libs(linked, link_dirs, Some(&ctx), true)?;
                     if !notfound.is_empty() {anyhow::bail!(LibsNotFound(notfound))}
-                    cc.libs.iter().for_each(|f| {inkwell::support::load_library_permanently(f.as_os_str().to_str().unwrap());});
                 }
                 for head in headers {
                     let mut file = BufReader::new(std::fs::File::open(head)?);
@@ -1507,7 +1506,7 @@ fn driver() -> anyhow::Result<()> {
                     reporter.nlibs = linked.len();
                     let start = Instant::now();
                     if !linked.is_empty() {
-                        let notfound = cc.search_libs(linked, link_dirs, Some(&ctx), false)?;
+                        let notfound = cc.search_libs(linked, link_dirs, Some(&ctx), true)?;
                         if !notfound.is_empty() {anyhow::bail!(LibsNotFound(notfound))}
                     }
                     for head in headers {

--- a/cobalt-cli/src/main.rs
+++ b/cobalt-cli/src/main.rs
@@ -12,8 +12,6 @@ use clap::{Parser, Subcommand, ValueEnum};
 use std::time::{Instant, Duration};
 use human_repr::*;
 
-use object;
-
 use cobalt_ast::{CompCtx, AST};
 use cobalt_errors::*;
 use cobalt_build::*;
@@ -29,6 +27,8 @@ enum OutputType {
     Library,
     #[value(name = "obj")]
     Object,
+    #[value(name = "raw-obj")]
+    RawObject,
     #[value(name = "asm")]
     Assembly,
     #[value(name = "llvm")]
@@ -38,9 +38,7 @@ enum OutputType {
     #[value(name = "header")]
     Header,
     #[value(name = "header-obj")]
-    HeaderObj,
-    #[value(name = "TEST-combined-obj-headerobj")]
-    TestCombinedObjHeaderObj
+    HeaderObj
 }
 impl fmt::Display for OutputType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -48,12 +46,12 @@ impl fmt::Display for OutputType {
             Self::Executable => "exe",
             Self::Library => "lib",
             Self::Object => "obj",
+            Self::RawObject => "raw-obj",
             Self::Assembly => "asm",
             Self::Llvm => "llvm",
             Self::Bitcode => "bc",
             Self::Header => "header",
-            Self::HeaderObj => "header-obj",
-            Self::TestCombinedObjHeaderObj => "TEST-combined-obj-headerobj"
+            Self::HeaderObj => "header-obj"
         })
     }
 }
@@ -673,7 +671,8 @@ fn driver() -> anyhow::Result<()> {
             let mut output = output.map(String::from).or_else(|| (input != "-").then(|| match emit {
                 OutputType::Executable => format!("{}{}", input.rfind('.').map_or(input.as_str(), |i| &input[..i]), if triple.contains("windows") {".exe"} else {""}),
                 OutputType::Library => libs::format_lib(input.rfind('.').map_or(input.as_str(), |i| &input[..i]), &trip),
-                OutputType::Object | OutputType::TestCombinedObjHeaderObj => format!("{}.o", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
+                OutputType::RawObject => format!("{}.raw.o", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
+                OutputType::Object => format!("{}.o", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
                 OutputType::Assembly => format!("{}.s", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
                 OutputType::Llvm => format!("{}.ll", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
                 OutputType::Bitcode => format!("{}.bc", input.rfind('.').map_or(input.as_str(), |i| &input[..i])),
@@ -747,11 +746,8 @@ fn driver() -> anyhow::Result<()> {
                         obj.write()
                     })?;
                     reporter.cg_time = Some(cg_time);
-                    if let Some(out) = output {
-                        let mut file = std::fs::File::create(out)?;
-                        file.write_all(&vec)?;
-                    }
-                    else {std::io::stdout().write_all(&vec)?;}
+                    if let Some(path) = output {Path::new(&path).write_anyhow(vec)?}
+                    else {std::io::stdout().write_all(&vec)?}
                 }
                 OutputType::Llvm => {
                     let (m, cg_time) = timeit(|| ctx.module.to_string());
@@ -762,13 +758,13 @@ fn driver() -> anyhow::Result<()> {
                 OutputType::Bitcode => {
                     let (m, cg_time) = timeit(|| ctx.module.write_bitcode_to_memory());
                     reporter.cg_time = Some(cg_time);
-                    if let Some(out) = output {std::fs::write(out, m.as_slice())?}
+                    if let Some(path) = output {Path::new(&path).write_anyhow(m.as_slice())?}
                     else {std::io::stdout().write_all(m.as_slice())?}
                 }
                 OutputType::Assembly => {
                     let (m, cg_time) = timeit(|| target_machine.write_to_memory_buffer(&ctx.module, inkwell::targets::FileType::Assembly).unwrap());
                     reporter.cg_time = Some(cg_time);
-                    if let Some(out) = output {std::fs::write(out, m.as_slice())?}
+                    if let Some(path) = output {Path::new(&path).write_anyhow(m.as_slice())?}
                     else {std::io::stdout().write_all(m.as_slice())?}
                 }
                 _ => {
@@ -806,17 +802,17 @@ fn driver() -> anyhow::Result<()> {
                             }
                             else {error!("cannot output library to stdout!"); Err(Exit(4))?}
                         }
-                        OutputType::Object => {
-                            if let Some(out) = output {std::fs::write(out, mb.as_slice())?}
+                        OutputType::RawObject => {
+                            if let Some(path) = output {Path::new(&path).write_anyhow(mb.as_slice())?}
                             else {std::io::stdout().write_all(mb.as_slice())?}
                         }
-                        OutputType::TestCombinedObjHeaderObj => {
+                        OutputType::Object => {
                             let parsed_llvm_object = object::read::File::parse(mb.as_slice())?;
                             let mut writeable_object = obj::get_writeable_object_from_file(parsed_llvm_object);
                             libs::populate_header(&mut writeable_object, &ctx);
-                            obj::write_object_to_file(
-                                std::path::Path::new("testing.o"), &writeable_object
-                            )?;
+                            let buf = writeable_object.write()?;
+                            if let Some(path) = output {Path::new(&path).write_anyhow(buf)?}
+                            else {std::io::stdout().write_all(&buf)?}
                         }
                         x => unreachable!("{x:?} has already been handled")
                     };
@@ -1297,8 +1293,7 @@ fn driver() -> anyhow::Result<()> {
                             out.set_extension("coh");
                             let mut buf = vec![];
                             *reporter.cg_time.get_or_insert(Duration::ZERO) += try_timeit(|| ctx.save(&mut buf))?.1;
-                            let mut file = std::fs::File::create(out)?;
-                            file.write_all(&buf)?;
+                            Path::new(&out).write_anyhow(buf)?;
                             Zero
                         }
                         OutputType::HeaderObj => {
@@ -1309,29 +1304,28 @@ fn driver() -> anyhow::Result<()> {
                                 obj.write()
                             })?;
                             *reporter.cg_time.get_or_insert(Duration::ZERO) += cg_time;
-                            let mut file = std::fs::File::create(out)?;
-                            file.write_all(&vec)?;
+                            Path::new(&out).write_anyhow(vec)?;
                             Zero
                         }
                         OutputType::Llvm => {
                             out.set_extension("ll");
                             let (m, cg_time) = timeit(|| ctx.module.to_string());
                             *reporter.cg_time.get_or_insert(Duration::ZERO) += cg_time;
-                            std::fs::write(out, m)?;
+                            Path::new(&out).write_anyhow(m)?;
                             Zero
                         }
                         OutputType::Bitcode => {
                             out.set_extension("bc");
                             let (m, cg_time) = timeit(|| ctx.module.write_bitcode_to_memory());
                             *reporter.cg_time.get_or_insert(Duration::ZERO) += cg_time;
-                            std::fs::write(out, m.as_slice())?;
+                            Path::new(&out).write_anyhow(m.as_slice())?;
                             Zero
                         }
                         OutputType::Assembly => {
                             out.set_extension("s");
                             let (m, cg_time) = timeit(|| target_machine.write_to_memory_buffer(&ctx.module, inkwell::targets::FileType::Assembly).unwrap());
                             *reporter.cg_time.get_or_insert(Duration::ZERO) += cg_time;
-                            std::fs::write(out, m.as_slice())?;
+                            Path::new(&out).write_anyhow(m.as_slice())?;
                             Zero
                         }
                         _ => {
@@ -1356,13 +1350,18 @@ fn driver() -> anyhow::Result<()> {
                                     cc.objs([tmp1.path(), tmp2.path()]);
                                     Two(tmp1, tmp2)
                                 }
-                                OutputType::Object => {
+                                OutputType::RawObject => {
                                     out.set_extension("o");
                                     std::fs::write(out, mb.as_slice())?;
                                     Zero
                                 }
-                                OutputType::TestCombinedObjHeaderObj => {
-                                    unimplemented!()
+                                OutputType::Object => {
+                                    let parsed_llvm_object = object::read::File::parse(mb.as_slice())?;
+                                    let mut writeable_object = obj::get_writeable_object_from_file(parsed_llvm_object);
+                                    libs::populate_header(&mut writeable_object, &ctx);
+                                    let buf = writeable_object.write()?;
+                                    Path::new(&out).write_anyhow(buf)?;
+                                    Zero
                                 }
                                 x => unreachable!("{x:?} has already been handled")
                             }

--- a/cobalt-cli/src/main.rs
+++ b/cobalt-cli/src/main.rs
@@ -1351,11 +1351,12 @@ fn driver() -> anyhow::Result<()> {
                                     Two(tmp1, tmp2)
                                 }
                                 OutputType::RawObject => {
-                                    out.set_extension("o");
+                                    out.set_extension("raw.o");
                                     std::fs::write(out, mb.as_slice())?;
                                     Zero
                                 }
                                 OutputType::Object => {
+                                    out.set_extension("o");
                                     let parsed_llvm_object = object::read::File::parse(mb.as_slice())?;
                                     let mut writeable_object = obj::get_writeable_object_from_file(parsed_llvm_object);
                                     libs::populate_header(&mut writeable_object, &ctx);


### PR DESCRIPTION
## Features

The main addition is an integrated (raw-)object and object-header type. Previously, an external program needed to be called to combine the two files into a library the `co` could use.
- The old `obj` type is now `raw-obj`.
- The new integrated object type is now `obj`.

Also fixes some issues with library loading in JIT mode.

## Bugs

There is currently a bug (tested on Apple silicon) with this object type when generating an integrated object which declares external C functions.