### PR TITLE
Fix #80

### DIFF
--- a/cobalt-parser/src/lib.rs
+++ b/cobalt-parser/src/lib.rs
@@ -391,6 +391,7 @@ fn declarations<'a>(loc: DeclLoc, anns: Option<Vec<(&'a str, Option<&'a str>, So
                 start += 1;
             }
             fn param(mut src: &str, mut start: usize) -> ParserReturn<ast::funcs::Parameter> {
+                (!src.starts_with(';')).then_some(())?;
                 let mut errs = vec![];
                 let begin = start;
                 loop {


### PR DESCRIPTION
#80 started as a simple parser issue, but revealed a significant issue in how variables are accessed. Doing so is safer now, so similar issues should be easy to diagnose in the future.