### PR TITLE
Rework type mutability

### DIFF
--- a/cobalt-ast/src/ast/funcs.rs
+++ b/cobalt-ast/src/ast/funcs.rs
@@ -146,13 +146,13 @@ impl AST for FnDefAST {
                 "method" if self.in_struct => {
                     if fn_type.is_none() && !params.is_empty() {
                         let self_t = Type::Reference(Box::new(ctx.with_vars(|v| v.symbols["self_t"].0.as_type().unwrap()).clone()));
-                        if ops::impl_convertible(self_t, params[0].0.clone()) {fn_type = Some(MethodType::Normal)};
+                        if ops::impl_convertible(&self_t, &params[0].0) {fn_type = Some(MethodType::Normal)};
                     }
                 },
                 "getter" if self.in_struct => {
                     if fn_type.is_none() && !params.is_empty() {
                         let self_t = Type::Reference(Box::new(ctx.with_vars(|v| v.symbols["self_t"].0.as_type().unwrap()).clone()));
-                        if ops::impl_convertible(self_t, params[0].0.clone()) {fn_type = Some(MethodType::Getter)};
+                        if ops::impl_convertible(&self_t, &params[0].0) {fn_type = Some(MethodType::Getter)};
                     }
                 },
                 _ => {}
@@ -546,7 +546,7 @@ impl AST for FnDefAST {
                         }
                         else {
                             let s = self_t.to_string();
-                            if !ops::impl_convertible(self_t, params[0].0.clone()) {
+                            if !ops::impl_convertible(&self_t, &params[0].0) {
                                 errs.push(CobaltError::InvalidSelfParam {
                                     loc: self.params[0].2.loc(),
                                     self_t: s,
@@ -585,7 +585,7 @@ impl AST for FnDefAST {
                         }
                         else {
                             let s = self_t.to_string();
-                            if !ops::impl_convertible(self_t, params[0].0.clone()) {
+                            if !ops::impl_convertible(&self_t, &params[0].0) {
                                 errs.push(CobaltError::InvalidSelfParam {
                                     loc: self.params[0].2.loc(),
                                     self_t: s,

--- a/cobalt-ast/src/ast/funcs.rs
+++ b/cobalt-ast/src/ast/funcs.rs
@@ -140,13 +140,13 @@ impl AST for FnDefAST {
                 },
                 "method" if self.in_struct => {
                     if fn_type.is_none() && !params.is_empty() {
-                        let self_t = Type::Reference(Box::new(ctx.with_vars(|v| v.symbols["self_t"].0.as_type().unwrap()).clone()), true);
+                        let self_t = Type::Reference(Box::new(ctx.with_vars(|v| v.symbols["self_t"].0.as_type().unwrap()).clone()));
                         if ops::impl_convertible(self_t, params[0].0.clone()) {fn_type = Some(MethodType::Normal)};
                     }
                 },
                 "getter" if self.in_struct => {
                     if fn_type.is_none() && !params.is_empty() {
-                        let self_t = Type::Reference(Box::new(ctx.with_vars(|v| v.symbols["self_t"].0.as_type().unwrap()).clone()), true);
+                        let self_t = Type::Reference(Box::new(ctx.with_vars(|v| v.symbols["self_t"].0.as_type().unwrap()).clone()));
                         if ops::impl_convertible(self_t, params[0].0.clone()) {fn_type = Some(MethodType::Getter)};
                     }
                 },
@@ -518,7 +518,7 @@ impl AST for FnDefAST {
                                 loc
                             });
                         }
-                        let self_t = Type::Reference(Box::new(ctx.with_vars(|v| v.symbols["self_t"].0.as_type().unwrap()).clone()), true);
+                        let self_t = Type::Reference(Box::new(ctx.with_vars(|v| v.symbols["self_t"].0.as_type().unwrap()).clone()));
                         if params.is_empty() {
                             errs.push(CobaltError::InvalidSelfParam {
                                 loc: self.loc,
@@ -557,7 +557,7 @@ impl AST for FnDefAST {
                                 loc
                             });
                         }
-                        let self_t = Type::Reference(Box::new(ctx.with_vars(|v| v.symbols["self_t"].0.as_type().unwrap()).clone()), true);
+                        let self_t = Type::Reference(Box::new(ctx.with_vars(|v| v.symbols["self_t"].0.as_type().unwrap()).clone()));
                         if params.is_empty() {
                             errs.push(CobaltError::InvalidSelfParam {
                                 loc: self.loc,

--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -314,7 +314,8 @@ impl AST for TupleLiteralAST {
         let mut errs = vec![];
         let (comps, (inters, types)): (Vec<_>, (Vec<_>, Vec<_>)) = self.vals.iter().map(|x| {
             let mut v = x.codegen_errs(ctx, &mut errs);
-            v = ops::impl_convert(unreachable_span(), (v, None), (ops::decay(v.data_type.clone()), None), ctx).unwrap();
+            let decayed = ops::decay(v.data_type.clone());
+            v = ops::impl_convert(unreachable_span(), (v, None), (decayed, None), ctx).unwrap();
             v
         }).map(|Value {comp_val, inter_val, data_type, ..}| (comp_val, (inter_val, data_type))).unzip();
         let mut val = Value::null();

--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -164,7 +164,7 @@ impl AST for StringLiteralAST {
     fn is_const(&self) -> bool {true}
     fn res_type(&self, _ctx: &CompCtx) -> Type {
         match self.suffix {
-            None => Type::Reference(Box::new(Type::Array(Box::new(Type::Int(8, true)), Some(self.val.len() as u32))), false),
+            None => Type::Reference(Box::new(Type::Array(Box::new(Type::Int(8, true)), Some(self.val.len() as u32)))),
             Some(_) => Type::Null
         }
     }
@@ -179,7 +179,7 @@ impl AST for StringLiteralAST {
                 (Value::interpreted(
                     gv.as_pointer_value().const_cast(ctx.context.i8_type().ptr_type(Default::default())).into(),
                     InterData::Array(self.val.iter().map(|&c| InterData::Int(c as i128)).collect()),
-                    Type::Reference(Box::new(Type::Array(Box::new(Type::Int(8, true)), Some(self.val.len() as u32))), false)
+                    Type::Reference(Box::new(Type::Array(Box::new(Type::Int(8, true)), Some(self.val.len() as u32))))
                 ), vec![])
             },
             Some((x, loc)) => (Value::error(), vec![CobaltError::UnknownLiteralSuffix {loc, lit: "string", suf: x.to_string()}])
@@ -212,23 +212,9 @@ impl AST for ArrayLiteralAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.start, self.end)}
     fn nodes(&self) -> usize {self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1}
     fn res_type(&self, ctx: &CompCtx) -> Type {
-        let mut elem = self.vals.get(0).map_or(Type::Null, |x| match x.res_type(ctx) {
-            Type::IntLiteral => Type::Int(64, false),
-            Type::Reference(b, m) => match *b {
-                x @ Type::Array(..) => Type::Reference(Box::new(x), m),
-                x => x
-            },
-            x => x
-        });
+        let mut elem = self.vals.get(0).map_or(Type::Null, |x| ops::decay(x.res_type(ctx)));
         for val in self.vals.iter() {
-            if let Some(c) = ops::common(&elem, &match val.res_type(ctx) {
-                Type::IntLiteral => Type::Int(64, false),
-                Type::Reference(b, m) => match *b {
-                    x @ Type::Array(..) => Type::Reference(Box::new(x), m),
-                    x => x
-                },
-                x => x
-            }) {elem = c;}
+            if let Some(c) = ops::common(&elem, &ops::decay(val.res_type(ctx))) {elem = c;}
             else {
                 elem = Type::Error;
                 break;
@@ -244,14 +230,7 @@ impl AST for ArrayLiteralAST {
         let mut errs = vec![];
         for val in self.vals.iter() {
             let (v, mut es) = val.codegen(ctx);
-            let dt = match v.data_type.clone() {
-                Type::IntLiteral => Type::Int(64, false),
-                Type::Reference(b, m) => match *b {
-                    x @ Type::Array(..) => Type::Reference(Box::new(x), m),
-                    x => x
-                },
-                x => x
-            };
+            let dt = ops::decay(v.data_type.clone());
             errs.append(&mut es);
             if first {
                 first = false;
@@ -329,35 +308,14 @@ impl AST for TupleLiteralAST {
     }
     fn nodes(&self) -> usize {self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1}
     fn res_type(&self, ctx: &CompCtx) -> Type {
-        Type::Tuple(self.vals.iter().map(|x| match x.res_type(ctx) {
-            Type::IntLiteral => Type::Int(64, false),
-            Type::Reference(b, m) => {
-                if x.expl_type(ctx) {Type::Reference(b, m)}
-                else {*b}
-            },
-            x => x
-        }).collect())
+        Type::Tuple(self.vals.iter().map(|x| ops::decay(x.res_type(ctx))).collect())
     }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let mut errs = vec![];
         let (comps, (inters, types)): (Vec<_>, (Vec<_>, Vec<_>)) = self.vals.iter().map(|x| {
             let mut v = x.codegen_errs(ctx, &mut errs);
-            match v.data_type {
-                Type::IntLiteral => Value {data_type: Type::Int(64, false), ..v},
-                Type::Reference(b, m) => {
-                    if x.expl_type(ctx) {Value {data_type: Type::Reference(b, m), ..v}}
-                    else {
-                        if !ctx.is_const.get() {
-                            if let Some(PointerValue(pv)) = v.comp_val {
-                                v.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), pv, ""));
-                            }
-                        }
-                        v.data_type = *b;
-                        v
-                    }
-                },
-                x => Value {data_type: x, ..v}
-            }
+            v = ops::impl_convert(unreachable_span(), (v, None), (ops::decay(v.data_type.clone()), None), ctx).unwrap();
+            v
         }).map(|Value {comp_val, inter_val, data_type, ..}| (comp_val, (inter_val, data_type))).unzip();
         let mut val = Value::null();
         val.data_type = Type::Tuple(types);

--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -221,7 +221,7 @@ impl AST for ArrayLiteralAST {
             x => x
         });
         for val in self.vals.iter() {
-            if let Some(c) = types::utils::common(&elem, &match val.res_type(ctx) {
+            if let Some(c) = ops::common(&elem, &match val.res_type(ctx) {
                 Type::IntLiteral => Type::Int(64, false),
                 Type::Reference(b, m) => match *b {
                     x @ Type::Array(..) => Type::Reference(Box::new(x), m),
@@ -259,7 +259,7 @@ impl AST for ArrayLiteralAST {
                 ty = dt;
             }
             else if ty != dt {
-                if let Some(t) = types::utils::common(&ty, &dt) {
+                if let Some(t) = ops::common(&ty, &dt) {
                     ty = t;
                     elem_loc = val.loc();
                 }
@@ -278,7 +278,7 @@ impl AST for ArrayLiteralAST {
             errs.push(CobaltError::ArrayTooLong {loc: self.vals[u32::MAX as usize + 1].loc(), len: elems.len()});
             elems.truncate(u32::MAX as usize);
         }
-        let elems = elems.into_iter().enumerate().filter_map(|(n, v)| types::utils::impl_convert(self.vals[n].loc(), (v, None), (ty.clone(), None), ctx).map_err(|e| errs.push(e)).ok()).collect::<Vec<_>>();
+        let elems = elems.into_iter().enumerate().filter_map(|(n, v)| ops::impl_convert(self.vals[n].loc(), (v, None), (ty.clone(), None), ctx).map_err(|e| errs.push(e)).ok()).collect::<Vec<_>>();
         let len = elems.len();
         (Value::new(
             if let (Some(llt), false) = (ty.llvm_type(ctx), ctx.is_const.get()) {

--- a/cobalt-ast/src/ast/misc.rs
+++ b/cobalt-ast/src/ast/misc.rs
@@ -14,14 +14,14 @@ impl AST for CastAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.val.loc(), self.target.loc())}
     fn nodes(&self) -> usize {self.val.nodes() + self.target.nodes() + 1}
     fn expl_type(&self, _: &CompCtx) -> bool {true}
-    fn res_type(&self, ctx: &CompCtx) -> Type {if let Some(InterData::Type(ty)) = types::utils::impl_convert(unreachable_span(), (self.target.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(|t| t.inter_val) {*ty} else {Type::Error}}
+    fn res_type(&self, ctx: &CompCtx) -> Type {if let Some(InterData::Type(ty)) = ops::impl_convert(unreachable_span(), (self.target.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(|t| t.inter_val) {*ty} else {Type::Error}}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let (val, mut errs) = self.val.codegen(ctx);
         if val.data_type == Type::Error {return (Value::error(), errs)}
         let oic = ctx.is_const.replace(true);
-        let t = types::utils::impl_convert(self.target.loc(), (self.target.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+        let t = ops::impl_convert(self.target.loc(), (self.target.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
         ctx.is_const.set(oic);
-        (types::utils::expl_convert(self.loc, (val, Some(self.val.loc())), (t, Some(self.target.loc())), ctx).unwrap_or_else(|e| {
+        (ops::expl_convert(self.loc, (val, Some(self.val.loc())), (t, Some(self.target.loc())), ctx).unwrap_or_else(|e| {
             errs.push(e);
             Value::error()
         }), errs)
@@ -48,12 +48,12 @@ impl AST for BitCastAST {
     fn loc(&self) -> SourceSpan {merge_spans(self.val.loc(), self.target.loc())}
     fn nodes(&self) -> usize {self.val.nodes() + self.target.nodes() + 1}
     fn expl_type(&self, _: &CompCtx) -> bool {true}
-    fn res_type(&self, ctx: &CompCtx) -> Type {if let Some(InterData::Type(ty)) = types::utils::impl_convert(unreachable_span(), (self.target.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(|t| t.inter_val) {*ty} else {Type::Error}}
+    fn res_type(&self, ctx: &CompCtx) -> Type {if let Some(InterData::Type(ty)) = ops::impl_convert(unreachable_span(), (self.target.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(|t| t.inter_val) {*ty} else {Type::Error}}
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let (mut val, mut errs) = self.val.codegen(ctx);
         if val.data_type == Type::Error {return (Value::error(), errs)}
         let oic = ctx.is_const.replace(true);
-        let t = types::utils::impl_convert(self.target.loc(), (self.target.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+        let t = ops::impl_convert(self.target.loc(), (self.target.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
         ctx.is_const.set(oic);
         while let Type::Reference(b, _) = val.data_type {
             if !ctx.is_const.get() {

--- a/cobalt-ast/src/ast/misc.rs
+++ b/cobalt-ast/src/ast/misc.rs
@@ -53,7 +53,8 @@ impl AST for BitCastAST {
         let oic = ctx.is_const.replace(true);
         let t = ops::impl_convert(self.target.loc(), (self.target.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
         ctx.is_const.set(oic);
-        val = ops::impl_convert(unreachable_span(), (val, None), (ops::decay(val.data_type.clone()), None), ctx).unwrap();
+        let decayed = ops::decay(val.data_type.clone());
+        val = ops::impl_convert(unreachable_span(), (val, None), (decayed, None), ctx).unwrap();
         match (t.size(ctx), val.data_type.size(ctx)) {
             (SizeType::Static(d), SizeType::Static(s)) => {
                 if d != s {

--- a/cobalt-ast/src/ast/ops.rs
+++ b/cobalt-ast/src/ast/ops.rs
@@ -16,7 +16,7 @@ impl AST for BinOpAST {
         if self.op == "&?" || self.op == "|?" {
             let t = self.rhs.res_type(ctx);
             if t == Type::IntLiteral {return Type::IntLiteral}
-            if ops::expl_convertible(Type::Int(1, false), t.clone()) {t} else {Type::Null}
+            if ops::expl_convertible(&Type::Int(1, false), &t) {t} else {Type::Null}
         }
         else {ops::bin_type(self.lhs.res_type(ctx), self.rhs.res_type(ctx), self.op.as_str())}
     }

--- a/cobalt-ast/src/ast/vars.rs
+++ b/cobalt-ast/src/ast/vars.rs
@@ -83,7 +83,7 @@ impl AST for VarDefAST {
         let t2 = self.val.const_codegen(ctx).0.data_type;
         let dt = if let Some(t) = self.type_.as_ref().map(|t| {
             let oic = ctx.is_const.replace(true);
-            let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
+            let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
             ctx.is_const.set(oic);
             t
         }) {t} else {
@@ -305,7 +305,7 @@ impl AST for VarDefAST {
                 let t2 = self.val.res_type(ctx);
                 let dt = if let Some(t) = self.type_.as_ref().map(|t| {
                     let oic = ctx.is_const.replace(true);
-                    let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+                    let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
                     ctx.is_const.set(oic);
                     t
                 }) {t} else {
@@ -355,7 +355,7 @@ impl AST for VarDefAST {
                 let t2 = val.data_type.clone();
                 let dt = if let Some(t) = self.type_.as_ref().map(|t| {
                     let oic = ctx.is_const.replace(true);
-                    let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+                    let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
                     ctx.is_const.set(oic);
                     t
                 }) {t} else {
@@ -414,7 +414,7 @@ impl AST for VarDefAST {
                 let t = self.val.res_type(ctx);
                 let dt = if let Some(t) = self.type_.as_ref().map(|t| {
                     let oic = ctx.is_const.replace(true);
-                    let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+                    let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
                     ctx.is_const.set(oic);
                     t
                 }) {t} else {
@@ -434,7 +434,7 @@ impl AST for VarDefAST {
                         let t2 = val.data_type.clone();
                         let dt = if let Some(t) = self.type_.as_ref().map(|t| {
                             let oic = ctx.is_const.replace(true);
-                            let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or(Type::Error, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+                            let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or(Type::Error, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
                             ctx.is_const.set(oic);
                             t
                         }) {t} else {
@@ -447,7 +447,7 @@ impl AST for VarDefAST {
                                 x => x
                             }
                         };
-                        let mut val = types::utils::impl_convert(self.val.loc(), (val, None), (dt, None), ctx).unwrap_or_else(|e| {
+                        let mut val = ops::impl_convert(self.val.loc(), (val, None), (dt, None), ctx).unwrap_or_else(|e| {
                             errs.push(e);
                             Value::error()
                         });
@@ -478,7 +478,7 @@ impl AST for VarDefAST {
                         let t2 = val.data_type.clone();
                         let dt = if let Some(t) = self.type_.as_ref().map(|t| {
                             let oic = ctx.is_const.replace(true);
-                            let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+                            let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
                             ctx.is_const.set(oic);
                             t
                         }) {t} else {
@@ -491,7 +491,7 @@ impl AST for VarDefAST {
                                 x => x
                             }
                         };
-                        let mut val = types::utils::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
+                        let mut val = ops::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
                             errs.push(e);
                             Value::error()
                         });
@@ -529,7 +529,7 @@ impl AST for VarDefAST {
                     let t2 = val.data_type.clone();
                     let dt = if let Some(t) = self.type_.as_ref().map(|t| {
                         let oic = ctx.is_const.replace(true);
-                        let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or(Type::Error, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+                        let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or(Type::Error, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
                         ctx.is_const.set(oic);
                         t
                     }) {t} else {
@@ -542,7 +542,7 @@ impl AST for VarDefAST {
                             x => x
                         }
                     };
-                    let val = types::utils::impl_convert(self.val.loc(), (val, None), (dt, None), ctx).unwrap_or_else(|e| {
+                    let val = ops::impl_convert(self.val.loc(), (val, None), (dt, None), ctx).unwrap_or_else(|e| {
                         errs.push(e);
                         Value::error()
                     });
@@ -583,7 +583,7 @@ impl AST for VarDefAST {
             let t2 = val.data_type.clone();
             let dt = if let Some(t) = self.type_.as_ref().map(|t| {
                 let oic = ctx.is_const.replace(true);
-                let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+                let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
                 ctx.is_const.set(oic);
                 t
             }) {t} else {
@@ -596,7 +596,7 @@ impl AST for VarDefAST {
                     x => x
                 }
             };
-            let val = types::utils::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
+            let val = ops::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
                 errs.push(e);
                 Value::error()
             });
@@ -646,634 +646,6 @@ impl AST for VarDefAST {
     }
     fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
         writeln!(f, "let: {}", self.name)?;
-        writeln!(f, "{pre}├── annotations:")?;
-        pre.push(false);
-        for (n, (name, arg, _)) in self.annotations.iter().enumerate() {
-            writeln!(f, "{pre}{}@{name}{}", if n + 1 < self.annotations.len() {"├── "} else {"└── "}, arg.as_ref().map(|x| format!("({x})")).unwrap_or_default())?;
-        }
-        pre.pop();
-        if let Some(ref ast) = self.type_ {print_ast_child(f, pre, &**ast, false, file)?}
-        print_ast_child(f, pre, &*self.val, true, file)
-    }
-}
-#[derive(Debug, Clone)]
-pub struct MutDefAST {
-    loc: SourceSpan,
-    pub name: DottedName,
-    pub val: Box<dyn AST>,
-    pub type_: Option<Box<dyn AST>>,
-    pub annotations: Vec<(String, Option<String>, SourceSpan)>,
-    pub global: bool
-}
-impl MutDefAST {
-    pub fn new(loc: SourceSpan, name: DottedName, val: Box<dyn AST>, type_: Option<Box<dyn AST>>, annotations: Vec<(String, Option<String>, SourceSpan)>, global: bool) -> Self {MutDefAST {loc, name, val, type_, annotations, global}}
-}
-impl AST for MutDefAST {
-    fn loc(&self) -> SourceSpan {merge_spans(self.loc, self.val.loc())}
-    fn nodes(&self) -> usize {self.val.nodes() + self.type_.as_ref().map_or(0, |x| x.nodes()) + 1}
-    fn fwddef_prepass(&self, ctx: &CompCtx) {
-        let mut errs = vec![];
-        let mut link_type = None;
-        let mut linkas = None;
-        let mut vis_spec = None;
-        let mut target_match = 2u8;
-        for (ann, arg, loc) in self.annotations.iter() {
-            let loc = *loc;
-            match ann.as_str() {
-                "link" => {
-                    link_type = match arg.as_ref().map(|x| x.as_str()) {
-                        Some("extern") | Some("external") => Some(External),
-                        Some("extern-weak") | Some("extern_weak") | Some("external-weak") | Some("external_weak") => Some(ExternalWeak),
-                        Some("intern") | Some("internal") => Some(Internal),
-                        Some("private") => Some(Private),
-                        Some("weak") => Some(WeakAny),
-                        Some("weak-odr") | Some("weak_odr") => Some(WeakODR),
-                        Some("linkonce") | Some("link-once") | Some("link_once") => Some(LinkOnceAny),
-                        Some("linkonce-odr") | Some("linkonce_odr") | Some("link-once-odr") | Some("link_once_odr") => Some(LinkOnceODR),
-                        Some("common") => Some(Common),
-                        _ => None
-                    }.map(|x| (x, loc))
-                },
-                "linkas" => {
-                    if let Some(arg) = arg {
-                        linkas = Some(arg.clone())
-                    }
-                },
-                "c" | "C" => linkas = Some(self.name.ids.last().expect("function name shouldn't be empty!").0.clone()),
-                "target" => {
-                    if let Some(arg) = arg {
-                        let mut arg = arg.as_str();
-                        let negate = if arg.as_bytes().first() == Some(&0x21) {arg = &arg[1..]; true} else {false};
-                        if let Ok(pat) = Pattern::new(arg) {
-                            target_match = u8::from(negate ^ pat.matches(&ctx.module.get_triple().as_str().to_string_lossy()))
-                        }
-                    }
-                },
-                "export" => {
-                    if vis_spec.is_none() {
-                        match arg.as_deref() {
-                            None | Some("true") | Some("1") | Some("") => vis_spec = Some(true),
-                            Some("false") | Some("0") => vis_spec = Some(false),
-                            _ => {},
-                        }
-                    }
-                },
-                "private" => {
-                    if vis_spec.is_none() {
-                        match arg.as_deref() {
-                            None | Some("true") | Some("1") | Some("") => vis_spec = Some(false),
-                            Some("false") | Some("0") => vis_spec = Some(true),
-                            _ => {}
-                        }
-                    }
-                },
-                _ => {}
-            }
-        }
-        let vs = vis_spec.unwrap_or(ctx.export.get());
-        if target_match == 0 {return}
-        let t2 = self.val.const_codegen(ctx).0.data_type;
-        let dt = if let Some(t) = self.type_.as_ref().map(|t| {
-            let oic = ctx.is_const.replace(true);
-            let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
-            ctx.is_const.set(oic);
-            t
-        }) {t} else {
-            match t2 {
-                Type::IntLiteral => Type::Int(64, false),
-                Type::Reference(b, m) => match *b {
-                    x @ Type::Array(..) => Type::Reference(Box::new(x), m),
-                    x => x
-                },
-                x => x
-            }
-        };
-        let _ = ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::new(
-            dt.llvm_type(ctx).map(|t| {
-                let gv = ctx.module.add_global(t, None, &linkas.unwrap_or_else(|| ctx.mangle(&self.name)));
-                match link_type {
-                    None => {},
-                    Some((WeakAny, _)) => gv.set_linkage(ExternalWeak),
-                    Some((x, _)) => gv.set_linkage(x)
-                }
-                PointerValue(gv.as_pointer_value())
-            }),
-            None,
-            Type::Reference(Box::new(dt), false)
-        ), VariableData {fwd: true, ..VariableData::with_vis(self.loc, vs)})));
-    }
-    fn res_type(&self, ctx: &CompCtx) -> Type {self.val.res_type(ctx)}
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
-        let mut errs = vec![];
-        let mut is_static = false;
-        let mut link_type = None;
-        let mut linkas = None;
-        let mut is_extern = None;
-        let mut vis_spec = None;
-        let mut target_match = 2u8;
-        for (ann, arg, loc) in self.annotations.iter() {
-            let loc = *loc;
-            match ann.as_str() {
-                "static" => {
-                    if arg.is_some() {
-                        errs.push(CobaltError::InvalidAnnArgument {
-                            name: "static",
-                            expected: None,
-                            found: arg.clone(),
-                            loc
-                        });
-                    }
-                    is_static = true;
-                },
-                "link" => {
-                    if let Some((_, prev)) = link_type {
-                        errs.push(CobaltError::RedefAnnArgument {
-                            name: "link",
-                            loc, prev
-                        });
-                    }
-                    link_type = match arg.as_deref() {
-                        Some("extern") | Some("external") => Some(External),
-                        Some("extern-weak") | Some("extern_weak") | Some("external-weak") | Some("external_weak") => Some(ExternalWeak),
-                        Some("intern") | Some("internal") => Some(Internal),
-                        Some("private") => Some(Private),
-                        Some("weak") => Some(WeakAny),
-                        Some("weak-odr") | Some("weak_odr") => Some(WeakODR),
-                        Some("linkonce") | Some("link-once") | Some("link_once") => Some(LinkOnceAny),
-                        Some("linkonce-odr") | Some("linkonce_odr") | Some("link-once-odr") | Some("link_once_odr") => Some(LinkOnceODR),
-                        Some("common") => Some(Common),
-                        _ => {
-                            errs.push(CobaltError::InvalidAnnArgument {
-                                name: "link",
-                                found: arg.clone(),
-                                expected: Some("link type"),
-                                loc
-                            });
-                            None
-                        }
-                    }.map(|x| (x, loc))
-                },
-                "linkas" => {
-                    if let Some((_, prev)) = linkas {
-                        errs.push(CobaltError::RedefAnnArgument {
-                            name: "linkas",
-                            loc, prev
-                        });
-                    }
-                    if let Some(arg) = arg {linkas = Some((arg.clone(), loc))}
-                    else {
-                        errs.push(CobaltError::InvalidAnnArgument {
-                            name: "linkas",
-                            found: arg.clone(),
-                            expected: Some("linkage name"),
-                            loc
-                        });
-                    }
-                },
-                "extern" => {
-                    is_extern = Some(loc);
-                    if arg.is_some() {
-                        errs.push(CobaltError::InvalidAnnArgument {
-                            name: "extern",
-                            found: arg.clone(),
-                            expected: None,
-                            loc
-                        });
-                    }
-                },
-                "c" | "C" => {
-                    match arg.as_ref().map(|x| x.as_str()) {
-                        Some("") | None => {},
-                        Some("extern") => is_extern = Some(loc),
-                        Some(_) => errs.push(CobaltError::InvalidAnnArgument {
-                            name: "C",
-                            found: arg.clone(),
-                            expected: Some(r#"no argument or "extern""#),
-                            loc
-                        })
-                    }
-                    linkas = Some((self.name.ids.last().expect("variable name shouldn't be empty!").0.clone(), loc))
-                },
-                "target" => {
-                    if let Some(arg) = arg {
-                        let mut arg = arg.as_str();
-                        let negate = if arg.as_bytes().first() == Some(&0x21) {arg = &arg[1..]; true} else {false};
-                        match Pattern::new(arg) {
-                            Ok(pat) => if target_match != 1 {target_match = u8::from(negate ^ pat.matches(&ctx.module.get_triple().as_str().to_string_lossy()))},
-                            Err(err) => errs.push(CobaltError::GlobPatternError {pos: err.pos, msg: err.msg.to_string(), loc})
-                        }
-                    }
-                    else {
-                        errs.push(CobaltError::InvalidAnnArgument {
-                            name: "target",
-                            found: arg.clone(),
-                            expected: Some("target glob"),
-                            loc
-                        });
-                    }
-                },
-                "export" => {
-                    if !self.global {
-                        errs.push(CobaltError::MustBeGlobal {
-                            name: "export",
-                            loc
-                        });
-                    }
-                    if let Some((_, prev)) = vis_spec {
-                        errs.push(CobaltError::RedefAnnArgument {
-                            name: "export",
-                            loc, prev
-                        });
-                    }
-                    else {
-                        match arg.as_deref() {
-                            None | Some("true") | Some("1") | Some("") => vis_spec = Some((true, loc)),
-                            Some("false") | Some("0") => vis_spec = Some((false, loc)),
-                            Some(_) => errs.push(CobaltError::InvalidAnnArgument {
-                                name: "export",
-                                found: arg.clone(),
-                                expected: Some(r#"no argument, "true", or "false""#),
-                                loc
-                            })
-                        }
-                    }
-                },
-                "private" => {
-                    if !self.global {
-                        errs.push(CobaltError::MustBeGlobal {
-                            name: "private",
-                            loc
-                        });
-                    }
-                    if let Some((_, prev)) = vis_spec {
-                        errs.push(CobaltError::RedefAnnArgument {
-                            name: "private",
-                            loc, prev
-                        });
-                    }
-                    else {
-                        match arg.as_deref() {
-                            None | Some("true") | Some("1") | Some("") => vis_spec = Some((false, loc)),
-                            Some("false") | Some("0") => vis_spec = Some((true, loc)),
-                            Some(_) => errs.push(CobaltError::InvalidAnnArgument {
-                                name: "private",
-                                found: arg.clone(),
-                                expected: Some(r#"no argument, "true", or "false""#),
-                                loc
-                            })
-                        }
-                    }
-                },
-                _ => errs.push(CobaltError::UnknownAnnotation {loc, name: ann.clone(), def: "variable"})
-            }
-        }
-        let vs = vis_spec.map_or(ctx.export.get(), |(v, _)| v);
-        if target_match == 0 {return (Value::null(), errs)}
-        if self.global || is_static {
-            if is_extern.is_some() {
-                let t2 = self.val.res_type(ctx);
-                let dt = if let Some(t) = self.type_.as_ref().map(|t| {
-                    let oic = ctx.is_const.replace(true);
-                    let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
-                    ctx.is_const.set(oic);
-                    t
-                }) {t} else {
-                    match t2 {
-                        Type::IntLiteral => Type::Int(64, false),
-                        Type::Reference(b, m) => match *b {
-                            x @ Type::Array(..) => Type::Reference(Box::new(x), m),
-                            x => x
-                        },
-                        x => x
-                    }
-                };
-                match ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::new(
-                    dt.llvm_type(ctx).map(|t| {
-                        let mangled = linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name);
-                        let gv = ctx.lookup_full(&self.name).and_then(|x| -> Option<GlobalValue> {Some(unsafe {std::mem::transmute(x.comp_val?.as_value_ref())})}).unwrap_or_else(|| ctx.module.add_global(t, None, &mangled));
-                        match link_type {
-                            None => {},
-                            Some((WeakAny, _)) => gv.set_linkage(ExternalWeak),
-                            Some((x, _)) => gv.set_linkage(x)
-                        }
-                        PointerValue(gv.as_pointer_value())
-                    }).or_else(|| {if dt != Type::Error {errs.push(CobaltError::TypeIsConstOnly {ty: dt.to_string(), loc: self.type_.as_ref().unwrap_or(&self.val).loc()})}; None}),
-                    None,
-                    Type::Reference(Box::new(dt), false)
-                ), VariableData::with_vis(self.loc, vs)))) {
-                    Ok(x) => (x.0.clone(), errs),
-                    Err(RedefVariable::NotAModule(x, _)) => {
-                        errs.push(CobaltError::NotAModule {
-                            loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string()
-                        });
-                        (Value::error(), errs)
-                    },
-                    Err(RedefVariable::AlreadyExists(x, d, _)) => {
-                        errs.push(CobaltError::RedefVariable {
-                            loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string(),
-                            prev: d
-                        });
-                        (Value::error(), errs)
-                    }
-                }
-            }
-            else if self.val.is_const() && self.type_.is_none() {
-                let mut val = self.val.codegen_errs(ctx, &mut errs);
-                let t2 = val.data_type.clone();
-                let dt = if let Some(t) = self.type_.as_ref().map(|t| {
-                    let oic = ctx.is_const.replace(true);
-                    let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
-                    ctx.is_const.set(oic);
-                    t
-                }) {t} else {
-                    match t2 {
-                        Type::IntLiteral => Type::Int(64, false),
-                        Type::Reference(b, m) => match *b {
-                            x @ Type::Array(..) => Type::Reference(Box::new(x), m),
-                            x => x
-                        },
-                        x => x
-                    }
-                };
-                match if let Some(v) = val.value(ctx) {
-                    val.inter_val = None;
-                    if ctx.is_const.get() {
-                        ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData::with_vis(self.loc, vs))))
-                    }
-                    else {
-                        let t = dt.llvm_type(ctx).unwrap();
-                        let mangled = linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name);
-                        let gv = ctx.lookup_full(&self.name).and_then(|x| -> Option<GlobalValue> {Some(unsafe {std::mem::transmute(x.comp_val?.as_value_ref())})}).unwrap_or_else(|| ctx.module.add_global(t, None, &mangled));
-                        gv.set_constant(false);
-                        gv.set_initializer(&v);
-                        if let Some((link, _)) = link_type {gv.set_linkage(link)}
-                        ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::new(
-                            Some(PointerValue(gv.as_pointer_value())),
-                            None,
-                            Type::Reference(Box::new(dt), false)
-                        ), VariableData::with_vis(self.loc, vs))))
-                    }
-                }
-                else {
-                    val.inter_val = None;
-                    if dt != Type::Error {errs.push(CobaltError::TypeIsConstOnly {ty: dt.to_string(), loc: self.type_.as_ref().unwrap_or(&self.val).loc()})}
-                    ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData::with_vis(self.loc, false))))
-                } {
-                    Ok(x) => (x.0.clone(), errs),
-                    Err(RedefVariable::NotAModule(x, _)) => {
-                        errs.push(CobaltError::NotAModule {
-                            loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string()
-                        });
-                        (Value::error(), errs)
-                    },
-                    Err(RedefVariable::AlreadyExists(x, d, _)) => {
-                        errs.push(CobaltError::RedefVariable {
-                            loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string(),
-                            prev: d
-                        });
-                        (Value::error(), errs)
-                    }
-                }
-            }
-            else {
-                let t = self.val.res_type(ctx);
-                let dt = if let Some(t) = self.type_.as_ref().map(|t| {
-                    let oic = ctx.is_const.replace(true);
-                    let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
-                    ctx.is_const.set(oic);
-                    t
-                }) {t} else {
-                    match t {
-                        Type::IntLiteral => Type::Int(64, false),
-                        Type::Reference(b, m) => match *b {
-                            x @ Type::Array(..) => Type::Reference(Box::new(x), m),
-                            x => x
-                        },
-                        x => x
-                    }
-                };
-                match if let Some(t) = dt.llvm_type(ctx) {
-                    let old_global = ctx.global.replace(true);
-                    let val = if ctx.is_const.get() {
-                        let val = self.val.codegen_errs(ctx, &mut errs);
-                        let t2 = val.data_type.clone();
-                        let dt = if let Some(t) = self.type_.as_ref().map(|t| {
-                            let oic = ctx.is_const.replace(true);
-                            let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or(Type::Error, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
-                            ctx.is_const.set(oic);
-                            t
-                        }) {t} else {
-                            match t2 {
-                                Type::IntLiteral => Type::Int(64, false),
-                                Type::Reference(b, m) => match *b {
-                                    x @ Type::Array(..) => Type::Reference(Box::new(x), m),
-                                    x => x
-                                },
-                                x => x
-                            }
-                        };
-                        let mut val = types::utils::impl_convert(self.val.loc(), (val, None), (dt, None), ctx).unwrap_or_else(|e| {
-                            errs.push(e);
-                            Value::error()
-                        });
-                        val.inter_val = None;
-                        ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData::with_vis(self.loc, vs))))
-                    }
-                    else {
-                        let mangled = linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name);
-                        let gv = ctx.lookup_full(&self.name).and_then(|x| -> Option<GlobalValue> {Some(unsafe {std::mem::transmute(x.comp_val?.as_value_ref())})}).unwrap_or_else(|| ctx.module.add_global(t, None, &mangled));
-                        gv.set_constant(false);
-                        gv.set_initializer(&t.const_zero());
-                        if let Some((link, _)) = link_type {gv.set_linkage(link)}
-                        let f = ctx.module.add_function(format!("cobalt.init{}", ctx.mangle(&self.name)).as_str(), ctx.context.void_type().fn_type(&[], false), Some(inkwell::module::Linkage::Private));
-                        {
-                            let as0 = inkwell::AddressSpace::from(0u16);
-                            let i32t = ctx.context.i32_type();
-                            let i8tp = ctx.context.i8_type().ptr_type(as0);
-                            let st = ctx.context.struct_type(&[i32t.into(), ctx.context.void_type().fn_type(&[], false).ptr_type(as0).into(), i8tp.into()], false);
-                            let g = ctx.module.add_global(st.array_type(1), None, "llvm.global_ctors");
-                            g.set_linkage(inkwell::module::Linkage::Appending);
-                            g.set_initializer(&st.const_array(&[st.const_named_struct(&[i32t.const_int(ctx.priority.decr().get() as u64, false).into(), f.as_global_value().as_pointer_value().into(), i8tp.const_zero().into()])]));
-                        }
-                        let entry = ctx.context.append_basic_block(f, "entry");
-                        let old_ip = ctx.builder.get_insert_block();
-                        ctx.builder.position_at_end(entry);
-                        let old_scope = ctx.push_scope(&self.name);
-                        let val = self.val.codegen_errs(ctx, &mut errs);
-                        let t2 = val.data_type.clone();
-                        let dt = if let Some(t) = self.type_.as_ref().map(|t| {
-                            let oic = ctx.is_const.replace(true);
-                            let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
-                            ctx.is_const.set(oic);
-                            t
-                        }) {t} else {
-                            match t2 {
-                                Type::IntLiteral => Type::Int(64, false),
-                                Type::Reference(b, m) => match *b {
-                                    x @ Type::Array(..) => Type::Reference(Box::new(x), m),
-                                    x => x
-                                },
-                                x => x
-                            }
-                        };
-                        let mut val = types::utils::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
-                            errs.push(e);
-                            Value::error()
-                        });
-                        ctx.restore_scope(old_scope);
-                        if let Some(v) = val.value(ctx) {
-                            val.inter_val = None;
-                            ctx.builder.build_store(gv.as_pointer_value(), v);
-                            ctx.builder.build_return(None);
-                            hoist_allocas(&ctx.builder);
-                            if let Some(bb) = old_ip {ctx.builder.position_at_end(bb);}
-                            else {ctx.builder.clear_insertion_position();}
-                            ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::new(
-                                Some(PointerValue(gv.as_pointer_value())),
-                                None,
-                                Type::Reference(Box::new(dt), false)
-                            ), VariableData::with_vis(self.loc, vs))))
-                        }
-                        else {
-                            val.inter_val = None;
-                            unsafe {
-                                gv.delete();
-                                f.delete();
-                            }
-                            if dt != Type::Error {errs.push(CobaltError::TypeIsConstOnly {ty: dt.to_string(), loc: self.type_.as_ref().unwrap_or(&self.val).loc()})}
-                            ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData::with_vis(self.loc, false))))
-                        }
-                    };
-                    ctx.global.set(old_global);
-                    val
-                }
-                else {
-                    let old_scope = ctx.push_scope(&self.name);
-                    if dt != Type::Error {errs.push(CobaltError::TypeIsConstOnly {ty: dt.to_string(), loc: self.type_.as_ref().unwrap_or(&self.val).loc()})}
-                    let val = self.val.codegen_errs(ctx, &mut errs);
-                    let t2 = val.data_type.clone();
-                    let dt = if let Some(t) = self.type_.as_ref().map(|t| {
-                        let oic = ctx.is_const.replace(true);
-                        let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or(Type::Error, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
-                        ctx.is_const.set(oic);
-                        t
-                    }) {t} else {
-                        match t2 {
-                            Type::IntLiteral => Type::Int(64, false),
-                            Type::Reference(b, m) => match *b {
-                                x @ Type::Array(..) => Type::Reference(Box::new(x), m),
-                                x => x
-                            },
-                            x => x
-                        }
-                    };
-                    let val = types::utils::impl_convert(self.val.loc(), (val, None), (dt, None), ctx).unwrap_or_else(|e| {
-                        errs.push(e);
-                        Value::error()
-                    });
-                    ctx.restore_scope(old_scope);
-                    ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData::with_vis(self.loc, vs))))
-                } {
-                    Ok(x) => (x.0.clone(), errs),
-                    Err(RedefVariable::NotAModule(x, _)) => {
-                        errs.push(CobaltError::NotAModule {
-                            loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string()
-                        });
-                        (Value::error(), errs)
-                    },
-                    Err(RedefVariable::AlreadyExists(x, d, _)) => {
-                        errs.push(CobaltError::RedefVariable {
-                            loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string(),
-                            prev: d
-                        });
-                        (Value::error(), errs)
-                    }
-                }
-            }
-        }
-        else {
-            if let Some(loc) = is_extern {
-                errs.push(CobaltError::MustBeLocal {name: "extern", loc});
-            }
-            if let Some((_, loc)) = link_type {
-                errs.push(CobaltError::MustBeLocal {name: "link", loc});
-            }
-            if let Some((_, loc)) = linkas {
-                errs.push(CobaltError::MustBeLocal {name: "linkas", loc});
-            }
-            let old_scope = ctx.push_scope(&self.name);
-            let val = self.val.codegen_errs(ctx, &mut errs);
-            let t2 = val.data_type.clone();
-            let dt = if let Some(t) = self.type_.as_ref().map(|t| {
-                let oic = ctx.is_const.replace(true);
-                let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
-                ctx.is_const.set(oic);
-                t
-            }) {t} else {
-                match t2 {
-                    Type::IntLiteral => Type::Int(64, false),
-                    Type::Reference(b, m) => match *b {
-                        x @ Type::Array(..) => Type::Reference(Box::new(x), m),
-                        x => x
-                    },
-                    x => x
-                }
-            };
-            let val = types::utils::impl_convert(self.val.loc(), (val, None), (dt, None), ctx).unwrap_or_else(|e| {
-                errs.push(e);
-                Value::error()
-            });
-            ctx.restore_scope(old_scope);
-            match if ctx.is_const.get() {
-                ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData {scope: ctx.var_scope.get().try_into().ok(), ..VariableData::with_vis(self.loc, false)})))
-            } 
-            else if let (Some(t), Some(v)) = (val.data_type.llvm_type(ctx), val.value(ctx)) {
-                let a = val.addr(ctx).unwrap_or_else(|| {
-                    let a = ctx.builder.build_alloca(t, self.name.ids.last().map_or("", |(x, _)| x.as_str()));
-                    ctx.builder.build_store(a, v);
-                    a
-                });
-                ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::new(
-                    Some(PointerValue(a)),
-                    val.inter_val,
-                    Type::Reference(Box::new(val.data_type), true)
-                ), VariableData {scope: ctx.var_scope.get().try_into().ok(), ..VariableData::with_vis(self.loc, false)})))
-            }
-            else {
-                ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData {scope: ctx.var_scope.get().try_into().ok(), ..VariableData::with_vis(self.loc, false)})))
-            } {
-                Ok(x) => (x.0.clone(), errs),
-                Err(RedefVariable::NotAModule(x, _)) => {
-                    errs.push(CobaltError::NotAModule {
-                        loc: self.name.ids[x].1,
-                        name: self.name.start(x).to_string()
-                    });
-                    (Value::error(), errs)
-                },
-                Err(RedefVariable::AlreadyExists(x, d, _)) => {
-                    errs.push(CobaltError::RedefVariable {
-                        loc: self.name.ids[x].1,
-                        name: self.name.start(x).to_string(),
-                        prev: d
-                    });
-                    (Value::error(), errs)
-                }
-            }
-        }
-    }
-    fn to_code(&self) -> String {
-        let mut out = "".to_string();
-        for s in self.annotations.iter().map(|(name, arg, _)| ("@".to_string() + name.as_str() + arg.as_ref().map(|x| format!("({x})")).unwrap_or_default().as_str() + " ")) {out += s.as_str();}
-        out + format!("mut {}{} = {}", self.name, self.type_.as_ref().map_or("".to_string(), |t| format!(": {t}")), self.val.to_code()).as_str()
-    }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
-        writeln!(f, "mut: {}", self.name)?;
         writeln!(f, "{pre}├── annotations:")?;
         pre.push(false);
         for (n, (name, arg, _)) in self.annotations.iter().enumerate() {
@@ -1390,7 +762,7 @@ impl AST for ConstDefAST {
         let val = self.val.codegen_errs(ctx, &mut errs);
         let t2 = val.data_type.clone();
         let dt = if let Some(t) = self.type_.as_ref().map(|t| {
-            let t = types::utils::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+            let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
             t
         }) {t} else {
             match t2 {
@@ -1402,7 +774,7 @@ impl AST for ConstDefAST {
                 x => x
             }
         };
-        let val = types::utils::impl_convert(self.val.loc(), (val, None), (dt, None), ctx).unwrap_or_else(|e| {
+        let val = ops::impl_convert(self.val.loc(), (val, None), (dt, None), ctx).unwrap_or_else(|e| {
             errs.push(e);
             Value::error()
         });
@@ -1528,7 +900,7 @@ impl AST for TypeDefAST {
             Box::new(vm)
         });
         let old_scope = ctx.push_scope(&self.name);
-        let ty = types::utils::impl_convert(unreachable_span(), (self.val.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
+        let ty = ops::impl_convert(unreachable_span(), (self.val.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
         ctx.with_vars(|v| {
             v.symbols.insert("base_t".to_string(), Value::make_type(ty.clone()).into());
             v.symbols.insert("self_t".to_string(), Value::make_type(Type::Nominal(mangled.clone())).into());
@@ -1612,7 +984,7 @@ impl AST for TypeDefAST {
         }
         let vs = vis_spec.map_or(ctx.export.get(), |(v, _)| v);
         if target_match == 0 {return (Value::null(), errs)}
-        let ty = types::utils::impl_convert(self.val.loc(), (self.val.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+        let ty = ops::impl_convert(self.val.loc(), (self.val.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
         let mangled = ctx.format(&self.name);
         ctx.map_vars(|v| {
             let mut vm = VarMap::new(Some(v));

--- a/cobalt-ast/src/ast/vars.rs
+++ b/cobalt-ast/src/ast/vars.rs
@@ -111,7 +111,6 @@ impl AST for VarDefAST {
         let mut linkas = None;
         let mut is_extern = None;
         let mut vis_spec = None;
-        let mut stack = None;
         let mut target_match = 2u8;
         for (ann, arg, loc) in self.annotations.iter() {
             let loc = *loc;
@@ -272,9 +271,6 @@ impl AST for VarDefAST {
         let vs = vis_spec.map_or(ctx.export.get(), |(v, _)| v);
         if target_match == 0 {return (Value::null(), errs)}
         if self.global || is_static {
-            if let Some(loc) = stack {
-                errs.push(CobaltError::MustBeLocal {name: "stack", loc});
-            }
             if is_extern.is_some() {
                 let t2 = self.val.res_type(ctx);
                 let dt = if let Some(t) = self.type_.as_ref().map(|t| {

--- a/cobalt-ast/src/ast/vars.rs
+++ b/cobalt-ast/src/ast/vars.rs
@@ -551,10 +551,10 @@ impl AST for VarDefAST {
     fn to_code(&self) -> String {
         let mut out = "".to_string();
         for s in self.annotations.iter().map(|(name, arg, _)| ("@".to_string() + name.as_str() + arg.as_ref().map(|x| format!("({x})")).unwrap_or_default().as_str() + " ")) {out += s.as_str();}
-        out + format!("let {}{} = {}", self.name, self.type_.as_ref().map_or("".to_string(), |t| format!(": {}", t.to_code())), self.val.to_code()).as_str()
+        out + format!("let {}{}{} = {}", if self.is_mut {"mut "} else {""}, self.name, self.type_.as_ref().map_or("".to_string(), |t| format!(": {}", t.to_code())), self.val.to_code()).as_str()
     }
     fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
-        writeln!(f, "let: {}", self.name)?;
+        writeln!(f, "let {}: {}", if self.is_mut {"(mut)"} else {""}, self.name)?;
         writeln!(f, "{pre}├── annotations:")?;
         pre.push(false);
         for (n, (name, arg, _)) in self.annotations.iter().enumerate() {

--- a/cobalt-ast/src/context.rs
+++ b/cobalt-ast/src/context.rs
@@ -190,7 +190,7 @@ impl<'ctx> CompCtx<'ctx> {
                         return None
                     }
                 }
-                x => types::utils::attr((x, unreachable_span()), (&name.0, unreachable_span()), self).ok()?
+                x => ops::attr((x, unreachable_span()), (&name.0, unreachable_span()), self).ok()?
             };
         }
         Some(v)

--- a/cobalt-ast/src/lib.rs
+++ b/cobalt-ast/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod ast;
 pub mod context;
 pub mod dottedname;
+pub mod ops;
 pub mod types;
 pub mod varmap;
 pub mod value;

--- a/cobalt-ast/src/ops.rs
+++ b/cobalt-ast/src/ops.rs
@@ -1864,7 +1864,7 @@ pub fn impl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
     else if target == Type::Null {return Ok(Value::null())}
     else if target == Type::Error {return Ok(Value::error())}
     else if let Type::Reference(ref b) = target {
-        if **b == val.data_type {return Ok(Value::new(val.addr(ctx).map(From::from), None, target))}
+        if **b == val.data_type {return Ok(Value::new(if matches!(val.data_type, Type::Mut(_)) {val.value(ctx)} else {val.addr(ctx).map(From::from)}, None, target))}
         if let Type::Mut(b) = b.as_ref() {
             if **b == val.data_type {
                 return Ok(Value::new(val.addr(ctx).map(From::from), None, target))
@@ -2077,7 +2077,7 @@ pub fn expl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
     else if target == Type::Null {return Ok(Value::null())}
     else if target == Type::Error {return Ok(Value::error())}
     else if let Type::Reference(ref b) = target {
-        if **b == val.data_type {return Ok(Value::new(val.addr(ctx).map(From::from), None, target))}
+        if **b == val.data_type {return Ok(Value::new(if matches!(val.data_type, Type::Mut(_)) {val.value(ctx)} else {val.addr(ctx).map(From::from)}, None, target))}
         if let Type::Mut(b) = b.as_ref() {
             if **b == val.data_type {
                 return Ok(Value::new(val.addr(ctx).map(From::from), None, target))

--- a/cobalt-ast/src/ops.rs
+++ b/cobalt-ast/src/ops.rs
@@ -2245,7 +2245,7 @@ pub fn attr<'ctx>((mut val, vloc): (Value<'ctx>, SourceSpan), (id, iloc): (&str,
                             Ok(v)
                         },
                         MethodType::Static => Err(err),
-                        MethodType::Getter => types::utils::call(Value::new(*comp_val, Some(iv.clone()), Type::Function(ret.clone(), args.clone())), iloc, None, vec![(Value {data_type: Type::Reference(b.clone(), m), ..val.clone()}, vloc)], ctx)
+                        MethodType::Getter => ops::call(Value::new(*comp_val, Some(iv.clone()), Type::Function(ret.clone(), args.clone())), iloc, None, vec![(Value {data_type: Type::Reference(b.clone(), m), ..val.clone()}, vloc)], ctx)
                     }
                 } else {Err(err)})
             }
@@ -2275,7 +2275,7 @@ pub fn attr<'ctx>((mut val, vloc): (Value<'ctx>, SourceSpan), (id, iloc): (&str,
                     MethodType::Getter => {
                         val.comp_val = val.addr(ctx).map(From::from);
                         val.data_type = Type::Reference(Box::new(val.data_type.clone()), false);
-                        types::utils::call(Value::new(*comp_val, Some(iv.clone()), Type::Function(ret.clone(), args.clone())), iloc, None, vec![(val.clone(), vloc)], ctx)
+                        ops::call(Value::new(*comp_val, Some(iv.clone()), Type::Function(ret.clone(), args.clone())), iloc, None, vec![(val.clone(), vloc)], ctx)
                     }
                 }
             } else {Err(err)})

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -82,7 +82,7 @@ impl Display for Type {
                     len -= 1;
                 }
                 write!(f, "): {}", *ret)
-            },
+            }
             BoundMethod(base, ret, args, m) => {
                 write!(f, "{} {base}.fn (", if *m {"mut"} else {"const"})?;
                 let mut len = args.len();
@@ -95,7 +95,7 @@ impl Display for Type {
                     len -= 1;
                 }
                 write!(f, "): {}", *ret)
-            },
+            }
             Nominal(n) => write!(f, "{n}"),
             Tuple(v) => {
                 write!(f, "(")?;

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -180,10 +180,11 @@ impl Type {
                     let mut args = Vec::<BasicMetadataTypeEnum>::with_capacity(p.len());
                     for (p, c) in p {if !c {args.push(p.llvm_type(ctx)?.into());}}
                     Some(if r.size(ctx) == Static(0) {ctx.context.void_type().fn_type(&args, false)} else {r.llvm_type(ctx)?.fn_type(&args, false)}.ptr_type(Default::default()).into())
-                },
+                }
+                Type::Mut(b) => b.llvm_type(ctx),
                 b => if b.size(ctx) == Static(0) {Some(PointerType(ctx.null_type.ptr_type(Default::default())))} else {Some(PointerType(b.llvm_type(ctx)?.ptr_type(Default::default())))}
             }
-            Mut(b) => b.llvm_type(ctx),
+            Mut(b) => b.llvm_type(ctx).map(|t| t.ptr_type(Default::default()).into()),
             Tuple(v) => {
                 let mut vec = Vec::with_capacity(v.len());
                 for t in v {vec.push(t.llvm_type(ctx)?);}

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -181,7 +181,7 @@ impl Type {
                     for (p, c) in p {if !c {args.push(p.llvm_type(ctx)?.into());}}
                     Some(if r.size(ctx) == Static(0) {ctx.context.void_type().fn_type(&args, false)} else {r.llvm_type(ctx)?.fn_type(&args, false)}.ptr_type(Default::default()).into())
                 }
-                Type::Mut(b) => b.llvm_type(ctx),
+                Type::Mut(b) => b.llvm_type(ctx).map(|t| t.ptr_type(Default::default()).into()),
                 b => if b.size(ctx) == Static(0) {Some(PointerType(ctx.null_type.ptr_type(Default::default())))} else {Some(PointerType(b.llvm_type(ctx)?.ptr_type(Default::default())))}
             }
             Mut(b) => b.llvm_type(ctx).map(|t| t.ptr_type(Default::default()).into()),

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -327,7 +327,7 @@ impl Type {
                 b.save(out)
             }
             Mut(b) => {
-                out.write_all(&[11]);
+                out.write_all(&[11])?;
                 b.save(out)
             }
             Function(b, p) => {

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -487,4 +487,3 @@ pub fn tuple_type<'ctx>(v: &[Type], ctx: &CompCtx<'ctx>) -> Option<BasicTypeEnum
     for t in v {vec.push(t.llvm_type(ctx)?);}
     Some(ctx.context.struct_type(&vec, false).into())
 }
-pub mod utils;

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -43,7 +43,7 @@ pub enum Type {
     IntLiteral, Intrinsic(String),
     Int(u16, bool),
     Float16, Float32, Float64, Float128,
-    Pointer(Box<Type>, bool), Reference(Box<Type>, bool),
+    Pointer(Box<Type>), Reference(Box<Type>), Mut(Box<Type>),
     Null, Module, TypeData, InlineAsm(Box<Type>), Array(Box<Type>, Option<u32>),
     Function(Box<Type>, Vec<(Type, bool)>), BoundMethod(Box<Type>, Box<Type>, Vec<(Type, bool)>, bool), Nominal(String),
     Tuple(Vec<Type>),
@@ -61,10 +61,9 @@ impl Display for Type {
             Float32 => write!(f, "f32"),
             Float64 => write!(f, "f64"),
             Float128 => write!(f, "f128"),
-            Pointer(x, false) => write!(f, "{} const*", *x),
-            Pointer(x, true) => write!(f, "{} mut*", *x),
-            Reference(x, false) => write!(f, "{} const&", *x),
-            Reference(x, true) => write!(f, "{} mut&", *x),
+            Pointer(x) => write!(f, "*{x}"),
+            Reference(x) => write!(f, "&{x}"),
+            Mut(x) => write!(f, "mut {x}"),
             Null => write!(f, "null"),
             Module => write!(f, "module"),
             TypeData => write!(f, "type"),
@@ -125,10 +124,11 @@ impl Type {
             Array(_, None) => Dynamic,
             Function(..) | Module | TypeData | InlineAsm(_) | Intrinsic(_) | Error => Meta,
             BoundMethod(..) => Static(ctx.flags.word_size as u32 * 2),
-            Pointer(b, _) | Reference(b, _) => match **b {
+            Pointer(b) | Reference(b) => match **b {
                 Type::Array(_, None) => Static(ctx.flags.word_size as u32 * 2),
                 _ => Static(ctx.flags.word_size as u32)
-            },
+            }
+            Mut(b) => b.size(ctx),
             Tuple(v) => v.iter().fold(Static(0), |v, t| if let Static(bs) = v {
                 let n = t.size(ctx);
                 if let Static(ns) = n {
@@ -155,7 +155,8 @@ impl Type {
             Null => 1,
             Array(b, _) => b.align(ctx),
             Function(..) | Module | TypeData | InlineAsm(_) | Intrinsic(_) | Error => 0,
-            Pointer(..) | Reference(..) | BoundMethod(..) => ctx.flags.word_size,
+            Pointer(_) | Reference(_) | BoundMethod(..) => ctx.flags.word_size,
+            Mut(b) => b.align(ctx),
             Tuple(v) => v.iter().map(|x| x.align(ctx)).max().unwrap_or(1),
             Nominal(n) => ctx.nominals.borrow()[n].0.align(ctx)
         }
@@ -169,10 +170,10 @@ impl Type {
             Float64 => Some(FloatType(ctx.context.f64_type())),
             Float128 => Some(FloatType(ctx.context.f128_type())),
             Null | Function(..) | Module | TypeData | InlineAsm(_) | Intrinsic(_) | Error => None,
-            BoundMethod(base, ret, params, _) => Some(ctx.context.struct_type(&[Type::Pointer(base.clone(), false).llvm_type(ctx)?, Type::Pointer(Box::new(Type::Function(ret.clone(), params.clone())), false).llvm_type(ctx)?], false).into()),
+            BoundMethod(base, ret, params, _) => Some(ctx.context.struct_type(&[Type::Pointer(base.clone()).llvm_type(ctx)?, Type::Pointer(Box::new(Type::Function(ret.clone(), params.clone()))).llvm_type(ctx)?], false).into()),
             Array(b, Some(n)) => Some(b.llvm_type(ctx)?.array_type(*n).into()),
             Array(_, None) => None,
-            Pointer(b, _) | Reference(b, _) => match &**b {
+            Pointer(b) | Reference(b) => match &**b {
                 Type::Array(b, None) => Some(ctx.context.struct_type(&[b.llvm_type(ctx)?.ptr_type(Default::default()).into(), ctx.context.i64_type().into()], false).into()),
                 Type::Array(b, Some(_)) => Some(b.llvm_type(ctx)?.ptr_type(Default::default()).into()),
                 Type::Function(r, p) => {
@@ -181,12 +182,13 @@ impl Type {
                     Some(if r.size(ctx) == Static(0) {ctx.context.void_type().fn_type(&args, false)} else {r.llvm_type(ctx)?.fn_type(&args, false)}.ptr_type(Default::default()).into())
                 },
                 b => if b.size(ctx) == Static(0) {Some(PointerType(ctx.null_type.ptr_type(Default::default())))} else {Some(PointerType(b.llvm_type(ctx)?.ptr_type(Default::default())))}
-            },
+            }
+            Mut(b) => b.llvm_type(ctx),
             Tuple(v) => {
                 let mut vec = Vec::with_capacity(v.len());
                 for t in v {vec.push(t.llvm_type(ctx)?);}
                 Some(ctx.context.struct_type(&vec, false).into())
-            },
+            }
             Nominal(n) => ctx.nominals.borrow()[n].0.llvm_type(ctx)
         }
     }
@@ -195,6 +197,7 @@ impl Type {
             IntLiteral | Int(_, _) | Float16 | Float32 | Float64 | Float128 | Null | Function(..) | Pointer(..) | Reference(..) | BoundMethod(..) => true,
             Tuple(v) => v.iter().all(|x| x.copyable(ctx)),
             Nominal(n) => ctx.nominals.borrow()[n].0.copyable(ctx),
+            Mut(b) => b.copyable(ctx),
             _ => false
         }
     }
@@ -205,6 +208,7 @@ impl Type {
             Type::Array(b, Some(n)) => if let InterData::Array(v) = v {v.len() == *n as _ && v.iter().all(|v| b.can_be_compiled(v, ctx))} else {false} 
             Type::Tuple(vs) => if let InterData::Array(is) = v {vs.len() == is.len() && vs.iter().zip(is).all(|(t, v)| t.can_be_compiled(v, ctx))} else {false},
             Type::Nominal(n) => ctx.nominals.borrow()[n].0.can_be_compiled(v, ctx),
+            Type::Mut(b) => b.can_be_compiled(v, ctx),
             _ => false
         }
     }
@@ -245,13 +249,14 @@ impl Type {
                 else {unreachable!()}
             },
             Type::Nominal(n) => ctx.nominals.borrow()[n].0.into_compiled(v, ctx),
+            Type::Mut(b) => b.into_compiled(v, ctx),
             _ => None
         }
     }
     pub fn contains_nominal(&self) -> bool {
         match self {
             Type::Nominal(_) => true,
-            Type::Reference(b, _) | Type::Pointer(b, _) | Type::Array(b, _) | Type::InlineAsm(b) => b.contains_nominal(),
+            Type::Reference(b) | Type::Pointer(b) | Type::Mut(b) | Type::Array(b, _) | Type::InlineAsm(b) => b.contains_nominal(),
             Type::Tuple(v) => v.iter().any(|t| t.contains_nominal()),
             Type::Function(r, a) => r.contains_nominal() || a.iter().any(|t| t.0.contains_nominal()),
             Type::BoundMethod(b, r, a, _) => b.contains_nominal() || r.contains_nominal() || a.iter().any(|t| t.0.contains_nominal()),
@@ -261,11 +266,11 @@ impl Type {
     pub fn unwrapped(&self, ctx: &CompCtx) -> Cow<Self> {
         match self {
             Type::Nominal(n) => Cow::Owned(ctx.nominals.borrow()[n].0.clone()),
-            Type::Reference(b, m) =>
-                if b.contains_nominal() {Cow::Owned(Type::Reference(Box::new(b.unwrapped(ctx).into_owned()), *m))}
+            Type::Reference(b) =>
+                if b.contains_nominal() {Cow::Owned(Type::Reference(Box::new(b.unwrapped(ctx).into_owned())))}
                 else {Cow::Borrowed(self)},
-            Type::Pointer(b, m) =>
-                if b.contains_nominal() {Cow::Owned(Type::Pointer(Box::new(b.unwrapped(ctx).into_owned()), *m))}
+            Type::Pointer(b) =>
+                if b.contains_nominal() {Cow::Owned(Type::Pointer(Box::new(b.unwrapped(ctx).into_owned())))}
                 else {Cow::Borrowed(self)},
             Type::Array(b, s) =>
                 if b.contains_nominal() {Cow::Owned(Type::Array(Box::new(b.unwrapped(ctx).into_owned()), *s))}
@@ -302,33 +307,29 @@ impl Type {
                 let mut v = *s as i16;
                 if *u {v = -v;}
                 out.write_all(&v.to_be_bytes())
-            },
+            }
             Intrinsic(s) => {
                 out.write_all(&[2])?;
                 out.write_all(s.as_bytes())?;
                 out.write_all(&[0])
-            },
+            }
             Float16 => out.write_all(&[3]),
             Float32 => out.write_all(&[4]),
             Float64 => out.write_all(&[5]),
             Float128 => out.write_all(&[6]),
             Null => out.write_all(&[7]),
-            Pointer(b, false) => {
+            Pointer(b) => {
                 out.write_all(&[8])?;
                 b.save(out)
-            },
-            Pointer(b, true) => {
-                out.write_all(&[9])?;
-                b.save(out)
-            },
-            Reference(b, false) => {
+            }
+            Reference(b) => {
                 out.write_all(&[10])?;
                 b.save(out)
-            },
-            Reference(b, true) => {
-                out.write_all(&[11])?;
+            }
+            Mut(b) => {
+                out.write_all(&[11]);
                 b.save(out)
-            },
+            }
             Function(b, p) => {
                 out.write_all(&[13])?;
                 out.write_all(&(p.len() as u16).to_be_bytes())?; // # of params
@@ -402,10 +403,9 @@ impl Type {
             5 => Type::Float64,
             6 => Type::Float128,
             7 => Type::Null,
-            8 => Type::Pointer(Box::new(Type::load(buf)?), false),
-            9 => Type::Pointer(Box::new(Type::load(buf)?), true),
-            10 => Type::Reference(Box::new(Type::load(buf)?), false),
-            11 => Type::Reference(Box::new(Type::load(buf)?), true),
+            8 => Type::Pointer(Box::new(Type::load(buf)?)),
+            10 => Type::Reference(Box::new(Type::load(buf)?)),
+            11 => Type::Mut(Box::new(Type::load(buf)?)),
             13 => {
                 let mut bytes = [0; 2];
                 buf.read_exact(&mut bytes)?;
@@ -467,7 +467,7 @@ impl Type {
     pub fn export(&self, ctx: &CompCtx) {
         match self {
             Type::Nominal(n) => ctx.nominals.borrow_mut().get_mut(n).unwrap().1 = true,
-            Type::Reference(b, _) | Type::Pointer(b, _) | Type::Array(b, _) | Type::InlineAsm(b) => b.export(ctx),
+            Type::Reference(b) | Type::Pointer(b) | Type::Mut(b) | Type::Array(b, _) | Type::InlineAsm(b) => b.export(ctx),
             Type::Tuple(v) => v.iter().for_each(|t| t.export(ctx)),
             Type::Function(r, a) => {
                 r.export(ctx);

--- a/cobalt-ast/src/value.rs
+++ b/cobalt-ast/src/value.rs
@@ -226,7 +226,7 @@ impl<'ctx> Value<'ctx> {
                     }
                 }
             }
-            else if let Some(t) = if let Type::Reference(ref b, _) = var.data_type {b.llvm_type(ctx)} else {None} {
+            else if let Some(t) = if let Type::Reference(ref b) = var.data_type {b.llvm_type(ctx)} else {None} {
                 let gv = ctx.module.add_global(t, None, std::str::from_utf8(&name).expect("LLVM variable names should be valid UTF-8")); // maybe do something with linkage/call convention?
                 gv.set_linkage(DLLImport);
                 var.comp_val = Some(BasicValueEnum::PointerValue(gv.as_pointer_value()));

--- a/cobalt-errors/src/error.rs
+++ b/cobalt-errors/src/error.rs
@@ -253,6 +253,17 @@ pub enum CobaltError {
         #[label("this string should be valid UTF-8, but there was an error at byte {pos}")]
         loc: SourceSpan
     },
+    #[error("parameter type can't be mutable")]
+    #[help("try `mut param: T` instead")]
+    ParamCantBeMut {
+        #[label]
+        loc: SourceSpan
+    },
+    #[error("return type can't be mutable")]
+    ReturnCantBeMut {
+        #[label]
+        loc: SourceSpan
+    },
 
     // @asm issues
     #[error("invalid creation of inline assembly")]

--- a/cobalt-parser/src/lib.rs
+++ b/cobalt-parser/src/lib.rs
@@ -1379,9 +1379,11 @@ fn expr(mode: u8, src: &str, start: usize) -> ParserReturn<Box<dyn AST>> {
                     }).to_string(), start));
                     src = &src[1..];
                     start += 1;
+                    continue
                 }
                 _ => {}
             }
+            break
         }
         let ast = ops.into_iter().fold(ast, |ast, op| match op {
             PostfixType::Operator(op, loc) => Box::new(PostfixAST::new((loc, op.len()).into(), op, ast)) as _,
@@ -1406,9 +1408,10 @@ fn expr(mode: u8, src: &str, start: usize) -> ParserReturn<Box<dyn AST>> {
                 src = &src[1..];
                 start += 1;
             }
-            else if process(|src, start| start_match("mut"), &mut src, &mut start, &mut errs).is_some() {
+            else if process(|src, start| start_match("mut", src, start), &mut src, &mut start, &mut errs).is_some() {
                 ops.push((start, "mut".to_string()));
             }
+            else {break}
             process(ignored, &mut src, &mut start, &mut errs);
         }
         let ast = process(postfix, &mut src, &mut start, &mut errs)?.0;

--- a/cobalt-parser/src/lib.rs
+++ b/cobalt-parser/src/lib.rs
@@ -1425,7 +1425,7 @@ fn expr(mode: u8, src: &str, start: usize) -> ParserReturn<Box<dyn AST>> {
         let first = process(prefix, &mut src, &mut start, &mut errs)?.0;
         let mut rest = vec![];
         process(ignored, &mut src, &mut start, &mut errs);
-        while src.starts_with(['*', '/', '%']) {
+        while src.starts_with(['*', '/', '%']) && src.as_bytes().get(1) != Some(&b'=') {
             let loc = start;
             let op = src[..1].to_string();
             src = &src[1..];
@@ -1446,7 +1446,7 @@ fn expr(mode: u8, src: &str, start: usize) -> ParserReturn<Box<dyn AST>> {
         let first = process(mul_div, &mut src, &mut start, &mut errs)?.0;
         let mut rest = vec![];
         process(ignored, &mut src, &mut start, &mut errs);
-        while src.starts_with(['+', '-']) {
+        while src.starts_with(['+', '-']) && src.as_bytes().get(1) != Some(&b'=') {
             let loc = start;
             let add = src.starts_with('+');
             src = &src[1..];
@@ -1467,7 +1467,7 @@ fn expr(mode: u8, src: &str, start: usize) -> ParserReturn<Box<dyn AST>> {
         let first = process(add_sub, &mut src, &mut start, &mut errs)?.0;
         let mut rest = vec![];
         process(ignored, &mut src, &mut start, &mut errs);
-        while src.starts_with("<<") || src.starts_with(">>") {
+        while (src.starts_with("<<") || src.starts_with(">>")) && src.as_bytes().get(1) != Some(&b'=') {
             let loc = start;
             let ls = src.starts_with("<<");
             src = &src[2..];
@@ -1488,7 +1488,7 @@ fn expr(mode: u8, src: &str, start: usize) -> ParserReturn<Box<dyn AST>> {
         let first = process(shift, &mut src, &mut start, &mut errs)?.0;
         let mut rest = vec![];
         process(ignored, &mut src, &mut start, &mut errs);
-        while src.starts_with('>') || src.starts_with('<') {
+        while (src.starts_with('>') || src.starts_with('<')) && src.as_bytes().get(1) != Some(&b'=') {
             let loc = start;
             let gt = src.starts_with('>');
             src = &src[1..];
@@ -1535,7 +1535,7 @@ fn expr(mode: u8, src: &str, start: usize) -> ParserReturn<Box<dyn AST>> {
         let first = process(eq, &mut src, &mut start, &mut errs)?.0;
         let mut rest = vec![];
         process(ignored, &mut src, &mut start, &mut errs);
-        while src.starts_with('&') {
+        while src.starts_with('&') && src.as_bytes().get(1) != Some(&b'=') {
             let loc = start;
             src = &src[1..];
             start += 1;
@@ -1555,7 +1555,7 @@ fn expr(mode: u8, src: &str, start: usize) -> ParserReturn<Box<dyn AST>> {
         let first = process(bit_and, &mut src, &mut start, &mut errs)?.0;
         let mut rest = vec![];
         process(ignored, &mut src, &mut start, &mut errs);
-        while src.starts_with('^') {
+        while src.starts_with('^') && src.as_bytes().get(1) != Some(&b'=') {
             let loc = start;
             src = &src[1..];
             start += 1;
@@ -1575,7 +1575,7 @@ fn expr(mode: u8, src: &str, start: usize) -> ParserReturn<Box<dyn AST>> {
         let first = process(bit_xor, &mut src, &mut start, &mut errs)?.0;
         let mut rest = vec![];
         process(ignored, &mut src, &mut start, &mut errs);
-        while src.starts_with('|') {
+        while src.starts_with('|') && src.as_bytes().get(1) != Some(&b'=') {
             let loc = start;
             src = &src[1..];
             start += 1;


### PR DESCRIPTION
Changes:
- Syntax
  - `T&` is now `&T`
  - `T mut&` is now `&mut T`
  - `T const&` is not allowed
  - `mut x = val;` is now `let mut x = val;`
  - pointers are reworked similarly
- Semantics
  - Pointers and references don't store mutability themselves. Mutability is stored in a separate wrapper type
  - Covariant pointers work a bit better
    - Any pointer can be cast to `*null`
    - Array references can be cast in the same ways as pointers
- Bugs
  - In-place binary operators now parse correctly
