### PR TITLE
Add more intrinsics

### DIFF
--- a/cobalt-ast/src/ast/funcs.rs
+++ b/cobalt-ast/src/ast/funcs.rs
@@ -983,7 +983,7 @@ impl IntrinsicAST {
 impl AST for IntrinsicAST {
     fn loc(&self) -> SourceSpan {self.loc}
     fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
-        if matches!(self.name.as_str(), "alloca" | "asm" | "sizeof" | "typeof") {(Value::new(None, None, Type::Intrinsic(self.name.clone())), vec![])}
+        if matches!(self.name.as_str(), "alloca" | "asm" | "sizeof" | "typeof" | "typename") {(Value::new(None, None, Type::Intrinsic(self.name.clone())), vec![])}
         else {(Value::error(), vec![CobaltError::UnknownIntrinsic {name: self.name.clone(), loc: self.loc}])}
     }
     fn print_impl(&self, f: &mut std::fmt::Formatter, _pre: &mut TreePrefix, _file: Option<CobaltFile>) -> std::fmt::Result {writeln!(f, "intrinsic: {}", self.name)}

--- a/cobalt-ast/src/ast/funcs.rs
+++ b/cobalt-ast/src/ast/funcs.rs
@@ -983,7 +983,7 @@ impl IntrinsicAST {
 impl AST for IntrinsicAST {
     fn loc(&self) -> SourceSpan {self.loc}
     fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
-        if matches!(self.name.as_str(), "alloca" | "asm") {(Value::new(None, None, Type::Intrinsic(self.name.clone())), vec![])}
+        if matches!(self.name.as_str(), "alloca" | "asm" | "sizeof" | "typeof") {(Value::new(None, None, Type::Intrinsic(self.name.clone())), vec![])}
         else {(Value::error(), vec![CobaltError::UnknownIntrinsic {name: self.name.clone(), loc: self.loc}])}
     }
     fn print_impl(&self, f: &mut std::fmt::Formatter, _pre: &mut TreePrefix, _file: Option<CobaltFile>) -> std::fmt::Result {writeln!(f, "intrinsic: {}", self.name)}

--- a/cobalt-ast/src/ast/funcs.rs
+++ b/cobalt-ast/src/ast/funcs.rs
@@ -982,7 +982,10 @@ impl IntrinsicAST {
 }
 impl AST for IntrinsicAST {
     fn loc(&self) -> SourceSpan {self.loc}
-    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {(Value::new(None, None, Type::Intrinsic(self.name.clone())), vec![])}
+    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+        if matches!(self.name.as_str(), "alloca" | "asm") {(Value::new(None, None, Type::Intrinsic(self.name.clone())), vec![])}
+        else {(Value::error(), vec![CobaltError::UnknownIntrinsic {name: self.name.clone(), loc: self.loc}])}
+    }
     fn print_impl(&self, f: &mut std::fmt::Formatter, _pre: &mut TreePrefix, _file: Option<CobaltFile>) -> std::fmt::Result {writeln!(f, "intrinsic: {}", self.name)}
 }
 /// Move all constant alloca instructions to the entry block of the function

--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -21,12 +21,12 @@ impl AST for IntLiteralAST {
             Some((x, _)) if x.as_bytes()[0] == 0x69 && x[1..].chars().all(char::is_numeric) => {
                 let size: u16 = x[1..].parse().unwrap_or(0);
                 (Value::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(size, false)), vec![])
-            },
+            }
             Some(("usize", _)) => (Value::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(64, true)), vec![]),
             Some((x, _)) if x.as_bytes()[0] == 0x75 && x[1..].chars().all(char::is_numeric) => {
                 let size: u16 = x[1..].parse().unwrap_or(0);
                 (Value::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(size, true)), vec![])
-            },
+            }
             Some((x, loc)) => (Value::error(), vec![CobaltError::UnknownLiteralSuffix {loc: *loc, lit: "integer", suf: x.to_string()}])
         }
     }
@@ -82,12 +82,12 @@ impl AST for CharLiteralAST {
             Some((x, _)) if x.as_bytes()[0] == 0x69 && x[1..].chars().all(char::is_numeric) => {
                 let size: u16 = x[1..].parse().unwrap_or(0);
                 (Value::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(size, false)), vec![])
-            },
+            }
             Some(("usize", _)) => (Value::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(64, true)), vec![]),
             Some((x, _)) if x.as_bytes()[0] == 0x75 && x[1..].chars().all(char::is_numeric) => {
                 let size: u16 = x[1..].parse().unwrap_or(0);
                 (Value::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(size, true)), vec![])
-            },
+            }
             Some((x, loc)) => (Value::error(), vec![CobaltError::UnknownLiteralSuffix {loc: *loc, lit: "character", suf: x.to_string()}])
         }
     }
@@ -122,7 +122,7 @@ impl AST for StringLiteralAST {
                     InterData::Array(self.val.iter().map(|&c| InterData::Int(c as i128)).collect()),
                     Type::Reference(Box::new(Type::Array(Box::new(Type::Int(8, true)), Some(self.val.len() as u32))))
                 ), vec![])
-            },
+            }
             Some((x, loc)) => (Value::error(), vec![CobaltError::UnknownLiteralSuffix {loc, lit: "string", suf: x.to_string()}])
         }
     }

--- a/cobalt-ast/src/ops.rs
+++ b/cobalt-ast/src/ops.rs
@@ -2708,6 +2708,12 @@ pub fn call<'ctx>(mut target: Value<'ctx>, loc: SourceSpan, cparen: Option<Sourc
                     }
                 }
             }
+            "sizeof" => Ok(Value::metaval(InterData::Int(Type::Tuple(args.into_iter().map(|(v, aloc)| v.clone().into_type().ok_or_else(|| CobaltError::SizeofNeedsType {loc, aloc, ty: v.data_type.to_string()})).collect::<Result<_, _>>()?).size(ctx).as_static().unwrap_or(0) as _), Type::IntLiteral)),
+            "typeof" => Ok(match args.len() {
+                0 => Value::null(),
+                1 => Value::make_type(args.into_iter().next().unwrap().0.data_type),
+                _ => Value::make_type(Type::Tuple(args.into_iter().map(|x| x.0.data_type).collect())),
+            }),
             x => Err(CobaltError::UnknownIntrinsic {loc, name: x.to_string()})
         }
         t => Err(CobaltError::CannotCallWithArgs {

--- a/cobalt-ast/src/ops.rs
+++ b/cobalt-ast/src/ops.rs
@@ -2708,7 +2708,15 @@ pub fn call<'ctx>(mut target: Value<'ctx>, loc: SourceSpan, cparen: Option<Sourc
                     }
                 }
             }
-            "sizeof" => Ok(Value::metaval(InterData::Int(Type::Tuple(args.into_iter().map(|(v, aloc)| v.clone().into_type().ok_or_else(|| CobaltError::SizeofNeedsType {loc, aloc, ty: v.data_type.to_string()})).collect::<Result<_, _>>()?).size(ctx).as_static().unwrap_or(0) as _), Type::IntLiteral)),
+            "sizeof" => Ok(Value::metaval(InterData::Int(Type::Tuple(args.into_iter().map(|(v, aloc)| v.clone().into_type().ok_or_else(|| CobaltError::ExpectedType {loc, aloc, ty: v.data_type.to_string()})).collect::<Result<_, _>>()?).size(ctx).as_static().unwrap_or(0) as _), Type::IntLiteral)),
+            "typename" => {
+                let name = match args.len() {
+                    0 => "null".into(),
+                    1 => args[0].0.clone().into_type().ok_or_else(|| CobaltError::ExpectedType {loc, aloc: args[0].1, ty: args[0].0.data_type.to_string()})?.to_string(),
+                    _ => Type::Tuple(args.into_iter().map(|(v, aloc)| v.clone().into_type().ok_or_else(|| CobaltError::ExpectedType {loc, aloc, ty: v.data_type.to_string()})).collect::<Result<_, _>>()?).to_string(),
+                };
+                Ok(Value::interpreted(ctx.builder.build_global_string_ptr(&name, "cobalt.str").as_pointer_value().into(), InterData::Array(name.bytes().map(|v| InterData::Int(v as _)).collect()), Type::Reference(Box::new(Type::Array(Box::new(Type::Int(8, true)), Some(name.len() as _))))))
+            }
             "typeof" => Ok(match args.len() {
                 0 => Value::null(),
                 1 => Value::make_type(args.into_iter().next().unwrap().0.data_type),

--- a/cobalt-errors/src/error.rs
+++ b/cobalt-errors/src/error.rs
@@ -202,7 +202,7 @@ pub enum CobaltError {
         errs: Vec<CobaltError>
     },
     #[error("@sizeof requires all arguments to be types")]
-    SizeofNeedsType {
+    ExpectedType {
         #[label]
         loc: SourceSpan,
         #[label("argument type is {ty}")]

--- a/cobalt-errors/src/error.rs
+++ b/cobalt-errors/src/error.rs
@@ -201,6 +201,14 @@ pub enum CobaltError {
         #[related]
         errs: Vec<CobaltError>
     },
+    #[error("@sizeof requires all arguments to be types")]
+    SizeofNeedsType {
+        #[label]
+        loc: SourceSpan,
+        #[label("argument type is {ty}")]
+        aloc: SourceSpan,
+        ty: String
+    },
     #[error("bit cast target must be the same size as the source")]
     DifferentBitCastSizes {
         #[label]


### PR DESCRIPTION
The `@sizeof`, `@typeof`, and `@typename` intrinsics have been added. `@typeof` returns the type of the input, and `@sizeof` and `@typename` take a type and return the relevant information.
