### PR TITLE
Improve errors around mutability

### DIFF
--- a/cobalt-ast/src/ast/vars.rs
+++ b/cobalt-ast/src/ast/vars.rs
@@ -351,7 +351,7 @@ impl AST for VarDefAST {
                             name: self.name.start(x).to_string()
                         });
                         (Value::error(), errs)
-                    },
+                    }
                     Err(RedefVariable::AlreadyExists(x, d, _)) => {
                         errs.push(CobaltError::RedefVariable {
                             loc: self.name.ids[x].1,
@@ -377,7 +377,7 @@ impl AST for VarDefAST {
                         Value::error()
                     });
                     val.inter_val = None;
-                    ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData::with_vis(self.loc, vs))))
+                    ctx.with_vars(|v| v.insert(&self.name, Symbol(val.freeze(self.loc), VariableData::with_vis(self.loc, vs))))
                 }
                 else {
                     let f = ctx.module.add_function(format!("cobalt.init{}", ctx.mangle(&self.name)).as_str(), ctx.context.void_type().fn_type(&[], false), Some(inkwell::module::Linkage::Private));
@@ -424,7 +424,7 @@ impl AST for VarDefAST {
                                 Some(PointerValue(gv.as_pointer_value())),
                                 None,
                                 Type::Reference(ops::maybe_mut(Box::new(dt), self.is_mut))
-                            ), VariableData::with_vis(self.loc, vs))))
+                            ).freeze(self.loc), VariableData::with_vis(self.loc, vs))))
                         }
                         else {
                             val.inter_val = None;
@@ -433,7 +433,7 @@ impl AST for VarDefAST {
                                 f.delete();
                             }
                             if dt != Type::Error {errs.push(CobaltError::TypeIsConstOnly {ty: dt.to_string(), loc: self.type_.as_ref().unwrap_or(&self.val).loc()})}
-                            ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData::with_vis(self.loc, false))))
+                            ctx.with_vars(|v| v.insert(&self.name, Symbol(val.freeze(self.loc), VariableData::with_vis(self.loc, false))))
                         }
                     }
                     else {
@@ -452,7 +452,7 @@ impl AST for VarDefAST {
                             Value::error()
                         });
                         ctx.restore_scope(old_scope);
-                        ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData::with_vis(self.loc, vs))))
+                        ctx.with_vars(|v| v.insert(&self.name, Symbol(val.freeze(self.loc), VariableData::with_vis(self.loc, vs))))
                     }
                 };
                 match res {
@@ -463,7 +463,7 @@ impl AST for VarDefAST {
                             name: self.name.start(x).to_string()
                         });
                         (Value::error(), errs)
-                    },
+                    }
                     Err(RedefVariable::AlreadyExists(x, d, _)) => {
                         errs.push(CobaltError::RedefVariable {
                             loc: self.name.ids[x].1,
@@ -500,6 +500,7 @@ impl AST for VarDefAST {
             });
             ctx.restore_scope(old_scope);
             val.comp_val = val.value(ctx);
+            val.frozen = (!self.is_mut).then_some(self.loc);
             match if ctx.is_const.get() || !self.is_mut {
                 ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData {scope: ctx.var_scope.get().try_into().ok(), ..VariableData::with_vis(self.loc, false)})))
             } 
@@ -526,7 +527,7 @@ impl AST for VarDefAST {
                         name: self.name.start(x).to_string()
                     });
                     (Value::error(), errs)
-                },
+                }
                 Err(RedefVariable::AlreadyExists(x, d, _)) => {
                     errs.push(CobaltError::RedefVariable {
                         loc: self.name.ids[x].1,
@@ -664,7 +665,7 @@ impl AST for ConstDefAST {
         });
         ctx.restore_scope(old_scope);
         ctx.is_const.set(old_is_const);
-        match ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData {fwd: ctx.prepass.get(), init: errs.iter().any(|e| matches!(e, CobaltError::UninitializedGlobal {..})), ..VariableData::with_vis(self.loc, vs)}))) {
+        match ctx.with_vars(|v| v.insert(&self.name, Symbol(val.freeze(self.loc), VariableData {fwd: ctx.prepass.get(), init: errs.iter().any(|e| matches!(e, CobaltError::UninitializedGlobal {..})), ..VariableData::with_vis(self.loc, vs)}))) {
             Ok(x) => (x.0.clone(), errs),
             Err(RedefVariable::NotAModule(x, _)) => {
                 errs.push(CobaltError::NotAModule {
@@ -722,8 +723,8 @@ impl AST for TypeDefAST {
         let pp = ctx.prepass.replace(true);
         let old_scope = ctx.push_scope(&self.name);
         ctx.with_vars(|v| {
-            v.symbols.insert("base_t".to_string(), Value::make_type(Type::Null.clone()).into());
-            v.symbols.insert("self_t".to_string(), Value::make_type(Type::Nominal(mangled.clone())).into());
+            v.symbols.insert("base_t".to_string(), Value::make_type(Type::Null).freeze(self.loc).into());
+            v.symbols.insert("self_t".to_string(), Value::make_type(Type::Nominal(mangled.clone())).freeze(self.loc).into());
         });
         {
             let mut noms = ctx.nominals.borrow_mut();
@@ -756,8 +757,8 @@ impl AST for TypeDefAST {
         });
         let old_scope = ctx.push_scope(&self.name);
         ctx.with_vars(|v| {
-            v.symbols.insert("base_t".to_string(), Value::make_type(Type::Null.clone()).into());
-            v.symbols.insert("self_t".to_string(), Value::make_type(Type::Nominal(mangled.clone())).into());
+            v.symbols.insert("base_t".to_string(), Value::make_type(Type::Null).freeze(self.loc).into());
+            v.symbols.insert("self_t".to_string(), Value::make_type(Type::Nominal(mangled.clone())).freeze(self.loc).into());
         });
         {
             let mut noms = ctx.nominals.borrow_mut();
@@ -780,8 +781,8 @@ impl AST for TypeDefAST {
         let old_scope = ctx.push_scope(&self.name);
         let ty = ops::impl_convert(unreachable_span(), (self.val.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
         ctx.with_vars(|v| {
-            v.symbols.insert("base_t".to_string(), Value::make_type(ty.clone()).into());
-            v.symbols.insert("self_t".to_string(), Value::make_type(Type::Nominal(mangled.clone())).into());
+            v.symbols.insert("base_t".to_string(), Value::make_type(ty.clone()).freeze(self.loc).into());
+            v.symbols.insert("self_t".to_string(), Value::make_type(Type::Nominal(mangled.clone())).freeze(self.loc).into());
         });
         match ctx.nominals.borrow_mut().entry(mangled.clone()) {
             Entry::Occupied(mut x) => x.get_mut().0 = ty,
@@ -872,8 +873,8 @@ impl AST for TypeDefAST {
         });
         let old_scope = ctx.push_scope(&self.name);
         ctx.with_vars(|v| {
-            v.symbols.insert("base_t".to_string(), Value::make_type(ty.clone()).into());
-            v.symbols.insert("self_t".to_string(), Value::make_type(Type::Nominal(mangled.clone())).into());
+            v.symbols.insert("base_t".to_string(), Value::make_type(ty.clone()).freeze(self.loc).into());
+            v.symbols.insert("self_t".to_string(), Value::make_type(Type::Nominal(mangled.clone())).freeze(self.loc).into());
         });
         match ctx.nominals.borrow_mut().entry(mangled.clone()) {
             Entry::Occupied(mut x) => x.get_mut().0 = ty,
@@ -883,7 +884,7 @@ impl AST for TypeDefAST {
         let mut noms = ctx.nominals.borrow_mut();
         ctx.restore_scope(old_scope);
         noms.get_mut(&mangled).unwrap().2 = ctx.map_split_vars(|v| (v.parent.unwrap(), v.symbols.into_iter().map(|(k, v)| (k, v.0)).collect()));
-        match ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::make_type(Type::Nominal(mangled.clone())), VariableData {fwd: ctx.prepass.get(), init: errs.iter().any(|e| matches!(e, CobaltError::UninitializedGlobal {..})), ..VariableData::with_vis(self.loc, vs)}))) {
+        match ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::make_type(Type::Nominal(mangled.clone())).freeze(self.loc), VariableData {fwd: ctx.prepass.get(), init: errs.iter().any(|e| matches!(e, CobaltError::UninitializedGlobal {..})), ..VariableData::with_vis(self.loc, vs)}))) {
             Ok(x) => (x.0.clone(), errs),
             Err(RedefVariable::NotAModule(x, _)) => {
                 noms.remove(&mangled);
@@ -892,7 +893,7 @@ impl AST for TypeDefAST {
                     name: self.name.start(x).to_string()
                 });
                 (Value::error(), errs)
-            },
+            }
             Err(RedefVariable::AlreadyExists(x, d, _)) => {
                 noms.remove(&mangled);
                 errs.push(CobaltError::RedefVariable {

--- a/cobalt-ast/src/ops.rs
+++ b/cobalt-ast/src/ops.rs
@@ -1785,7 +1785,11 @@ pub fn impl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
     }
     match val.data_type.clone() {
         Type::Reference(b) => {
-            if covariant(&b, &target) {return Ok(Value::new(val.comp_val, val.inter_val, Type::Reference(b)));}
+            if let Type::Reference(t) = &target {
+                if covariant(&b, t) {
+                    return Ok(Value::new(val.comp_val, val.inter_val, Type::Reference(b)));
+                }
+            }
             match *b {
                 Type::Mut(b) => match *b {
                     Type::Array(b, Some(l)) => match target {
@@ -2005,7 +2009,11 @@ pub fn expl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
     }
     match val.data_type {
         Type::Reference(b) => {
-            if covariant(&b, &target) {return Ok(Value::new(val.comp_val, val.inter_val, Type::Reference(b)));}
+            if let Type::Reference(t) = &target {
+                if covariant(&b, t) {
+                    return Ok(Value::new(val.comp_val, val.inter_val, Type::Reference(b)));
+                }
+            }
             match *b {
                 Type::Mut(b) => match *b {
                     Type::Array(b, Some(l)) => match target {

--- a/cobalt-ast/src/ops.rs
+++ b/cobalt-ast/src/ops.rs
@@ -1112,13 +1112,16 @@ pub fn bin_op<'ctx>(loc: SourceSpan, (mut lhs, lloc): (Value<'ctx>, SourceSpan),
         _ => Err(err)
     };
     out.map_err(|err| {
-        let oic = ctx.is_const.replace(true);
         let tyname = ldt.to_string();
-        let lhs = Value {data_type: Type::Mut(Box::new(ldt)), ..Value::null()};
-        let rhs = Value {data_type: rdt, ..Value::null()};
-        let uloc = unreachable_span();
-        let non_mut = bin_op(uloc, (lhs, uloc), (rhs, uloc), op, ctx).is_ok();
-        ctx.is_const.set(oic);
+        let non_mut = !matches!(ldt, Type::Mut(_)) && {
+            let oic = ctx.is_const.replace(true);
+            let lhs = Value {data_type: Type::Mut(Box::new(ldt)), ..Value::null()};
+            let rhs = Value {data_type: rdt, ..Value::null()};
+            let uloc = unreachable_span();
+            let non_mut = bin_op(uloc, (lhs, uloc), (rhs, uloc), op, ctx).is_ok();
+            ctx.is_const.set(oic);
+            non_mut
+        };
         if non_mut {
             CobaltError::CantMutateImmut {
                 vloc: lloc,
@@ -1342,12 +1345,15 @@ pub fn pre_op<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, SourceSpan),
         _ => Err(err)
     };
     out.map_err(|err| {
-        let oic = ctx.is_const.replace(true);
         let tyname = vdt.to_string();
-        let val = Value {data_type: Type::Mut(Box::new(vdt)), ..Value::null()};
-        let uloc = unreachable_span();
-        let non_mut = pre_op(uloc, (val, uloc), op, ctx).is_ok();
-        ctx.is_const.set(oic);
+        let non_mut = (!matches!(vdt, Type::Mut(_))) && {
+            let oic = ctx.is_const.replace(true);
+            let val = Value {data_type: Type::Mut(Box::new(vdt)), ..Value::null()};
+            let uloc = unreachable_span();
+            let non_mut = post_op(uloc, (val, uloc), op, ctx).is_ok();
+            ctx.is_const.set(oic);
+            non_mut
+        };
         if non_mut {
             CobaltError::CantMutateImmut {
                 vloc,
@@ -1370,12 +1376,15 @@ pub fn post_op<'ctx>(loc: SourceSpan, (val, vloc): (Value<'ctx>, SourceSpan), op
     let vf = val.frozen;
     let out = Err(err);
     out.map_err(|err| {
-        let oic = ctx.is_const.replace(true);
         let tyname = vdt.to_string();
-        let val = Value {data_type: Type::Mut(Box::new(vdt)), ..Value::null()};
-        let uloc = unreachable_span();
-        let non_mut = post_op(uloc, (val, uloc), op, ctx).is_ok();
-        ctx.is_const.set(oic);
+        let non_mut = (!matches!(vdt, Type::Mut(_))) && {
+            let oic = ctx.is_const.replace(true);
+            let val = Value {data_type: Type::Mut(Box::new(vdt)), ..Value::null()};
+            let uloc = unreachable_span();
+            let non_mut = post_op(uloc, (val, uloc), op, ctx).is_ok();
+            ctx.is_const.set(oic);
+            non_mut
+        };
         if non_mut {
             CobaltError::CantMutateImmut {
                 vloc,

--- a/cobalt-ast/src/value.rs
+++ b/cobalt-ast/src/value.rs
@@ -151,19 +151,20 @@ pub struct Value<'ctx> {
     pub comp_val: Option<BasicValueEnum<'ctx>>,
     pub inter_val: Option<InterData<'ctx>>,
     pub data_type: Type,
-    pub address: Rc<Cell<Option<PointerValue<'ctx>>>>
+    pub address: Rc<Cell<Option<PointerValue<'ctx>>>>,
+    pub frozen: Option<SourceSpan>
 }
 impl<'ctx> Value<'ctx> {
-    pub fn error() -> Self {Value {comp_val: None, inter_val: None, data_type: Type::Error, address: Rc::default()}}
-    pub fn null() -> Self {Value {comp_val: None, inter_val: None, data_type: Type::Null, address: Rc::default()}}
-    pub fn new(comp_val: Option<BasicValueEnum<'ctx>>, inter_val: Option<InterData<'ctx>>, data_type: Type) -> Self {Value {comp_val, inter_val, data_type, address: Rc::default()}}
-    pub fn with_addr(comp_val: Option<BasicValueEnum<'ctx>>, inter_val: Option<InterData<'ctx>>, data_type: Type, addr: PointerValue<'ctx>) -> Self {Value {comp_val, inter_val, data_type, address: Rc::new(Cell::new(Some(addr)))}}
-    pub fn compiled(comp_val: BasicValueEnum<'ctx>, data_type: Type) -> Self {Value {comp_val: Some(comp_val), inter_val: None, data_type, address: Rc::default()}}
-    pub fn interpreted(comp_val: BasicValueEnum<'ctx>, inter_val: InterData<'ctx>, data_type: Type) -> Self {Value {comp_val: Some(comp_val), inter_val: Some(inter_val), data_type, address: Rc::default()}}
-    pub fn metaval(inter_val: InterData<'ctx>, data_type: Type) -> Self {Value {comp_val: None, inter_val: Some(inter_val), data_type, address: Rc::default()}}
-    pub fn make_type(type_: Type) -> Self {Value {comp_val: None, inter_val: Some(InterData::Type(Box::new(type_))), data_type: Type::TypeData, address: Rc::default()}}
-    pub fn empty_mod(name: String) -> Self {Value {comp_val: None, inter_val: Some(InterData::Module(HashMap::new(), vec![], name)), data_type: Type::Module, address: Rc::default()}}
-    pub fn make_mod(syms: HashMap<String, Symbol<'ctx>>, imps: Vec<(CompoundDottedName, bool)>, name: String) -> Self {Value {comp_val: None, inter_val: Some(InterData::Module(syms, imps, name)), data_type: Type::Module, address: Rc::default()}}
+    pub fn error() -> Self {Value {comp_val: None, inter_val: None, data_type: Type::Error, address: Rc::default(), frozen: None}}
+    pub fn null() -> Self {Value {comp_val: None, inter_val: None, data_type: Type::Null, address: Rc::default(), frozen: None}}
+    pub fn new(comp_val: Option<BasicValueEnum<'ctx>>, inter_val: Option<InterData<'ctx>>, data_type: Type) -> Self {Value {comp_val, inter_val, data_type, address: Rc::default(), frozen: None}}
+    pub fn with_addr(comp_val: Option<BasicValueEnum<'ctx>>, inter_val: Option<InterData<'ctx>>, data_type: Type, addr: PointerValue<'ctx>) -> Self {Value {comp_val, inter_val, data_type, address: Rc::new(Cell::new(Some(addr))), frozen: None}}
+    pub fn compiled(comp_val: BasicValueEnum<'ctx>, data_type: Type) -> Self {Value {comp_val: Some(comp_val), inter_val: None, data_type, address: Rc::default(), frozen: None}}
+    pub fn interpreted(comp_val: BasicValueEnum<'ctx>, inter_val: InterData<'ctx>, data_type: Type) -> Self {Value {comp_val: Some(comp_val), inter_val: Some(inter_val), data_type, address: Rc::default(), frozen: None}}
+    pub fn metaval(inter_val: InterData<'ctx>, data_type: Type) -> Self {Value {comp_val: None, inter_val: Some(inter_val), data_type, address: Rc::default(), frozen: None}}
+    pub fn make_type(type_: Type) -> Self {Value {comp_val: None, inter_val: Some(InterData::Type(Box::new(type_))), data_type: Type::TypeData, address: Rc::default(), frozen: None}}
+    pub fn empty_mod(name: String) -> Self {Value {comp_val: None, inter_val: Some(InterData::Module(HashMap::new(), vec![], name)), data_type: Type::Module, address: Rc::default(), frozen: None}}
+    pub fn make_mod(syms: HashMap<String, Symbol<'ctx>>, imps: Vec<(CompoundDottedName, bool)>, name: String) -> Self {Value {comp_val: None, inter_val: Some(InterData::Module(syms, imps, name)), data_type: Type::Module, address: Rc::default(), frozen: None}}
     
     pub fn addr(&self, ctx: &CompCtx<'ctx>) -> Option<PointerValue<'ctx>> {
         self.address.get().or_else(|| {
@@ -173,6 +174,12 @@ impl<'ctx> Value<'ctx> {
             self.address.set(Some(alloca));
             Some(alloca)
         })
+    }
+    pub fn freeze(self, loc: SourceSpan) -> Value<'ctx> {
+        Value {
+            frozen: Some(loc),
+            ..self
+        }
     }
 
     pub fn value(&self, ctx: &CompCtx<'ctx>) -> Option<BasicValueEnum<'ctx>> {self.comp_val.or_else(|| self.inter_val.as_ref().and_then(|v| self.data_type.into_compiled(v, ctx)))}

--- a/cobalt-errors/src/error.rs
+++ b/cobalt-errors/src/error.rs
@@ -167,8 +167,10 @@ pub enum CobaltError {
         vloc: SourceSpan,
         ty: String,
         #[label("operator is `{op}`")]
-        oloc: SourceSpan,
-        op: String
+        oloc: Option<SourceSpan>,
+        op: String,
+        #[label("defined as immutable here")]
+        floc: SourceSpan
     },
 
     // Misc stuff

--- a/cobalt-errors/src/error.rs
+++ b/cobalt-errors/src/error.rs
@@ -161,6 +161,15 @@ pub enum CobaltError {
         #[label("index is {idx}")]
         iloc: SourceSpan
     },
+    #[error("cannot mutate an immutable value")]
+    CantMutateImmut {
+        #[label("value is of type `{ty}`")]
+        vloc: SourceSpan,
+        ty: String,
+        #[label("operator is `{op}`")]
+        oloc: SourceSpan,
+        op: String
+    },
 
     // Misc stuff
     #[error("error in glob pattern")]


### PR DESCRIPTION
Previously, when a binary operator meant to be called on a mutable value (like assignment) was called on an immutable value, the error message wasn't very clear about what the problem was. Now it's a bit clearer.
I also fixed an issue with `mut` on the right side of a binary operator not being unwrapped.