### PR TITLE
Run `cargo fmt`

### DIFF
--- a/cobalt-ast/src/ast/flow.rs
+++ b/cobalt-ast/src/ast/flow.rs
@@ -4,77 +4,141 @@ pub struct IfAST {
     loc: SourceSpan,
     pub cond: Box<dyn AST>,
     pub if_true: Box<dyn AST>,
-    pub if_false: Box<dyn AST>
+    pub if_false: Box<dyn AST>,
 }
 impl IfAST {
-    pub fn new(loc: SourceSpan, cond: Box<dyn AST>, if_true: Box<dyn AST>, if_false: Box<dyn AST>) -> Self {IfAST {loc, cond, if_true, if_false}}
+    pub fn new(
+        loc: SourceSpan,
+        cond: Box<dyn AST>,
+        if_true: Box<dyn AST>,
+        if_false: Box<dyn AST>,
+    ) -> Self {
+        IfAST {
+            loc,
+            cond,
+            if_true,
+            if_false,
+        }
+    }
 }
 impl AST for IfAST {
-    fn loc(&self) -> SourceSpan {self.loc}
-    fn nodes(&self) -> usize {self.cond.nodes() + self.if_true.nodes() + self.if_false.nodes() + 1}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn nodes(&self) -> usize {
+        self.cond.nodes() + self.if_true.nodes() + self.if_false.nodes() + 1
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
-        if ctx.is_const.get() {return (Value::null(), vec![])}
+        if ctx.is_const.get() {
+            return (Value::null(), vec![]);
+        }
         let mut errs = vec![];
         let (cond, mut es) = self.cond.codegen(ctx);
         errs.append(&mut es);
-        let cv = ops::expl_convert(self.cond.loc(), (cond, None), (Type::Int(1, false), None), ctx).unwrap_or_else(|e| {
+        let cv = ops::expl_convert(
+            self.cond.loc(),
+            (cond, None),
+            (Type::Int(1, false), None),
+            ctx,
+        )
+        .unwrap_or_else(|e| {
             errs.push(e);
-            Value::compiled(ctx.context.bool_type().const_int(0, false).into(), Type::Int(1, false))
+            Value::compiled(
+                ctx.context.bool_type().const_int(0, false).into(),
+                Type::Int(1, false),
+            )
         });
         if let Some(inkwell::values::BasicValueEnum::IntValue(v)) = cv.value(ctx) {
-            ({
-                if let Some(f) = ctx.builder.get_insert_block().and_then(|bb| bb.get_parent()) {
-                    let itb = ctx.context.append_basic_block(f, "if_true");
-                    let ifb = ctx.context.append_basic_block(f, "if_false");
-                    let mb = ctx.context.append_basic_block(f, "merge");
-                    ctx.builder.build_conditional_branch(v, itb, ifb);
-                    ctx.builder.position_at_end(itb);
-                    let if_true = self.if_true.codegen_errs(ctx, &mut errs);
-                    ctx.builder.position_at_end(ifb);
-                    let if_false = self.if_false.codegen_errs(ctx, &mut errs);
-                    if let Some(ty) = ops::common(&if_true.data_type, &if_false.data_type, ctx) {
+            (
+                {
+                    if let Some(f) = ctx
+                        .builder
+                        .get_insert_block()
+                        .and_then(|bb| bb.get_parent())
+                    {
+                        let itb = ctx.context.append_basic_block(f, "if_true");
+                        let ifb = ctx.context.append_basic_block(f, "if_false");
+                        let mb = ctx.context.append_basic_block(f, "merge");
+                        ctx.builder.build_conditional_branch(v, itb, ifb);
                         ctx.builder.position_at_end(itb);
-                        let if_true = ops::impl_convert(self.if_true.loc(), (if_true, None), (ty.clone(), None), ctx).unwrap_or_else(|e| {
-                            errs.push(e);
-                            Value::error()
-                        });
-                        ctx.builder.build_unconditional_branch(mb);
+                        let if_true = self.if_true.codegen_errs(ctx, &mut errs);
                         ctx.builder.position_at_end(ifb);
-                        let if_false = ops::impl_convert(self.if_false.loc(), (if_false, None), (ty.clone(), None), ctx).unwrap_or_else(|e| {
-                            errs.push(e);
-                            Value::error()
-                        });
-                        ctx.builder.build_unconditional_branch(mb);
-                        ctx.builder.position_at_end(mb);
-                        Value::new(
-                            if let Some(llt) = ty.llvm_type(ctx) {
-                                let phi = ctx.builder.build_phi(llt, "");
-                                if let Some(v) = if_true.value(ctx) {phi.add_incoming(&[(&v, itb)]);}
-                                if let Some(v) = if_false.value(ctx) {phi.add_incoming(&[(&v, ifb)]);}
-                                Some(phi.as_basic_value())
-                            } else {None},
-                            if let Some(InterData::Int(v)) = cv.inter_val {
-                                if v == 0 {if_false.inter_val}
-                                else {if_true.inter_val}
-                            } else {None},
-                            ty
-                        )
+                        let if_false = self.if_false.codegen_errs(ctx, &mut errs);
+                        if let Some(ty) = ops::common(&if_true.data_type, &if_false.data_type, ctx)
+                        {
+                            ctx.builder.position_at_end(itb);
+                            let if_true = ops::impl_convert(
+                                self.if_true.loc(),
+                                (if_true, None),
+                                (ty.clone(), None),
+                                ctx,
+                            )
+                            .unwrap_or_else(|e| {
+                                errs.push(e);
+                                Value::error()
+                            });
+                            ctx.builder.build_unconditional_branch(mb);
+                            ctx.builder.position_at_end(ifb);
+                            let if_false = ops::impl_convert(
+                                self.if_false.loc(),
+                                (if_false, None),
+                                (ty.clone(), None),
+                                ctx,
+                            )
+                            .unwrap_or_else(|e| {
+                                errs.push(e);
+                                Value::error()
+                            });
+                            ctx.builder.build_unconditional_branch(mb);
+                            ctx.builder.position_at_end(mb);
+                            Value::new(
+                                if let Some(llt) = ty.llvm_type(ctx) {
+                                    let phi = ctx.builder.build_phi(llt, "");
+                                    if let Some(v) = if_true.value(ctx) {
+                                        phi.add_incoming(&[(&v, itb)]);
+                                    }
+                                    if let Some(v) = if_false.value(ctx) {
+                                        phi.add_incoming(&[(&v, ifb)]);
+                                    }
+                                    Some(phi.as_basic_value())
+                                } else {
+                                    None
+                                },
+                                if let Some(InterData::Int(v)) = cv.inter_val {
+                                    if v == 0 {
+                                        if_false.inter_val
+                                    } else {
+                                        if_true.inter_val
+                                    }
+                                } else {
+                                    None
+                                },
+                                ty,
+                            )
+                        } else {
+                            ctx.builder.position_at_end(itb);
+                            ctx.builder.build_unconditional_branch(mb);
+                            ctx.builder.position_at_end(ifb);
+                            ctx.builder.build_unconditional_branch(mb);
+                            ctx.builder.position_at_end(mb);
+                            Value::null()
+                        }
+                    } else {
+                        Value::error()
                     }
-                    else {
-                        ctx.builder.position_at_end(itb);
-                        ctx.builder.build_unconditional_branch(mb);
-                        ctx.builder.position_at_end(ifb);
-                        ctx.builder.build_unconditional_branch(mb);
-                        ctx.builder.position_at_end(mb);
-                        Value::null()
-                    }
-                }
-                else {Value::error()}
-            }, errs)
+                },
+                errs,
+            )
+        } else {
+            (Value::error(), vec![])
         }
-        else {(Value::error(), vec![])}
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
         writeln!(f, "if/else")?;
         print_ast_child(f, pre, &*self.cond, false, file)?;
         print_ast_child(f, pre, &*self.if_true, false, file)?;
@@ -85,38 +149,64 @@ impl AST for IfAST {
 pub struct WhileAST {
     loc: SourceSpan,
     cond: Box<dyn AST>,
-    body: Box<dyn AST>
+    body: Box<dyn AST>,
 }
 impl WhileAST {
-    pub fn new(loc: SourceSpan, cond: Box<dyn AST>, body: Box<dyn AST>) -> Self {WhileAST {loc, cond, body}}
+    pub fn new(loc: SourceSpan, cond: Box<dyn AST>, body: Box<dyn AST>) -> Self {
+        WhileAST { loc, cond, body }
+    }
 }
 impl AST for WhileAST {
-    fn loc(&self) -> SourceSpan {self.loc}
-    fn nodes(&self) -> usize {self.cond.nodes() + self.body.nodes() + 1}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn nodes(&self) -> usize {
+        self.cond.nodes() + self.body.nodes() + 1
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
-        if ctx.is_const.get() {return (Value::null(), vec![])}
-        if let Some(f) = ctx.builder.get_insert_block().and_then(|bb| bb.get_parent()) {
+        if ctx.is_const.get() {
+            return (Value::null(), vec![]);
+        }
+        if let Some(f) = ctx
+            .builder
+            .get_insert_block()
+            .and_then(|bb| bb.get_parent())
+        {
             let cond = ctx.context.append_basic_block(f, "cond");
             let body = ctx.context.append_basic_block(f, "body");
             let exit = ctx.context.append_basic_block(f, "exit");
             ctx.builder.build_unconditional_branch(cond);
             ctx.builder.position_at_end(cond);
             let (c, mut errs) = self.cond.codegen(ctx);
-            let val = ops::expl_convert(self.cond.loc(), (c, None), (Type::Int(1, false), None), ctx).unwrap_or_else(|e| {
-                errs.push(e);
-                Value::compiled(ctx.context.bool_type().const_int(0, false).into(), Type::Int(1, false))
-            }).into_value(ctx).unwrap_or(ctx.context.bool_type().const_int(0, false).into());
-            ctx.builder.build_conditional_branch(val.into_int_value(), body, exit);
+            let val =
+                ops::expl_convert(self.cond.loc(), (c, None), (Type::Int(1, false), None), ctx)
+                    .unwrap_or_else(|e| {
+                        errs.push(e);
+                        Value::compiled(
+                            ctx.context.bool_type().const_int(0, false).into(),
+                            Type::Int(1, false),
+                        )
+                    })
+                    .into_value(ctx)
+                    .unwrap_or(ctx.context.bool_type().const_int(0, false).into());
+            ctx.builder
+                .build_conditional_branch(val.into_int_value(), body, exit);
             ctx.builder.position_at_end(body);
             let (_, mut es) = self.body.codegen(ctx);
             errs.append(&mut es);
             ctx.builder.build_unconditional_branch(cond);
             ctx.builder.position_at_end(exit);
             (Value::null(), errs)
+        } else {
+            (Value::error(), vec![])
         }
-        else {(Value::error(), vec![])}
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
         writeln!(f, "while")?;
         print_ast_child(f, pre, &*self.cond, false, file)?;
         print_ast_child(f, pre, &*self.body, true, file)

--- a/cobalt-ast/src/ast/groups.rs
+++ b/cobalt-ast/src/ast/groups.rs
@@ -2,14 +2,20 @@ use crate::*;
 #[derive(Debug, Clone)]
 pub struct BlockAST {
     loc: SourceSpan,
-    pub vals: Vec<Box<dyn AST>>
+    pub vals: Vec<Box<dyn AST>>,
 }
 impl BlockAST {
-    pub fn new(loc: SourceSpan, vals: Vec<Box<dyn AST>>) -> Self {BlockAST {loc, vals}}
+    pub fn new(loc: SourceSpan, vals: Vec<Box<dyn AST>>) -> Self {
+        BlockAST { loc, vals }
+    }
 }
 impl AST for BlockAST {
-    fn loc(&self) -> SourceSpan {self.loc}
-    fn nodes(&self) -> usize {self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn nodes(&self) -> usize {
+        self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         ctx.map_vars(|v| Box::new(VarMap::new(Some(v))));
         // ctx.lex_scope.incr();
@@ -18,23 +24,56 @@ impl AST for BlockAST {
         let start = cfg::Location::current(ctx);
         self.vals.iter().for_each(|val| {
             ctx.to_drop.borrow_mut().push(Vec::new());
-            if out.name.is_none() {out.ins_dtor(ctx);}
+            if out.name.is_none() {
+                out.ins_dtor(ctx);
+            }
             out = val.codegen_errs(ctx, &mut errs);
-            ctx.to_drop.borrow_mut().pop().unwrap().into_iter().for_each(|v| v.ins_dtor(ctx));
+            ctx.to_drop
+                .borrow_mut()
+                .pop()
+                .unwrap()
+                .into_iter()
+                .for_each(|v| v.ins_dtor(ctx));
         });
         let end = cfg::Location::current(ctx);
         if let (Some(start), Some(end)) = (start, end) {
-            if let Some(loc) = self.vals.last().map(|a| a.loc()) {ops::mark_move(&out, end, ctx, loc);}
+            if let Some(loc) = self.vals.last().map(|a| a.loc()) {
+                ops::mark_move(&out, end, ctx, loc);
+            }
             let graph = cfg::Cfg::new(start, end, ctx);
             graph.insert_dtors(ctx, true);
             unsafe {
-                let seen = errs.iter()
-                    .filter_map(|err| if let CobaltError::DoubleMove {loc, name, ..} = err {Some((*loc, &*(name.as_str() as *const str)))} else {None})
+                let seen = errs
+                    .iter()
+                    .filter_map(|err| {
+                        if let CobaltError::DoubleMove { loc, name, .. } = err {
+                            Some((*loc, &*(name.as_str() as *const str)))
+                        } else {
+                            None
+                        }
+                    })
                     .collect::<std::collections::HashSet<_>>();
-                errs.extend(graph.validate()
-                    .into_iter()
-                    .filter(|cfg::DoubleMove {name, loc, ..}| !seen.contains(&(*loc, name.as_str())))
-                    .map(|cfg::DoubleMove {name, loc, prev, guaranteed}| CobaltError::DoubleMove {loc, prev, name, guaranteed}));
+                errs.extend(
+                    graph
+                        .validate()
+                        .into_iter()
+                        .filter(|cfg::DoubleMove { name, loc, .. }| {
+                            !seen.contains(&(*loc, name.as_str()))
+                        })
+                        .map(
+                            |cfg::DoubleMove {
+                                 name,
+                                 loc,
+                                 prev,
+                                 guaranteed,
+                             }| CobaltError::DoubleMove {
+                                loc,
+                                prev,
+                                name,
+                                guaranteed,
+                            },
+                        ),
+                );
             }
         }
         // let mut b = ctx.moves.borrow_mut();
@@ -43,7 +82,12 @@ impl AST for BlockAST {
         ctx.map_vars(|v| v.parent.unwrap());
         (out, errs)
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
         writeln!(f, "block")?;
         let mut count = self.vals.len();
         for val in self.vals.iter() {
@@ -55,28 +99,44 @@ impl AST for BlockAST {
 }
 #[derive(Debug, Clone)]
 pub struct GroupAST {
-    pub vals: Vec<Box<dyn AST>>
+    pub vals: Vec<Box<dyn AST>>,
 }
 impl GroupAST {
     pub fn new(vals: Vec<Box<dyn AST>>) -> Self {
         assert!(!vals.is_empty());
-        GroupAST {vals}
+        GroupAST { vals }
     }
 }
 impl AST for GroupAST {
-    fn loc(&self) -> SourceSpan {merge_spans(self.vals[0].loc(), self.vals.last().unwrap().loc())}
-    fn nodes(&self) -> usize {self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1}
+    fn loc(&self) -> SourceSpan {
+        merge_spans(self.vals[0].loc(), self.vals.last().unwrap().loc())
+    }
+    fn nodes(&self) -> usize {
+        self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let mut out = Value::null();
         let mut errs = vec![];
         self.vals.iter().for_each(|val| {
-            if out.name.is_none() {out.ins_dtor(ctx);}
+            if out.name.is_none() {
+                out.ins_dtor(ctx);
+            }
             out = val.codegen_errs(ctx, &mut errs);
         });
-        if let (Some(loc), Some(end)) = (self.vals.last().map(|a| a.loc()), cfg::Location::current(ctx)) {ops::mark_move(&out, end, ctx, loc);}
+        if let (Some(loc), Some(end)) = (
+            self.vals.last().map(|a| a.loc()),
+            cfg::Location::current(ctx),
+        ) {
+            ops::mark_move(&out, end, ctx, loc);
+        }
         (out, errs)
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
         writeln!(f, "group")?;
         let mut count = self.vals.len();
         for val in self.vals.iter() {
@@ -89,27 +149,44 @@ impl AST for GroupAST {
 #[derive(Debug, Clone, Default)]
 pub struct TopLevelAST {
     pub file: Option<CobaltFile>,
-    pub vals: Vec<Box<dyn AST>>
+    pub vals: Vec<Box<dyn AST>>,
 }
 impl AST for TopLevelAST {
-    fn loc(&self) -> SourceSpan {unreachable_span()}
-    fn nodes(&self) -> usize {self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1}
+    fn loc(&self) -> SourceSpan {
+        unreachable_span()
+    }
+    fn nodes(&self) -> usize {
+        self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         if ctx.flags.prepass {
             self.vals.iter().for_each(|val| val.varfwd_prepass(ctx));
             let mut again = true;
             while again {
                 again = false;
-                self.vals.iter().for_each(|val| val.constinit_prepass(ctx, &mut again));
+                self.vals
+                    .iter()
+                    .for_each(|val| val.constinit_prepass(ctx, &mut again));
             }
             self.vals.iter().for_each(|val| val.fwddef_prepass(ctx));
         }
         let mut errs = vec![];
-        self.vals.iter().for_each(|val| std::mem::drop(val.codegen_errs(ctx, &mut errs)));
+        self.vals
+            .iter()
+            .for_each(|val| std::mem::drop(val.codegen_errs(ctx, &mut errs)));
         (Value::null(), errs)
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
-        if let Some(ref file) = self.file {writeln!(f, "{}", file.name())?} else {f.write_str("<file not set>\n")?};
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
+        if let Some(ref file) = self.file {
+            writeln!(f, "{}", file.name())?
+        } else {
+            f.write_str("<file not set>\n")?
+        };
         let mut count = self.vals.len();
         for val in self.vals.iter() {
             print_ast_child(f, pre, &**val, count == 1, file)?;
@@ -119,13 +196,17 @@ impl AST for TopLevelAST {
     }
 }
 impl TopLevelAST {
-    pub fn new(vals: Vec<Box<dyn AST>>) -> Self {TopLevelAST {vals, file: None}}
+    pub fn new(vals: Vec<Box<dyn AST>>) -> Self {
+        TopLevelAST { vals, file: None }
+    }
     pub fn run_passes(&self, ctx: &CompCtx) {
         self.vals.iter().for_each(|val| val.varfwd_prepass(ctx));
         let mut again = true;
         while again {
             again = false;
-            self.vals.iter().for_each(|val| val.constinit_prepass(ctx, &mut again));
+            self.vals
+                .iter()
+                .for_each(|val| val.constinit_prepass(ctx, &mut again));
         }
         self.vals.iter().for_each(|val| val.fwddef_prepass(ctx));
     }

--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -1,114 +1,297 @@
 use crate::*;
-use inkwell::values::BasicValueEnum::*;
-use inkwell::types::BasicType;
 use bstr::ByteSlice;
+use inkwell::types::BasicType;
+use inkwell::values::BasicValueEnum::*;
 #[derive(Debug, Clone)]
 pub struct IntLiteralAST {
     loc: SourceSpan,
     pub val: i128,
-    pub suffix: Option<(String, SourceSpan)>
+    pub suffix: Option<(String, SourceSpan)>,
 }
 impl IntLiteralAST {
-    pub fn new(loc: SourceSpan, val: i128, suffix: Option<(String, SourceSpan)>) -> Self {IntLiteralAST {loc, val, suffix}}
+    pub fn new(loc: SourceSpan, val: i128, suffix: Option<(String, SourceSpan)>) -> Self {
+        IntLiteralAST { loc, val, suffix }
+    }
 }
 impl AST for IntLiteralAST {
-    fn loc(&self) -> SourceSpan {self.loc}
-    fn is_const(&self) -> bool {true}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn is_const(&self) -> bool {
+        true
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         match self.suffix.as_ref().map(|(x, y)| (x.as_str(), y)) {
-            None | Some(("", _)) => (Value::metaval(InterData::Int(self.val), Type::IntLiteral), vec![]),
-            Some(("isize", _)) => (Value::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(64, false)), vec![]),
+            None | Some(("", _)) => (
+                Value::metaval(InterData::Int(self.val), Type::IntLiteral),
+                vec![],
+            ),
+            Some(("isize", _)) => (
+                Value::interpreted(
+                    IntValue(ctx.context.i64_type().const_int(self.val as u64, false)),
+                    InterData::Int(self.val),
+                    Type::Int(64, false),
+                ),
+                vec![],
+            ),
             Some((x, _)) if x.as_bytes()[0] == 0x69 && x[1..].chars().all(char::is_numeric) => {
                 let size: u16 = x[1..].parse().unwrap_or(0);
-                (Value::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(size, false)), vec![])
+                (
+                    Value::interpreted(
+                        IntValue(
+                            ctx.context
+                                .custom_width_int_type(size as u32)
+                                .const_int(self.val as u64, false),
+                        ),
+                        InterData::Int(self.val),
+                        Type::Int(size, false),
+                    ),
+                    vec![],
+                )
             }
-            Some(("usize", _)) => (Value::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(64, true)), vec![]),
+            Some(("usize", _)) => (
+                Value::interpreted(
+                    IntValue(ctx.context.i64_type().const_int(self.val as u64, false)),
+                    InterData::Int(self.val),
+                    Type::Int(64, true),
+                ),
+                vec![],
+            ),
             Some((x, _)) if x.as_bytes()[0] == 0x75 && x[1..].chars().all(char::is_numeric) => {
                 let size: u16 = x[1..].parse().unwrap_or(0);
-                (Value::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val), Type::Int(size, true)), vec![])
+                (
+                    Value::interpreted(
+                        IntValue(
+                            ctx.context
+                                .custom_width_int_type(size as u32)
+                                .const_int(self.val as u64, false),
+                        ),
+                        InterData::Int(self.val),
+                        Type::Int(size, true),
+                    ),
+                    vec![],
+                )
             }
-            Some((x, loc)) => (Value::error(), vec![CobaltError::UnknownLiteralSuffix {loc: *loc, lit: "integer", suf: x.to_string()}])
+            Some((x, loc)) => (
+                Value::error(),
+                vec![CobaltError::UnknownLiteralSuffix {
+                    loc: *loc,
+                    lit: "integer",
+                    suf: x.to_string(),
+                }],
+            ),
         }
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, _pre: &mut TreePrefix, _file: Option<CobaltFile>) -> std::fmt::Result {
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        _pre: &mut TreePrefix,
+        _file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
         write!(f, "int: {}", self.val)?;
-        if let Some((ref s, _)) = self.suffix {writeln!(f, ", suffix: {}", s)}
-        else {writeln!(f)}
+        if let Some((ref s, _)) = self.suffix {
+            writeln!(f, ", suffix: {}", s)
+        } else {
+            writeln!(f)
+        }
     }
 }
 #[derive(Debug, Clone)]
 pub struct FloatLiteralAST {
     loc: SourceSpan,
     pub val: f64,
-    pub suffix: Option<(String, SourceSpan)>
+    pub suffix: Option<(String, SourceSpan)>,
 }
 impl FloatLiteralAST {
-    pub fn new(loc: SourceSpan, val: f64, suffix: Option<(String, SourceSpan)>) -> Self {FloatLiteralAST {loc, val, suffix}}
+    pub fn new(loc: SourceSpan, val: f64, suffix: Option<(String, SourceSpan)>) -> Self {
+        FloatLiteralAST { loc, val, suffix }
+    }
 }
 impl AST for FloatLiteralAST {
-    fn loc(&self) -> SourceSpan {self.loc}
-    fn is_const(&self) -> bool {true}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn is_const(&self) -> bool {
+        true
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         match self.suffix.as_ref().map(|(x, y)| (x.as_str(), y)) {
-            None | Some(("f64", _)) => (Value::interpreted(FloatValue(ctx.context.f64_type().const_float(self.val)), InterData::Float(self.val), Type::Float64), vec![]),
-            Some(("f16", _)) => (Value::interpreted(FloatValue(ctx.context.f16_type().const_float(self.val)), InterData::Float(self.val), Type::Float16), vec![]),
-            Some(("f32", _)) => (Value::interpreted(FloatValue(ctx.context.f32_type().const_float(self.val)), InterData::Float(self.val), Type::Float32), vec![]),
-            Some(("f128", _)) => (Value::interpreted(FloatValue(ctx.context.f128_type().const_float(self.val)), InterData::Float(self.val), Type::Float128), vec![]),
-            Some((x, loc)) => (Value::error(), vec![CobaltError::UnknownLiteralSuffix {loc: *loc, lit: "floating-point", suf: x.to_string()}])
+            None | Some(("f64", _)) => (
+                Value::interpreted(
+                    FloatValue(ctx.context.f64_type().const_float(self.val)),
+                    InterData::Float(self.val),
+                    Type::Float64,
+                ),
+                vec![],
+            ),
+            Some(("f16", _)) => (
+                Value::interpreted(
+                    FloatValue(ctx.context.f16_type().const_float(self.val)),
+                    InterData::Float(self.val),
+                    Type::Float16,
+                ),
+                vec![],
+            ),
+            Some(("f32", _)) => (
+                Value::interpreted(
+                    FloatValue(ctx.context.f32_type().const_float(self.val)),
+                    InterData::Float(self.val),
+                    Type::Float32,
+                ),
+                vec![],
+            ),
+            Some(("f128", _)) => (
+                Value::interpreted(
+                    FloatValue(ctx.context.f128_type().const_float(self.val)),
+                    InterData::Float(self.val),
+                    Type::Float128,
+                ),
+                vec![],
+            ),
+            Some((x, loc)) => (
+                Value::error(),
+                vec![CobaltError::UnknownLiteralSuffix {
+                    loc: *loc,
+                    lit: "floating-point",
+                    suf: x.to_string(),
+                }],
+            ),
         }
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, _pre: &mut TreePrefix, _file: Option<CobaltFile>) -> std::fmt::Result {
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        _pre: &mut TreePrefix,
+        _file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
         write!(f, "float: {}", self.val)?;
-        if let Some((ref s, _)) = self.suffix {writeln!(f, ", suffix: {}", s)}
-        else {writeln!(f)}
+        if let Some((ref s, _)) = self.suffix {
+            writeln!(f, ", suffix: {}", s)
+        } else {
+            writeln!(f)
+        }
     }
 }
 #[derive(Debug, Clone)]
 pub struct CharLiteralAST {
     loc: SourceSpan,
     pub val: u32,
-    pub suffix: Option<(String, SourceSpan)>
+    pub suffix: Option<(String, SourceSpan)>,
 }
 impl CharLiteralAST {
-    pub fn new(loc: SourceSpan, val: u32, suffix: Option<(String, SourceSpan)>) -> Self {CharLiteralAST {loc, val, suffix}}
+    pub fn new(loc: SourceSpan, val: u32, suffix: Option<(String, SourceSpan)>) -> Self {
+        CharLiteralAST { loc, val, suffix }
+    }
 }
 impl AST for CharLiteralAST {
-    fn loc(&self) -> SourceSpan {self.loc}
-    fn is_const(&self) -> bool {true}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn is_const(&self) -> bool {
+        true
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         match self.suffix.as_ref().map(|(x, y)| (x.as_str(), y)) {
-            None | Some(("", _)) => (Value::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(32, true)), vec![]),
-            Some(("isize", _)) => (Value::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(64, false)), vec![]),
+            None | Some(("", _)) => (
+                Value::interpreted(
+                    IntValue(ctx.context.i64_type().const_int(self.val as u64, false)),
+                    InterData::Int(self.val as i128),
+                    Type::Int(32, true),
+                ),
+                vec![],
+            ),
+            Some(("isize", _)) => (
+                Value::interpreted(
+                    IntValue(ctx.context.i64_type().const_int(self.val as u64, false)),
+                    InterData::Int(self.val as i128),
+                    Type::Int(64, false),
+                ),
+                vec![],
+            ),
             Some((x, _)) if x.as_bytes()[0] == 0x69 && x[1..].chars().all(char::is_numeric) => {
                 let size: u16 = x[1..].parse().unwrap_or(0);
-                (Value::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(size, false)), vec![])
+                (
+                    Value::interpreted(
+                        IntValue(
+                            ctx.context
+                                .custom_width_int_type(size as u32)
+                                .const_int(self.val as u64, false),
+                        ),
+                        InterData::Int(self.val as i128),
+                        Type::Int(size, false),
+                    ),
+                    vec![],
+                )
             }
-            Some(("usize", _)) => (Value::interpreted(IntValue(ctx.context.i64_type().const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(64, true)), vec![]),
+            Some(("usize", _)) => (
+                Value::interpreted(
+                    IntValue(ctx.context.i64_type().const_int(self.val as u64, false)),
+                    InterData::Int(self.val as i128),
+                    Type::Int(64, true),
+                ),
+                vec![],
+            ),
             Some((x, _)) if x.as_bytes()[0] == 0x75 && x[1..].chars().all(char::is_numeric) => {
                 let size: u16 = x[1..].parse().unwrap_or(0);
-                (Value::interpreted(IntValue(ctx.context.custom_width_int_type(size as u32).const_int(self.val as u64, false)), InterData::Int(self.val as i128), Type::Int(size, true)), vec![])
+                (
+                    Value::interpreted(
+                        IntValue(
+                            ctx.context
+                                .custom_width_int_type(size as u32)
+                                .const_int(self.val as u64, false),
+                        ),
+                        InterData::Int(self.val as i128),
+                        Type::Int(size, true),
+                    ),
+                    vec![],
+                )
             }
-            Some((x, loc)) => (Value::error(), vec![CobaltError::UnknownLiteralSuffix {loc: *loc, lit: "character", suf: x.to_string()}])
+            Some((x, loc)) => (
+                Value::error(),
+                vec![CobaltError::UnknownLiteralSuffix {
+                    loc: *loc,
+                    lit: "character",
+                    suf: x.to_string(),
+                }],
+            ),
         }
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, _pre: &mut TreePrefix, _file: Option<CobaltFile>) -> std::fmt::Result {
-        if let Some(c) = char::from_u32(self.val) {write!(f, "char: {c:?}")} else {write!(f, "char: \\u{{{:0>X}}}", self.val)}?;
-        if let Some((ref s, _)) = self.suffix {writeln!(f, ", suffix: {}", s)}
-        else {writeln!(f)}
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        _pre: &mut TreePrefix,
+        _file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
+        if let Some(c) = char::from_u32(self.val) {
+            write!(f, "char: {c:?}")
+        } else {
+            write!(f, "char: \\u{{{:0>X}}}", self.val)
+        }?;
+        if let Some((ref s, _)) = self.suffix {
+            writeln!(f, ", suffix: {}", s)
+        } else {
+            writeln!(f)
+        }
     }
 }
 #[derive(Debug, Clone)]
 pub struct StringLiteralAST {
     loc: SourceSpan,
     pub val: Vec<u8>,
-    pub suffix: Option<(String, SourceSpan)>
+    pub suffix: Option<(String, SourceSpan)>,
 }
 impl StringLiteralAST {
-    pub fn new(loc: SourceSpan, val: Vec<u8>, suffix: Option<(String, SourceSpan)>) -> Self {StringLiteralAST {loc, val, suffix}}
+    pub fn new(loc: SourceSpan, val: Vec<u8>, suffix: Option<(String, SourceSpan)>) -> Self {
+        StringLiteralAST { loc, val, suffix }
+    }
 }
 impl AST for StringLiteralAST {
-    fn loc(&self) -> SourceSpan {self.loc}
-    fn is_const(&self) -> bool {true}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn is_const(&self) -> bool {
+        true
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         match self.suffix.as_ref().map(|(s, l)| (s.as_str(), *l)) {
             None | Some(("c" | "C", _)) => {
@@ -117,19 +300,47 @@ impl AST for StringLiteralAST {
                 gv.set_initializer(&cs);
                 gv.set_constant(true);
                 gv.set_linkage(inkwell::module::Linkage::Private);
-                (Value::interpreted(
-                    gv.as_pointer_value().const_cast(ctx.context.i8_type().ptr_type(Default::default())).into(),
-                    InterData::Array(self.val.iter().map(|&c| InterData::Int(c as i128)).collect()),
-                    Type::Reference(Box::new(Type::Array(Box::new(Type::Int(8, true)), Some(self.val.len() as u32 + self.suffix.is_some() as u32))))
-                ), vec![])
+                (
+                    Value::interpreted(
+                        gv.as_pointer_value()
+                            .const_cast(ctx.context.i8_type().ptr_type(Default::default()))
+                            .into(),
+                        InterData::Array(
+                            self.val
+                                .iter()
+                                .map(|&c| InterData::Int(c as i128))
+                                .collect(),
+                        ),
+                        Type::Reference(Box::new(Type::Array(
+                            Box::new(Type::Int(8, true)),
+                            Some(self.val.len() as u32 + self.suffix.is_some() as u32),
+                        ))),
+                    ),
+                    vec![],
+                )
             }
-            Some((x, loc)) => (Value::error(), vec![CobaltError::UnknownLiteralSuffix {loc, lit: "string", suf: x.to_string()}])
+            Some((x, loc)) => (
+                Value::error(),
+                vec![CobaltError::UnknownLiteralSuffix {
+                    loc,
+                    lit: "string",
+                    suf: x.to_string(),
+                }],
+            ),
         }
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, _pre: &mut TreePrefix, _file: Option<CobaltFile>) -> std::fmt::Result {
-        write!(f, "string: {:?}",self.val.as_bstr())?;
-        if let Some((ref s, _)) = self.suffix {writeln!(f, ", suffix: {}", s)}
-        else {writeln!(f)}
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        _pre: &mut TreePrefix,
+        _file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
+        write!(f, "string: {:?}", self.val.as_bstr())?;
+        if let Some((ref s, _)) = self.suffix {
+            writeln!(f, ", suffix: {}", s)
+        } else {
+            writeln!(f)
+        }
     }
 }
 #[derive(Debug, Clone)]
@@ -139,11 +350,17 @@ pub struct ArrayLiteralAST {
     pub vals: Vec<Box<dyn AST>>,
 }
 impl ArrayLiteralAST {
-    pub fn new(start: SourceSpan, end: SourceSpan, vals: Vec<Box<dyn AST>>) -> Self {ArrayLiteralAST {start, end, vals}}
+    pub fn new(start: SourceSpan, end: SourceSpan, vals: Vec<Box<dyn AST>>) -> Self {
+        ArrayLiteralAST { start, end, vals }
+    }
 }
 impl AST for ArrayLiteralAST {
-    fn loc(&self) -> SourceSpan {merge_spans(self.start, self.end)}
-    fn nodes(&self) -> usize {self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1}
+    fn loc(&self) -> SourceSpan {
+        merge_spans(self.start, self.end)
+    }
+    fn nodes(&self) -> usize {
+        self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let mut elems = vec![];
         let mut ty = Type::Null;
@@ -158,39 +375,70 @@ impl AST for ArrayLiteralAST {
                 first = false;
                 elem_loc = val.loc();
                 ty = dt;
-            }
-            else if ty != dt {
+            } else if ty != dt {
                 if let Some(t) = ops::common(&ty, &dt, ctx) {
                     ty = t;
                     elem_loc = val.loc();
-                }
-                else {
+                } else {
                     errs.push(CobaltError::ArrayElementsDontMatch {
                         loc: val.loc(),
                         prev: elem_loc,
                         current: ty.to_string(),
-                        new: dt.to_string()
+                        new: dt.to_string(),
                     });
                 }
             }
             elems.push(v);
         }
         if elems.len() > u32::MAX as usize {
-            errs.push(CobaltError::ArrayTooLong {loc: self.vals[u32::MAX as usize + 1].loc(), len: elems.len()});
+            errs.push(CobaltError::ArrayTooLong {
+                loc: self.vals[u32::MAX as usize + 1].loc(),
+                len: elems.len(),
+            });
             elems.truncate(u32::MAX as usize);
         }
-        let elems = elems.into_iter().enumerate().filter_map(|(n, v)| ops::impl_convert(self.vals[n].loc(), (v, None), (ty.clone(), None), ctx).map_err(|e| errs.push(e)).ok()).collect::<Vec<_>>();
+        let elems = elems
+            .into_iter()
+            .enumerate()
+            .filter_map(|(n, v)| {
+                ops::impl_convert(self.vals[n].loc(), (v, None), (ty.clone(), None), ctx)
+                    .map_err(|e| errs.push(e))
+                    .ok()
+            })
+            .collect::<Vec<_>>();
         let len = elems.len();
-        (Value::new(
-            if let (Some(llt), false) = (ty.llvm_type(ctx), ctx.is_const.get()) {
-                let arr_ty = llt.array_type(elems.len() as u32);
-                elems.iter().enumerate().try_fold(arr_ty.get_undef(), |val, (n, v)| ctx.builder.build_insert_value(val, v.comp_val?, n as _, "").map(|v| v.into_array_value())).map(Into::into)
-            } else {None},
-            elems.into_iter().map(|v| v.inter_val).collect::<Option<_>>().map(InterData::Array),
-            Type::Array(Box::new(ty), Some(len as u32))
-        ), errs)
+        (
+            Value::new(
+                if let (Some(llt), false) = (ty.llvm_type(ctx), ctx.is_const.get()) {
+                    let arr_ty = llt.array_type(elems.len() as u32);
+                    elems
+                        .iter()
+                        .enumerate()
+                        .try_fold(arr_ty.get_undef(), |val, (n, v)| {
+                            ctx.builder
+                                .build_insert_value(val, v.comp_val?, n as _, "")
+                                .map(|v| v.into_array_value())
+                        })
+                        .map(Into::into)
+                } else {
+                    None
+                },
+                elems
+                    .into_iter()
+                    .map(|v| v.inter_val)
+                    .collect::<Option<_>>()
+                    .map(InterData::Array),
+                Type::Array(Box::new(ty), Some(len as u32)),
+            ),
+            errs,
+        )
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
         writeln!(f, "array")?;
         let mut len = self.vals.len();
         for val in self.vals.iter() {
@@ -202,12 +450,12 @@ impl AST for ArrayLiteralAST {
 }
 #[derive(Debug, Clone)]
 pub struct TupleLiteralAST {
-    pub vals: Vec<Box<dyn AST>>
+    pub vals: Vec<Box<dyn AST>>,
 }
 impl TupleLiteralAST {
     pub fn new(vals: Vec<Box<dyn AST>>) -> Self {
         assert_ne!(vals.len(), 0);
-        TupleLiteralAST {vals}
+        TupleLiteralAST { vals }
     }
 }
 impl AST for TupleLiteralAST {
@@ -216,25 +464,57 @@ impl AST for TupleLiteralAST {
         let end = self.vals.last().unwrap().loc();
         merge_spans(start, end)
     }
-    fn nodes(&self) -> usize {self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1}
+    fn nodes(&self) -> usize {
+        self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let mut errs = vec![];
-        let (comps, (inters, types)): (Vec<_>, (Vec<_>, Vec<_>)) = self.vals.iter().map(|x| {
-            let mut v = x.codegen_errs(ctx, &mut errs);
-            let decayed = ops::decay(v.data_type.clone());
-            v = ops::impl_convert(unreachable_span(), (v, None), (decayed, None), ctx).unwrap();
-            v
-        }).map(|Value {comp_val, inter_val, data_type, ..}| (comp_val, (inter_val, data_type))).unzip();
+        let (comps, (inters, types)): (Vec<_>, (Vec<_>, Vec<_>)) = self
+            .vals
+            .iter()
+            .map(|x| {
+                let mut v = x.codegen_errs(ctx, &mut errs);
+                let decayed = ops::decay(v.data_type.clone());
+                v = ops::impl_convert(unreachable_span(), (v, None), (decayed, None), ctx).unwrap();
+                v
+            })
+            .map(
+                |Value {
+                     comp_val,
+                     inter_val,
+                     data_type,
+                     ..
+                 }| (comp_val, (inter_val, data_type)),
+            )
+            .unzip();
         let mut val = Value::null();
         val.data_type = Type::Tuple(types);
         if comps.iter().all(Option::is_some) {
             let llt = val.data_type.llvm_type(ctx).unwrap().into_struct_type();
-            val.comp_val = comps.into_iter().map(Option::unwrap).enumerate().try_fold(llt.get_undef(), |sv, (n, v)| ctx.builder.build_insert_value(sv, v, n as u32, "").map(|x| x.into_struct_value())).map(From::from);
+            val.comp_val = comps
+                .into_iter()
+                .map(Option::unwrap)
+                .enumerate()
+                .try_fold(llt.get_undef(), |sv, (n, v)| {
+                    ctx.builder
+                        .build_insert_value(sv, v, n as u32, "")
+                        .map(|x| x.into_struct_value())
+                })
+                .map(From::from);
         };
-        if inters.iter().all(Option::is_some) {val.inter_val = Some(InterData::Array(inters.into_iter().map(Option::unwrap).collect()));};
+        if inters.iter().all(Option::is_some) {
+            val.inter_val = Some(InterData::Array(
+                inters.into_iter().map(Option::unwrap).collect(),
+            ));
+        };
         (val, errs)
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
         writeln!(f, "tuple")?;
         let mut len = self.vals.len();
         for val in self.vals.iter() {

--- a/cobalt-ast/src/ast/misc.rs
+++ b/cobalt-ast/src/ast/misc.rs
@@ -5,26 +5,66 @@ use crate::*;
 pub struct CastAST {
     loc: SourceSpan,
     pub val: Box<dyn AST>,
-    pub target: Box<dyn AST>
+    pub target: Box<dyn AST>,
 }
 impl CastAST {
-    pub fn new(loc: SourceSpan, val: Box<dyn AST>, target: Box<dyn AST>) -> Self {CastAST {loc, val, target}}
+    pub fn new(loc: SourceSpan, val: Box<dyn AST>, target: Box<dyn AST>) -> Self {
+        CastAST { loc, val, target }
+    }
 }
 impl AST for CastAST {
-    fn loc(&self) -> SourceSpan {merge_spans(self.val.loc(), self.target.loc())}
-    fn nodes(&self) -> usize {self.val.nodes() + self.target.nodes() + 1}
+    fn loc(&self) -> SourceSpan {
+        merge_spans(self.val.loc(), self.target.loc())
+    }
+    fn nodes(&self) -> usize {
+        self.val.nodes() + self.target.nodes() + 1
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let (val, mut errs) = self.val.codegen(ctx);
-        if val.data_type == Type::Error {return (Value::error(), errs)}
+        if val.data_type == Type::Error {
+            return (Value::error(), errs);
+        }
         let oic = ctx.is_const.replace(true);
-        let t = ops::impl_convert(self.target.loc(), (self.target.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+        let t = ops::impl_convert(
+            self.target.loc(),
+            (self.target.codegen_errs(ctx, &mut errs), None),
+            (Type::TypeData, None),
+            ctx,
+        )
+        .map_or_else(
+            |e| {
+                errs.push(e);
+                Type::Error
+            },
+            |v| {
+                if let Some(InterData::Type(t)) = v.inter_val {
+                    *t
+                } else {
+                    Type::Error
+                }
+            },
+        );
         ctx.is_const.set(oic);
-        (ops::expl_convert(self.loc, (val, Some(self.val.loc())), (t, Some(self.target.loc())), ctx).unwrap_or_else(|e| {
-            errs.push(e);
-            Value::error()
-        }), errs)
+        (
+            ops::expl_convert(
+                self.loc,
+                (val, Some(self.val.loc())),
+                (t, Some(self.target.loc())),
+                ctx,
+            )
+            .unwrap_or_else(|e| {
+                errs.push(e);
+                Value::error()
+            }),
+            errs,
+        )
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
         writeln!(f, "cast")?;
         print_ast_child(f, pre, &*self.val, false, file)?;
         print_ast_child(f, pre, &*self.target, true, file)
@@ -34,19 +74,45 @@ impl AST for CastAST {
 pub struct BitCastAST {
     loc: SourceSpan,
     pub val: Box<dyn AST>,
-    pub target: Box<dyn AST>
+    pub target: Box<dyn AST>,
 }
 impl BitCastAST {
-    pub fn new(loc: SourceSpan, val: Box<dyn AST>, target: Box<dyn AST>) -> Self {BitCastAST {loc, val, target}}
+    pub fn new(loc: SourceSpan, val: Box<dyn AST>, target: Box<dyn AST>) -> Self {
+        BitCastAST { loc, val, target }
+    }
 }
 impl AST for BitCastAST {
-    fn loc(&self) -> SourceSpan {merge_spans(self.val.loc(), self.target.loc())}
-    fn nodes(&self) -> usize {self.val.nodes() + self.target.nodes() + 1}
+    fn loc(&self) -> SourceSpan {
+        merge_spans(self.val.loc(), self.target.loc())
+    }
+    fn nodes(&self) -> usize {
+        self.val.nodes() + self.target.nodes() + 1
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let (mut val, mut errs) = self.val.codegen(ctx);
-        if val.data_type == Type::Error {return (Value::error(), errs)}
+        if val.data_type == Type::Error {
+            return (Value::error(), errs);
+        }
         let oic = ctx.is_const.replace(true);
-        let t = ops::impl_convert(self.target.loc(), (self.target.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+        let t = ops::impl_convert(
+            self.target.loc(),
+            (self.target.codegen_errs(ctx, &mut errs), None),
+            (Type::TypeData, None),
+            ctx,
+        )
+        .map_or_else(
+            |e| {
+                errs.push(e);
+                Type::Error
+            },
+            |v| {
+                if let Some(InterData::Type(t)) = v.inter_val {
+                    *t
+                } else {
+                    Type::Error
+                }
+            },
+        );
         ctx.is_const.set(oic);
         let decayed = ops::decay(val.data_type.clone());
         val = ops::impl_convert(unreachable_span(), (val, None), (decayed, None), ctx).unwrap();
@@ -60,9 +126,9 @@ impl AST for BitCastAST {
                         from_loc: self.val.loc(),
                         to_ty: t.to_string(),
                         to_sz: d,
-                        to_loc: self.target.loc()
+                        to_loc: self.target.loc(),
                     });
-                    return (Value::error(), errs)
+                    return (Value::error(), errs);
                 }
             }
             _ => {
@@ -71,21 +137,34 @@ impl AST for BitCastAST {
                     from_ty: val.data_type.to_string(),
                     from_loc: self.val.loc(),
                     to_ty: t.to_string(),
-                    to_loc: self.target.loc()
+                    to_loc: self.target.loc(),
                 });
-                return (Value::error(), errs)
+                return (Value::error(), errs);
             }
         }
         if let (Some(llt), Some(ctval)) = (t.llvm_type(ctx), val.comp_val) {
             let bc = ctx.builder.build_bitcast(ctval, llt, "");
-            ops::mark_move(&val, bc.as_instruction_value().map(From::from).unwrap_or(cfg::Location::current(ctx).unwrap()), ctx, self.loc());
+            ops::mark_move(
+                &val,
+                bc.as_instruction_value()
+                    .map(From::from)
+                    .unwrap_or(cfg::Location::current(ctx).unwrap()),
+                ctx,
+                self.loc(),
+            );
             val.comp_val = Some(bc);
             val.data_type = t;
             (val, errs)
+        } else {
+            (Value::error(), errs)
         }
-        else {(Value::error(), errs)}
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
         writeln!(f, "bitcast")?;
         print_ast_child(f, pre, &*self.val, false, file)?;
         print_ast_child(f, pre, &*self.target, true, file)
@@ -93,64 +172,133 @@ impl AST for BitCastAST {
 }
 #[derive(Debug, Clone)]
 pub struct NullAST {
-    loc: SourceSpan
+    loc: SourceSpan,
 }
 impl NullAST {
-    pub fn new(loc: SourceSpan) -> Self {NullAST {loc}}
+    pub fn new(loc: SourceSpan) -> Self {
+        NullAST { loc }
+    }
 }
 impl AST for NullAST {
-    fn loc(&self) -> SourceSpan {self.loc}
-    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {(Value::null(), vec![])}
-    fn print_impl(&self, f: &mut std::fmt::Formatter, _pre: &mut TreePrefix, _file: Option<CobaltFile>) -> std::fmt::Result {writeln!(f, "null")}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+        (Value::null(), vec![])
+    }
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        _pre: &mut TreePrefix,
+        _file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
+        writeln!(f, "null")
+    }
 }
 #[derive(Debug, Clone)]
 pub struct ErrorAST {
-    loc: SourceSpan
+    loc: SourceSpan,
 }
 impl ErrorAST {
-    pub fn new(loc: SourceSpan) -> Self {ErrorAST {loc}}
+    pub fn new(loc: SourceSpan) -> Self {
+        ErrorAST { loc }
+    }
 }
 impl AST for ErrorAST {
-    fn loc(&self) -> SourceSpan {self.loc}
-    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {(Value::error(), vec![])}
-    fn print_impl(&self, f: &mut std::fmt::Formatter, _pre: &mut TreePrefix, _file: Option<CobaltFile>) -> std::fmt::Result {writeln!(f, "error")}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+        (Value::error(), vec![])
+    }
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        _pre: &mut TreePrefix,
+        _file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
+        writeln!(f, "error")
+    }
 }
 #[derive(Debug, Clone)]
 pub struct ErrorTypeAST {
-    loc: SourceSpan
+    loc: SourceSpan,
 }
 impl ErrorTypeAST {
-    pub fn new(loc: SourceSpan) -> Self {ErrorTypeAST {loc}}
+    pub fn new(loc: SourceSpan) -> Self {
+        ErrorTypeAST { loc }
+    }
 }
 impl AST for ErrorTypeAST {
-    fn loc(&self) -> SourceSpan {self.loc}
-    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {(Value::make_type(Type::Error), vec![])}
-    fn print_impl(&self, f: &mut std::fmt::Formatter, _pre: &mut TreePrefix, _file: Option<CobaltFile>) -> std::fmt::Result {writeln!(f, "error type")}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+        (Value::make_type(Type::Error), vec![])
+    }
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        _pre: &mut TreePrefix,
+        _file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
+        writeln!(f, "error type")
+    }
 }
 #[derive(Debug, Clone)]
 pub struct TypeLiteralAST {
-    loc: SourceSpan
+    loc: SourceSpan,
 }
 impl TypeLiteralAST {
-    pub fn new(loc: SourceSpan) -> Self {TypeLiteralAST {loc}}
+    pub fn new(loc: SourceSpan) -> Self {
+        TypeLiteralAST { loc }
+    }
 }
 impl AST for TypeLiteralAST {
-    fn loc(&self) -> SourceSpan {self.loc}
-    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {(Value::make_type(Type::TypeData), vec![])}
-    fn print_impl(&self, f: &mut std::fmt::Formatter, _pre: &mut TreePrefix, _file: Option<CobaltFile>) -> std::fmt::Result {writeln!(f, "type (literal)")}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+        (Value::make_type(Type::TypeData), vec![])
+    }
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        _pre: &mut TreePrefix,
+        _file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
+        writeln!(f, "type (literal)")
+    }
 }
 #[derive(Debug, Clone)]
 pub struct ParenAST {
     pub loc: SourceSpan,
-    pub base: Box<dyn AST>
+    pub base: Box<dyn AST>,
 }
 impl ParenAST {
-    pub fn new(loc: SourceSpan, base: Box<dyn AST>) -> Self {ParenAST {loc, base}}
+    pub fn new(loc: SourceSpan, base: Box<dyn AST>) -> Self {
+        ParenAST { loc, base }
+    }
 }
 impl AST for ParenAST {
-    fn loc(&self) -> SourceSpan {self.loc}
-    fn nodes(&self) -> usize {self.base.nodes() + 1}
-    fn is_const(&self) -> bool {self.base.is_const()}
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {self.base.codegen(ctx)}
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {self.base.print_impl(f, pre, file)}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn nodes(&self) -> usize {
+        self.base.nodes() + 1
+    }
+    fn is_const(&self) -> bool {
+        self.base.is_const()
+    }
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+        self.base.codegen(ctx)
+    }
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
+        self.base.print_impl(f, pre, file)
+    }
 }

--- a/cobalt-ast/src/ast/scope.rs
+++ b/cobalt-ast/src/ast/scope.rs
@@ -5,11 +5,15 @@ pub struct ModuleAST {
     loc: SourceSpan,
     pub name: DottedName,
     pub vals: Vec<Box<dyn AST>>,
-    pub annotations: Vec<(String, Option<String>, SourceSpan)>
+    pub annotations: Vec<(String, Option<String>, SourceSpan)>,
 }
 impl AST for ModuleAST {
-    fn loc(&self) -> SourceSpan {self.loc}
-    fn nodes(&self) -> usize {self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn nodes(&self) -> usize {
+        self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let mut errs = Vec::<CobaltError>::new();
         let mut target_match = 2u8;
@@ -20,104 +24,146 @@ impl AST for ModuleAST {
                 "target" => {
                     if let Some(arg) = arg {
                         let mut arg = arg.as_str();
-                        let negate = if arg.as_bytes().first() == Some(&0x21) {arg = &arg[1..]; true} else {false};
+                        let negate = if arg.as_bytes().first() == Some(&0x21) {
+                            arg = &arg[1..];
+                            true
+                        } else {
+                            false
+                        };
                         match Pattern::new(arg) {
-                            Ok(pat) => if target_match != 1 {target_match = u8::from(negate ^ pat.matches(&ctx.module.get_triple().as_str().to_string_lossy()))},
-                            Err(err) => errs.push(CobaltError::GlobPatternError {pos: err.pos, msg: err.msg.to_string(), loc})
+                            Ok(pat) => {
+                                if target_match != 1 {
+                                    target_match = u8::from(
+                                        negate
+                                            ^ pat.matches(
+                                                &ctx.module.get_triple().as_str().to_string_lossy(),
+                                            ),
+                                    )
+                                }
+                            }
+                            Err(err) => errs.push(CobaltError::GlobPatternError {
+                                pos: err.pos,
+                                msg: err.msg.to_string(),
+                                loc,
+                            }),
                         }
-                    }
-                    else {
+                    } else {
                         errs.push(CobaltError::InvalidAnnArgument {
                             name: "target",
                             found: arg.clone(),
                             expected: Some("target glob"),
-                            loc
+                            loc,
                         });
                     }
-                },
+                }
                 "export" => {
                     if let Some((_, prev)) = vis_spec {
                         errs.push(CobaltError::RedefAnnArgument {
                             name: "export",
-                            loc, prev
+                            loc,
+                            prev,
                         });
-                    }
-                    else {
+                    } else {
                         match arg.as_deref() {
-                            None | Some("true") | Some("1") | Some("") => vis_spec = Some((true, loc)),
+                            None | Some("true") | Some("1") | Some("") => {
+                                vis_spec = Some((true, loc))
+                            }
                             Some("false") | Some("0") => vis_spec = Some((false, loc)),
                             Some(_) => errs.push(CobaltError::InvalidAnnArgument {
                                 name: "export",
                                 found: arg.clone(),
                                 expected: Some(r#"no argument, "true", or "false""#),
-                                loc
-                            })
+                                loc,
+                            }),
                         }
                     }
-                },
+                }
                 "private" => {
                     if let Some((_, prev)) = vis_spec {
                         errs.push(CobaltError::RedefAnnArgument {
                             name: "private",
-                            loc, prev
+                            loc,
+                            prev,
                         });
-                    }
-                    else {
+                    } else {
                         match arg.as_deref() {
-                            None | Some("true") | Some("1") | Some("") => vis_spec = Some((false, loc)),
+                            None | Some("true") | Some("1") | Some("") => {
+                                vis_spec = Some((false, loc))
+                            }
                             Some("false") | Some("0") => vis_spec = Some((true, loc)),
                             Some(_) => errs.push(CobaltError::InvalidAnnArgument {
                                 name: "private",
                                 found: arg.clone(),
                                 expected: Some(r#"no argument, "true", or "false""#),
-                                loc
-                            })
+                                loc,
+                            }),
                         }
                     }
-                },
-                _ => errs.push(CobaltError::UnknownAnnotation {loc, name: ann.clone(), def: "module"})
+                }
+                _ => errs.push(CobaltError::UnknownAnnotation {
+                    loc,
+                    name: ann.clone(),
+                    def: "module",
+                }),
             }
         }
-        if target_match == 0 {return (Value::null(), errs)}
-        ctx.map_vars(|mut v| {
-            match v.lookup_mod(&self.name) {
-                Ok((m, i, _)) => Box::new(VarMap {parent: Some(v), symbols: m, imports: i}),
-                Err(UndefVariable::NotAModule(x)) => {
-                    errs.push(CobaltError::NotAModule {
-                        name: self.name.start(x).to_string(),
-                        loc: self.name.ids[x - 1].1
-                    });
-                    Box::new(VarMap::new(Some(v)))
-                },
-                Err(UndefVariable::DoesNotExist(x)) => {
-                    errs.push(CobaltError::RedefVariable {
-                        name: self.name.start(x).to_string(),
-                        loc: self.name.ids[x - 1].1,
-                        prev: None
-                    });
-                    Box::new(VarMap::new(Some(v)))
-                }
+        if target_match == 0 {
+            return (Value::null(), errs);
+        }
+        ctx.map_vars(|mut v| match v.lookup_mod(&self.name) {
+            Ok((m, i, _)) => Box::new(VarMap {
+                parent: Some(v),
+                symbols: m,
+                imports: i,
+            }),
+            Err(UndefVariable::NotAModule(x)) => {
+                errs.push(CobaltError::NotAModule {
+                    name: self.name.start(x).to_string(),
+                    loc: self.name.ids[x - 1].1,
+                });
+                Box::new(VarMap::new(Some(v)))
+            }
+            Err(UndefVariable::DoesNotExist(x)) => {
+                errs.push(CobaltError::RedefVariable {
+                    name: self.name.start(x).to_string(),
+                    loc: self.name.ids[x - 1].1,
+                    prev: None,
+                });
+                Box::new(VarMap::new(Some(v)))
             }
         });
         let old_scope = ctx.push_scope(&self.name);
-        let old_vis = if let Some((v, _)) = vis_spec {ctx.export.replace(v)} else {false};
+        let old_vis = if let Some((v, _)) = vis_spec {
+            ctx.export.replace(v)
+        } else {
+            false
+        };
         if ctx.flags.prepass {
             self.vals.iter().for_each(|val| val.varfwd_prepass(ctx));
             let mut again = true;
             while again {
                 again = false;
-                self.vals.iter().for_each(|val| val.constinit_prepass(ctx, &mut again));
+                self.vals
+                    .iter()
+                    .for_each(|val| val.constinit_prepass(ctx, &mut again));
             }
             self.vals.iter().for_each(|val| val.fwddef_prepass(ctx));
         }
         errs.extend(self.vals.iter().flat_map(|val| val.codegen(ctx).1));
         ctx.restore_scope(old_scope);
-        if vis_spec.is_some() {ctx.export.set(old_vis)}
+        if vis_spec.is_some() {
+            ctx.export.set(old_vis)
+        }
         let syms = ctx.map_split_vars(|v| (v.parent.unwrap(), (v.symbols, v.imports)));
         std::mem::drop(ctx.with_vars(|v| v.insert_mod(&self.name, syms, ctx.mangle(&self.name))));
         (Value::null(), errs)
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
         writeln!(f, "module: {}", self.name)?;
         let mut count = self.vals.len();
         for val in self.vals.iter() {
@@ -128,19 +174,43 @@ impl AST for ModuleAST {
     }
 }
 impl ModuleAST {
-    pub fn new(loc: SourceSpan, name: DottedName, vals: Vec<Box<dyn AST>>, annotations: Vec<(String, Option<String>, SourceSpan)>) -> Self {ModuleAST {loc, name, vals, annotations}}
+    pub fn new(
+        loc: SourceSpan,
+        name: DottedName,
+        vals: Vec<Box<dyn AST>>,
+        annotations: Vec<(String, Option<String>, SourceSpan)>,
+    ) -> Self {
+        ModuleAST {
+            loc,
+            name,
+            vals,
+            annotations,
+        }
+    }
 }
 #[derive(Debug, Clone)]
 pub struct ImportAST {
     loc: SourceSpan,
     pub name: CompoundDottedName,
-    pub annotations: Vec<(String, Option<String>, SourceSpan)>
+    pub annotations: Vec<(String, Option<String>, SourceSpan)>,
 }
 impl ImportAST {
-    pub fn new(loc: SourceSpan, name: CompoundDottedName, annotations: Vec<(String, Option<String>, SourceSpan)>) -> Self {ImportAST {loc, name, annotations}}
+    pub fn new(
+        loc: SourceSpan,
+        name: CompoundDottedName,
+        annotations: Vec<(String, Option<String>, SourceSpan)>,
+    ) -> Self {
+        ImportAST {
+            loc,
+            name,
+            annotations,
+        }
+    }
 }
 impl AST for ImportAST {
-    fn loc(&self) -> SourceSpan {self.loc}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let mut errs = vec![];
         let mut target_match = 2u8;
@@ -151,73 +221,111 @@ impl AST for ImportAST {
                 "target" => {
                     if let Some(arg) = arg {
                         let mut arg = arg.as_str();
-                        let negate = if arg.as_bytes().first() == Some(&0x21) {arg = &arg[1..]; true} else {false};
+                        let negate = if arg.as_bytes().first() == Some(&0x21) {
+                            arg = &arg[1..];
+                            true
+                        } else {
+                            false
+                        };
                         match Pattern::new(arg) {
-                            Ok(pat) => if target_match != 1 {target_match = u8::from(negate ^ pat.matches(&ctx.module.get_triple().as_str().to_string_lossy()))},
-                            Err(err) => errs.push(CobaltError::GlobPatternError {pos: err.pos, msg: err.msg.to_string(), loc})
+                            Ok(pat) => {
+                                if target_match != 1 {
+                                    target_match = u8::from(
+                                        negate
+                                            ^ pat.matches(
+                                                &ctx.module.get_triple().as_str().to_string_lossy(),
+                                            ),
+                                    )
+                                }
+                            }
+                            Err(err) => errs.push(CobaltError::GlobPatternError {
+                                pos: err.pos,
+                                msg: err.msg.to_string(),
+                                loc,
+                            }),
                         }
-                    }
-                    else {
+                    } else {
                         errs.push(CobaltError::InvalidAnnArgument {
                             name: "target",
                             found: arg.clone(),
                             expected: Some("target glob"),
-                            loc
+                            loc,
                         });
                     }
-                },
+                }
                 "export" => {
                     if let Some((_, prev)) = vis_spec {
                         errs.push(CobaltError::RedefAnnArgument {
                             name: "export",
-                            loc, prev
+                            loc,
+                            prev,
                         });
-                    }
-                    else {
+                    } else {
                         match arg.as_deref() {
-                            None | Some("true") | Some("1") | Some("") => vis_spec = Some((true, loc)),
+                            None | Some("true") | Some("1") | Some("") => {
+                                vis_spec = Some((true, loc))
+                            }
                             Some("false") | Some("0") => vis_spec = Some((false, loc)),
                             Some(_) => errs.push(CobaltError::InvalidAnnArgument {
                                 name: "export",
                                 found: arg.clone(),
                                 expected: Some(r#"no argument, "true", or "false""#),
-                                loc
-                            })
+                                loc,
+                            }),
                         }
                     }
-                },
+                }
                 "private" => {
                     if let Some((_, prev)) = vis_spec {
                         errs.push(CobaltError::RedefAnnArgument {
                             name: "private",
-                            loc, prev
+                            loc,
+                            prev,
                         });
-                    }
-                    else {
+                    } else {
                         match arg.as_deref() {
-                            None | Some("true") | Some("1") | Some("") => vis_spec = Some((false, loc)),
+                            None | Some("true") | Some("1") | Some("") => {
+                                vis_spec = Some((false, loc))
+                            }
                             Some("false") | Some("0") => vis_spec = Some((true, loc)),
                             Some(_) => errs.push(CobaltError::InvalidAnnArgument {
                                 name: "private",
                                 found: arg.clone(),
                                 expected: Some(r#"no argument, "true", or "false""#),
-                                loc
-                            })
+                                loc,
+                            }),
                         }
                     }
-                },
-                _ => errs.push(CobaltError::UnknownAnnotation {loc, name: ann.clone(), def: "import"})
+                }
+                _ => errs.push(CobaltError::UnknownAnnotation {
+                    loc,
+                    name: ann.clone(),
+                    def: "import",
+                }),
             }
         }
-        if target_match == 0 {return (Value::null(), errs)}
+        if target_match == 0 {
+            return (Value::null(), errs);
+        }
         ctx.with_vars(|v| {
             let vec = v.verify(&self.name);
-            errs.extend(vec.into_iter().map(|loc| CobaltError::UselessImport {loc}));
-            v.imports.push((self.name.clone(), vis_spec.map_or(ctx.export.get(), |(v, _)| v)))
+            errs.extend(
+                vec.into_iter()
+                    .map(|loc| CobaltError::UselessImport { loc }),
+            );
+            v.imports.push((
+                self.name.clone(),
+                vis_spec.map_or(ctx.export.get(), |(v, _)| v),
+            ))
         });
         (Value::null(), errs)
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, _pre: &mut TreePrefix, _file: Option<CobaltFile>) -> std::fmt::Result {
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        _pre: &mut TreePrefix,
+        _file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
         writeln!(f, "import: {}", self.name)
     }
 }

--- a/cobalt-ast/src/ast/vars.rs
+++ b/cobalt-ast/src/ast/vars.rs
@@ -1,9 +1,9 @@
 use crate::*;
 use ast::funcs::hoist_allocas;
-use inkwell::values::{AsValueRef, GlobalValue, BasicValueEnum::*};
-use inkwell::module::Linkage::*;
 use glob::Pattern;
-use std::collections::{HashSet, hash_map::Entry};
+use inkwell::module::Linkage::*;
+use inkwell::values::{AsValueRef, BasicValueEnum::*, GlobalValue};
+use std::collections::{hash_map::Entry, HashSet};
 #[derive(Debug, Clone)]
 pub struct VarDefAST {
     loc: SourceSpan,
@@ -12,14 +12,36 @@ pub struct VarDefAST {
     pub type_: Option<Box<dyn AST>>,
     pub annotations: Vec<(String, Option<String>, SourceSpan)>,
     pub global: bool,
-    pub is_mut: bool
+    pub is_mut: bool,
 }
 impl VarDefAST {
-    pub fn new(loc: SourceSpan, name: DottedName, val: Box<dyn AST>, type_: Option<Box<dyn AST>>, annotations: Vec<(String, Option<String>, SourceSpan)>, global: bool, is_mut: bool) -> Self {VarDefAST {loc, name, val, type_, annotations, global, is_mut}}
+    pub fn new(
+        loc: SourceSpan,
+        name: DottedName,
+        val: Box<dyn AST>,
+        type_: Option<Box<dyn AST>>,
+        annotations: Vec<(String, Option<String>, SourceSpan)>,
+        global: bool,
+        is_mut: bool,
+    ) -> Self {
+        VarDefAST {
+            loc,
+            name,
+            val,
+            type_,
+            annotations,
+            global,
+            is_mut,
+        }
+    }
 }
 impl AST for VarDefAST {
-    fn loc(&self) -> SourceSpan {merge_spans(self.loc, self.val.loc())}
-    fn nodes(&self) -> usize {self.val.nodes() + self.type_.as_ref().map_or(0, |x| x.nodes()) + 1}
+    fn loc(&self) -> SourceSpan {
+        merge_spans(self.loc, self.val.loc())
+    }
+    fn nodes(&self) -> usize {
+        self.val.nodes() + self.type_.as_ref().map_or(0, |x| x.nodes()) + 1
+    }
     fn fwddef_prepass(&self, ctx: &CompCtx) {
         let mut errs = vec![];
         let mut link_type = None;
@@ -32,29 +54,57 @@ impl AST for VarDefAST {
                 "link" => {
                     link_type = match arg.as_ref().map(|x| x.as_str()) {
                         Some("extern") | Some("external") => Some(External),
-                        Some("extern-weak") | Some("extern_weak") | Some("external-weak") | Some("external_weak") => Some(ExternalWeak),
+                        Some("extern-weak")
+                        | Some("extern_weak")
+                        | Some("external-weak")
+                        | Some("external_weak") => Some(ExternalWeak),
                         Some("intern") | Some("internal") => Some(Internal),
                         Some("private") => Some(Private),
                         Some("weak") => Some(WeakAny),
                         Some("weak-odr") | Some("weak_odr") => Some(WeakODR),
-                        Some("linkonce") | Some("link-once") | Some("link_once") => Some(LinkOnceAny),
-                        Some("linkonce-odr") | Some("linkonce_odr") | Some("link-once-odr") | Some("link_once_odr") => Some(LinkOnceODR),
+                        Some("linkonce") | Some("link-once") | Some("link_once") => {
+                            Some(LinkOnceAny)
+                        }
+                        Some("linkonce-odr")
+                        | Some("linkonce_odr")
+                        | Some("link-once-odr")
+                        | Some("link_once_odr") => Some(LinkOnceODR),
                         Some("common") => Some(Common),
-                        _ => None
-                    }.map(|x| (x, loc))
+                        _ => None,
+                    }
+                    .map(|x| (x, loc))
                 }
                 "linkas" => {
                     if let Some(arg) = arg {
                         linkas = Some(arg.clone())
                     }
                 }
-                "c" | "C" => linkas = Some(self.name.ids.last().expect("function name shouldn't be empty!").0.clone()),
+                "c" | "C" => {
+                    linkas = Some(
+                        self.name
+                            .ids
+                            .last()
+                            .expect("function name shouldn't be empty!")
+                            .0
+                            .clone(),
+                    )
+                }
                 "target" => {
                     if let Some(arg) = arg {
                         let mut arg = arg.as_str();
-                        let negate = if arg.as_bytes().first() == Some(&0x21) {arg = &arg[1..]; true} else {false};
+                        let negate = if arg.as_bytes().first() == Some(&0x21) {
+                            arg = &arg[1..];
+                            true
+                        } else {
+                            false
+                        };
                         if let Ok(pat) = Pattern::new(arg) {
-                            target_match = u8::from(negate ^ pat.matches(&ctx.module.get_triple().as_str().to_string_lossy()))
+                            target_match = u8::from(
+                                negate
+                                    ^ pat.matches(
+                                        &ctx.module.get_triple().as_str().to_string_lossy(),
+                                    ),
+                            )
                         }
                     }
                 }
@@ -63,7 +113,7 @@ impl AST for VarDefAST {
                         match arg.as_deref() {
                             None | Some("true") | Some("1") | Some("") => vis_spec = Some(true),
                             Some("false") | Some("0") => vis_spec = Some(false),
-                            _ => {},
+                            _ => {}
                         }
                     }
                 }
@@ -80,28 +130,57 @@ impl AST for VarDefAST {
             }
         }
         let vs = vis_spec.unwrap_or(ctx.export.get());
-        if target_match == 0 {return}
+        if target_match == 0 {
+            return;
+        }
         let t2 = self.val.const_codegen(ctx).0.data_type;
         let dt = if let Some(t) = self.type_.as_ref().map(|t| {
             let oic = ctx.is_const.replace(true);
-            let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
+            let t = ops::impl_convert(
+                t.loc(),
+                (t.codegen_errs(ctx, &mut errs), None),
+                (Type::TypeData, None),
+                ctx,
+            )
+            .ok()
+            .and_then(Value::into_type)
+            .unwrap_or(Type::Error);
             ctx.is_const.set(oic);
             t
-        }) {t} else {ops::decay(t2)};
-        let _ = ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::new(
-            dt.llvm_type(ctx).map(|t| {
-                let gv = ctx.module.add_global(t, None, &linkas.unwrap_or_else(|| ctx.mangle(&self.name)));
-                match link_type {
-                    None => {},
-                    Some((WeakAny, _)) => gv.set_linkage(ExternalWeak),
-                    Some((x, _)) => gv.set_linkage(x)
-                }
-                gv.set_constant(!self.is_mut);
-                PointerValue(gv.as_pointer_value())
-            }),
-            None,
-            Type::Reference(ops::maybe_mut(Box::new(dt), self.is_mut))
-        ), VariableData {fwd: true, ..VariableData::with_vis(self.loc, vs)})));
+        }) {
+            t
+        } else {
+            ops::decay(t2)
+        };
+        let _ = ctx.with_vars(|v| {
+            v.insert(
+                &self.name,
+                Symbol(
+                    Value::new(
+                        dt.llvm_type(ctx).map(|t| {
+                            let gv = ctx.module.add_global(
+                                t,
+                                None,
+                                &linkas.unwrap_or_else(|| ctx.mangle(&self.name)),
+                            );
+                            match link_type {
+                                None => {}
+                                Some((WeakAny, _)) => gv.set_linkage(ExternalWeak),
+                                Some((x, _)) => gv.set_linkage(x),
+                            }
+                            gv.set_constant(!self.is_mut);
+                            PointerValue(gv.as_pointer_value())
+                        }),
+                        None,
+                        Type::Reference(ops::maybe_mut(Box::new(dt), self.is_mut)),
+                    ),
+                    VariableData {
+                        fwd: true,
+                        ..VariableData::with_vis(self.loc, vs)
+                    },
+                ),
+            )
+        });
     }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let mut errs = vec![];
@@ -120,7 +199,7 @@ impl AST for VarDefAST {
                             name: "static",
                             expected: None,
                             found: arg.clone(),
-                            loc
+                            loc,
                         });
                     }
                     is_static = true;
@@ -129,44 +208,56 @@ impl AST for VarDefAST {
                     if let Some((_, prev)) = link_type {
                         errs.push(CobaltError::RedefAnnArgument {
                             name: "link",
-                            loc, prev
+                            loc,
+                            prev,
                         });
                     }
                     link_type = match arg.as_deref() {
                         Some("extern") | Some("external") => Some(External),
-                        Some("extern-weak") | Some("extern_weak") | Some("external-weak") | Some("external_weak") => Some(ExternalWeak),
+                        Some("extern-weak")
+                        | Some("extern_weak")
+                        | Some("external-weak")
+                        | Some("external_weak") => Some(ExternalWeak),
                         Some("intern") | Some("internal") => Some(Internal),
                         Some("private") => Some(Private),
                         Some("weak") => Some(WeakAny),
                         Some("weak-odr") | Some("weak_odr") => Some(WeakODR),
-                        Some("linkonce") | Some("link-once") | Some("link_once") => Some(LinkOnceAny),
-                        Some("linkonce-odr") | Some("linkonce_odr") | Some("link-once-odr") | Some("link_once_odr") => Some(LinkOnceODR),
+                        Some("linkonce") | Some("link-once") | Some("link_once") => {
+                            Some(LinkOnceAny)
+                        }
+                        Some("linkonce-odr")
+                        | Some("linkonce_odr")
+                        | Some("link-once-odr")
+                        | Some("link_once_odr") => Some(LinkOnceODR),
                         Some("common") => Some(Common),
                         _ => {
                             errs.push(CobaltError::InvalidAnnArgument {
                                 name: "link",
                                 found: arg.clone(),
                                 expected: Some("link type"),
-                                loc
+                                loc,
                             });
                             None
                         }
-                    }.map(|x| (x, loc))
+                    }
+                    .map(|x| (x, loc))
                 }
                 "linkas" => {
                     if let Some((_, prev)) = linkas {
                         errs.push(CobaltError::RedefAnnArgument {
                             name: "linkas",
-                            loc, prev
+                            loc,
+                            prev,
                         });
                     }
-                    if let Some(arg) = arg {linkas = Some((arg.clone(), loc))}
-                    else {
+                    if let Some(arg) = arg {
+                        linkas = Some((arg.clone(), loc))
+                    } else {
                         errs.push(CobaltError::InvalidAnnArgument {
                             name: "linkas",
                             found: arg.clone(),
                             expected: Some("linkage name"),
-                            loc
+                            loc,
                         });
                     }
                 }
@@ -177,38 +268,63 @@ impl AST for VarDefAST {
                             name: "extern",
                             found: arg.clone(),
                             expected: None,
-                            loc
+                            loc,
                         });
                     }
                 }
                 "c" | "C" => {
                     match arg.as_ref().map(|x| x.as_str()) {
-                        Some("") | None => {},
+                        Some("") | None => {}
                         Some("extern") => is_extern = Some(loc),
                         Some(_) => errs.push(CobaltError::InvalidAnnArgument {
                             name: "C",
                             found: arg.clone(),
                             expected: Some(r#"no argument or "extern""#),
-                            loc
-                        })
+                            loc,
+                        }),
                     }
-                    linkas = Some((self.name.ids.last().expect("variable name shouldn't be empty!").0.clone(), loc))
+                    linkas = Some((
+                        self.name
+                            .ids
+                            .last()
+                            .expect("variable name shouldn't be empty!")
+                            .0
+                            .clone(),
+                        loc,
+                    ))
                 }
                 "target" => {
                     if let Some(arg) = arg {
                         let mut arg = arg.as_str();
-                        let negate = if arg.as_bytes().first() == Some(&0x21) {arg = &arg[1..]; true} else {false};
+                        let negate = if arg.as_bytes().first() == Some(&0x21) {
+                            arg = &arg[1..];
+                            true
+                        } else {
+                            false
+                        };
                         match Pattern::new(arg) {
-                            Ok(pat) => if target_match != 1 {target_match = u8::from(negate ^ pat.matches(&ctx.module.get_triple().as_str().to_string_lossy()))},
-                            Err(err) => errs.push(CobaltError::GlobPatternError {pos: err.pos, msg: err.msg.to_string(), loc})
+                            Ok(pat) => {
+                                if target_match != 1 {
+                                    target_match = u8::from(
+                                        negate
+                                            ^ pat.matches(
+                                                &ctx.module.get_triple().as_str().to_string_lossy(),
+                                            ),
+                                    )
+                                }
+                            }
+                            Err(err) => errs.push(CobaltError::GlobPatternError {
+                                pos: err.pos,
+                                msg: err.msg.to_string(),
+                                loc,
+                            }),
                         }
-                    }
-                    else {
+                    } else {
                         errs.push(CobaltError::InvalidAnnArgument {
                             name: "target",
                             found: arg.clone(),
                             expected: Some("target glob"),
-                            loc
+                            loc,
                         });
                     }
                 }
@@ -216,25 +332,27 @@ impl AST for VarDefAST {
                     if !self.global {
                         errs.push(CobaltError::MustBeGlobal {
                             name: "export",
-                            loc
+                            loc,
                         });
                     }
                     if let Some((_, prev)) = vis_spec {
                         errs.push(CobaltError::RedefAnnArgument {
                             name: "export",
-                            loc, prev
+                            loc,
+                            prev,
                         });
-                    }
-                    else {
+                    } else {
                         match arg.as_deref() {
-                            None | Some("true") | Some("1") | Some("") => vis_spec = Some((true, loc)),
+                            None | Some("true") | Some("1") | Some("") => {
+                                vis_spec = Some((true, loc))
+                            }
                             Some("false") | Some("0") => vis_spec = Some((false, loc)),
                             Some(_) => errs.push(CobaltError::InvalidAnnArgument {
                                 name: "export",
                                 found: arg.clone(),
                                 expected: Some(r#"no argument, "true", or "false""#),
-                                loc
-                            })
+                                loc,
+                            }),
                         }
                     }
                 }
@@ -242,113 +360,223 @@ impl AST for VarDefAST {
                     if !self.global {
                         errs.push(CobaltError::MustBeGlobal {
                             name: "private",
-                            loc
+                            loc,
                         });
                     }
                     if let Some((_, prev)) = vis_spec {
                         errs.push(CobaltError::RedefAnnArgument {
                             name: "private",
-                            loc, prev
+                            loc,
+                            prev,
                         });
-                    }
-                    else {
+                    } else {
                         match arg.as_deref() {
-                            None | Some("true") | Some("1") | Some("") => vis_spec = Some((false, loc)),
+                            None | Some("true") | Some("1") | Some("") => {
+                                vis_spec = Some((false, loc))
+                            }
                             Some("false") | Some("0") => vis_spec = Some((true, loc)),
                             Some(_) => errs.push(CobaltError::InvalidAnnArgument {
                                 name: "private",
                                 found: arg.clone(),
                                 expected: Some(r#"no argument, "true", or "false""#),
-                                loc
-                            })
+                                loc,
+                            }),
                         }
                     }
                 }
-                _ => errs.push(CobaltError::UnknownAnnotation {loc, name: ann.clone(), def: "variable"})
+                _ => errs.push(CobaltError::UnknownAnnotation {
+                    loc,
+                    name: ann.clone(),
+                    def: "variable",
+                }),
             }
         }
         let vs = vis_spec.map_or(ctx.export.get(), |(v, _)| v);
-        if target_match == 0 {return (Value::null(), errs)}
+        if target_match == 0 {
+            return (Value::null(), errs);
+        }
         if self.global || is_static {
             if is_extern.is_some() {
                 let t2 = self.val.const_codegen_errs(ctx, &mut errs).data_type;
                 let dt = if let Some(t) = self.type_.as_ref().map(|t| {
                     let oic = ctx.is_const.replace(true);
-                    let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+                    let t = ops::impl_convert(
+                        t.loc(),
+                        (t.codegen_errs(ctx, &mut errs), None),
+                        (Type::TypeData, None),
+                        ctx,
+                    )
+                    .map_or_else(
+                        |e| {
+                            errs.push(e);
+                            Type::Error
+                        },
+                        |v| {
+                            if let Some(InterData::Type(t)) = v.inter_val {
+                                *t
+                            } else {
+                                Type::Error
+                            }
+                        },
+                    );
                     ctx.is_const.set(oic);
                     t
-                }) {t} else {ops::decay(t2)};
-                match ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::new(
-                    dt.llvm_type(ctx).map(|t| {
-                        let mangled = linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name);
-                        let gv = ctx.lookup_full(&self.name).and_then(|x| -> Option<GlobalValue> {Some(unsafe {std::mem::transmute(x.comp_val?.as_value_ref())})}).unwrap_or_else(|| ctx.module.add_global(t, None, &mangled));
-                        match link_type {
-                            None => {},
-                            Some((WeakAny, _)) => gv.set_linkage(ExternalWeak),
-                            Some((x, _)) => gv.set_linkage(x)
-                        }
-                        gv.set_constant(!self.is_mut);
-                        PointerValue(gv.as_pointer_value())
-                    }).or_else(|| {if dt != Type::Error {errs.push(CobaltError::TypeIsConstOnly {ty: dt.to_string(), loc: self.type_.as_ref().unwrap_or(&self.val).loc()})}; None}),
-                    None,
-                    Type::Reference(ops::maybe_mut(Box::new(dt), self.is_mut))
-                ), VariableData::with_vis(self.loc, vs)))) {
+                }) {
+                    t
+                } else {
+                    ops::decay(t2)
+                };
+                match ctx.with_vars(|v| {
+                    v.insert(
+                        &self.name,
+                        Symbol(
+                            Value::new(
+                                dt.llvm_type(ctx)
+                                    .map(|t| {
+                                        let mangled = linkas.map_or_else(
+                                            || ctx.mangle(&self.name),
+                                            |(name, _)| name,
+                                        );
+                                        let gv = ctx
+                                            .lookup_full(&self.name)
+                                            .and_then(|x| -> Option<GlobalValue> {
+                                                Some(unsafe {
+                                                    std::mem::transmute(x.comp_val?.as_value_ref())
+                                                })
+                                            })
+                                            .unwrap_or_else(|| {
+                                                ctx.module.add_global(t, None, &mangled)
+                                            });
+                                        match link_type {
+                                            None => {}
+                                            Some((WeakAny, _)) => gv.set_linkage(ExternalWeak),
+                                            Some((x, _)) => gv.set_linkage(x),
+                                        }
+                                        gv.set_constant(!self.is_mut);
+                                        PointerValue(gv.as_pointer_value())
+                                    })
+                                    .or_else(|| {
+                                        if dt != Type::Error {
+                                            errs.push(CobaltError::TypeIsConstOnly {
+                                                ty: dt.to_string(),
+                                                loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
+                                            })
+                                        };
+                                        None
+                                    }),
+                                None,
+                                Type::Reference(ops::maybe_mut(Box::new(dt), self.is_mut)),
+                            ),
+                            VariableData::with_vis(self.loc, vs),
+                        ),
+                    )
+                }) {
                     Ok(x) => (x.0.clone(), errs),
                     Err(RedefVariable::NotAModule(x, _)) => {
                         errs.push(CobaltError::NotAModule {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string()
+                            name: self.name.start(x).to_string(),
                         });
                         (Value::error(), errs)
-                    },
+                    }
                     Err(RedefVariable::AlreadyExists(x, d, _)) => {
                         errs.push(CobaltError::RedefVariable {
                             loc: self.name.ids[x].1,
                             name: self.name.start(x).to_string(),
-                            prev: d
+                            prev: d,
                         });
                         (Value::error(), errs)
                     }
                 }
-            }
-            else if self.val.is_const() && self.type_.is_none() {
+            } else if self.val.is_const() && self.type_.is_none() {
                 let mut val = self.val.codegen_errs(ctx, &mut errs);
                 let t2 = val.data_type.clone();
                 let dt = if let Some(t) = self.type_.as_ref().map(|t| {
                     let oic = ctx.is_const.replace(true);
-                    let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+                    let t = ops::impl_convert(
+                        t.loc(),
+                        (t.codegen_errs(ctx, &mut errs), None),
+                        (Type::TypeData, None),
+                        ctx,
+                    )
+                    .map_or_else(
+                        |e| {
+                            errs.push(e);
+                            Type::Error
+                        },
+                        |v| {
+                            if let Some(InterData::Type(t)) = v.inter_val {
+                                *t
+                            } else {
+                                Type::Error
+                            }
+                        },
+                    );
                     ctx.is_const.set(oic);
                     t
-                }) {t} else {ops::decay(t2)};
+                }) {
+                    t
+                } else {
+                    ops::decay(t2)
+                };
                 match if let Some(v) = val.value(ctx) {
                     val.inter_val = None;
                     if ctx.is_const.get() {
-                        ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData::with_vis(self.loc, vs))))
-                    }
-                    else {
+                        ctx.with_vars(|v| {
+                            v.insert(
+                                &self.name,
+                                Symbol(val, VariableData::with_vis(self.loc, vs)),
+                            )
+                        })
+                    } else {
                         let t = dt.llvm_type(ctx).unwrap();
-                        let mangled = linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name);
-                        let gv = ctx.lookup_full(&self.name).and_then(|x| -> Option<GlobalValue> {Some(unsafe {std::mem::transmute(x.comp_val?.as_value_ref())})}).unwrap_or_else(|| ctx.module.add_global(t, None, &mangled));
+                        let mangled =
+                            linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name);
+                        let gv = ctx
+                            .lookup_full(&self.name)
+                            .and_then(|x| -> Option<GlobalValue> {
+                                Some(unsafe { std::mem::transmute(x.comp_val?.as_value_ref()) })
+                            })
+                            .unwrap_or_else(|| ctx.module.add_global(t, None, &mangled));
                         gv.set_initializer(&v);
                         gv.set_constant(!self.is_mut);
-                        if let Some((link, _)) = link_type {gv.set_linkage(link)}
-                        ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::new(
-                            Some(PointerValue(gv.as_pointer_value())),
-                            None,
-                            Type::Reference(ops::maybe_mut(Box::new(dt), self.is_mut))
-                        ), VariableData::with_vis(self.loc, vs))))
+                        if let Some((link, _)) = link_type {
+                            gv.set_linkage(link)
+                        }
+                        ctx.with_vars(|v| {
+                            v.insert(
+                                &self.name,
+                                Symbol(
+                                    Value::new(
+                                        Some(PointerValue(gv.as_pointer_value())),
+                                        None,
+                                        Type::Reference(ops::maybe_mut(Box::new(dt), self.is_mut)),
+                                    ),
+                                    VariableData::with_vis(self.loc, vs),
+                                ),
+                            )
+                        })
                     }
-                }
-                else {
+                } else {
                     val.inter_val = None;
-                    if dt != Type::Error {errs.push(CobaltError::TypeIsConstOnly {ty: dt.to_string(), loc: self.type_.as_ref().unwrap_or(&self.val).loc()})}
-                    ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData::with_vis(self.loc, false))))
+                    if dt != Type::Error {
+                        errs.push(CobaltError::TypeIsConstOnly {
+                            ty: dt.to_string(),
+                            loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
+                        })
+                    }
+                    ctx.with_vars(|v| {
+                        v.insert(
+                            &self.name,
+                            Symbol(val, VariableData::with_vis(self.loc, false)),
+                        )
+                    })
                 } {
                     Ok(x) => (x.0.clone(), errs),
                     Err(RedefVariable::NotAModule(x, _)) => {
                         errs.push(CobaltError::NotAModule {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string()
+                            name: self.name.start(x).to_string(),
                         });
                         (Value::error(), errs)
                     }
@@ -356,31 +584,55 @@ impl AST for VarDefAST {
                         errs.push(CobaltError::RedefVariable {
                             loc: self.name.ids[x].1,
                             name: self.name.start(x).to_string(),
-                            prev: d
+                            prev: d,
                         });
                         (Value::error(), errs)
                     }
                 }
-            }
-            else {
+            } else {
                 let res = if ctx.is_const.get() {
                     let val = self.val.codegen_errs(ctx, &mut errs);
                     let t2 = val.data_type.clone();
                     let dt = if let Some(t) = self.type_.as_ref().map(|t| {
                         let oic = ctx.is_const.replace(true);
-                        let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or(Type::Error, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+                        let t = ops::impl_convert(
+                            t.loc(),
+                            (t.codegen_errs(ctx, &mut errs), None),
+                            (Type::TypeData, None),
+                            ctx,
+                        )
+                        .map_or(Type::Error, |v| {
+                            if let Some(InterData::Type(t)) = v.inter_val {
+                                *t
+                            } else {
+                                Type::Error
+                            }
+                        });
                         ctx.is_const.set(oic);
                         t
-                    }) {t} else {ops::decay(t2)};
-                    let mut val = ops::impl_convert(self.val.loc(), (val, None), (dt, None), ctx).unwrap_or_else(|e| {
-                        errs.push(e);
-                        Value::error()
-                    });
+                    }) {
+                        t
+                    } else {
+                        ops::decay(t2)
+                    };
+                    let mut val = ops::impl_convert(self.val.loc(), (val, None), (dt, None), ctx)
+                        .unwrap_or_else(|e| {
+                            errs.push(e);
+                            Value::error()
+                        });
                     val.inter_val = None;
-                    ctx.with_vars(|v| v.insert(&self.name, Symbol(val.freeze(self.loc), VariableData::with_vis(self.loc, vs))))
-                }
-                else {
-                    let f = ctx.module.add_function(format!("cobalt.init{}", ctx.mangle(&self.name)).as_str(), ctx.context.void_type().fn_type(&[], false), Some(inkwell::module::Linkage::Private));
+                    ctx.with_vars(|v| {
+                        v.insert(
+                            &self.name,
+                            Symbol(val.freeze(self.loc), VariableData::with_vis(self.loc, vs)),
+                        )
+                    })
+                } else {
+                    let f = ctx.module.add_function(
+                        format!("cobalt.init{}", ctx.mangle(&self.name)).as_str(),
+                        ctx.context.void_type().fn_type(&[], false),
+                        Some(inkwell::module::Linkage::Private),
+                    );
                     let entry = ctx.context.append_basic_block(f, "entry");
                     let old_ip = ctx.builder.get_insert_block();
                     ctx.builder.position_at_end(entry);
@@ -389,70 +641,177 @@ impl AST for VarDefAST {
                     let t2 = val.data_type.clone();
                     let dt = if let Some(t) = self.type_.as_ref().map(|t| {
                         let oic = ctx.is_const.replace(true);
-                        let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+                        let t = ops::impl_convert(
+                            t.loc(),
+                            (t.codegen_errs(ctx, &mut errs), None),
+                            (Type::TypeData, None),
+                            ctx,
+                        )
+                        .map_or_else(
+                            |e| {
+                                errs.push(e);
+                                Type::Error
+                            },
+                            |v| {
+                                if let Some(InterData::Type(t)) = v.inter_val {
+                                    *t
+                                } else {
+                                    Type::Error
+                                }
+                            },
+                        );
                         ctx.is_const.set(oic);
                         t
-                    }) {t} else {ops::decay(t2)};
-                    let mut val = ops::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
-                        errs.push(e);
-                        Value::error()
-                    });
+                    }) {
+                        t
+                    } else {
+                        ops::decay(t2)
+                    };
+                    let mut val =
+                        ops::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx)
+                            .unwrap_or_else(|e| {
+                                errs.push(e);
+                                Value::error()
+                            });
                     if let Some(t) = dt.llvm_type(ctx) {
-                        let mangled = linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name);
-                        let gv = ctx.lookup_full(&self.name).and_then(|x| -> Option<GlobalValue> {Some(unsafe {std::mem::transmute(x.comp_val?.as_value_ref())})}).unwrap_or_else(|| ctx.module.add_global(t, None, &mangled));
+                        let mangled =
+                            linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name);
+                        let gv = ctx
+                            .lookup_full(&self.name)
+                            .and_then(|x| -> Option<GlobalValue> {
+                                Some(unsafe { std::mem::transmute(x.comp_val?.as_value_ref()) })
+                            })
+                            .unwrap_or_else(|| ctx.module.add_global(t, None, &mangled));
                         gv.set_constant(!self.is_mut);
                         gv.set_initializer(&t.const_zero());
-                        if let Some((link, _)) = link_type {gv.set_linkage(link)}
+                        if let Some((link, _)) = link_type {
+                            gv.set_linkage(link)
+                        }
                         ctx.restore_scope(old_scope);
                         if let Some(v) = val.value(ctx) {
                             val.inter_val = None;
                             ctx.builder.build_store(gv.as_pointer_value(), v);
                             ctx.builder.build_return(None);
                             hoist_allocas(&ctx.builder);
-                            if let Some(bb) = old_ip {ctx.builder.position_at_end(bb);}
-                            else {ctx.builder.clear_insertion_position();}
+                            if let Some(bb) = old_ip {
+                                ctx.builder.position_at_end(bb);
+                            } else {
+                                ctx.builder.clear_insertion_position();
+                            }
                             {
                                 let as0 = inkwell::AddressSpace::from(0u16);
                                 let i32t = ctx.context.i32_type();
                                 let i8tp = ctx.context.i8_type().ptr_type(as0);
-                                let st = ctx.context.struct_type(&[i32t.into(), ctx.context.void_type().fn_type(&[], false).ptr_type(as0).into(), i8tp.into()], false);
-                                let g = ctx.module.add_global(st.array_type(1), None, "llvm.global_ctors");
+                                let st = ctx.context.struct_type(
+                                    &[
+                                        i32t.into(),
+                                        ctx.context
+                                            .void_type()
+                                            .fn_type(&[], false)
+                                            .ptr_type(as0)
+                                            .into(),
+                                        i8tp.into(),
+                                    ],
+                                    false,
+                                );
+                                let g = ctx.module.add_global(
+                                    st.array_type(1),
+                                    None,
+                                    "llvm.global_ctors",
+                                );
                                 g.set_linkage(inkwell::module::Linkage::Appending);
-                                g.set_initializer(&st.const_array(&[st.const_named_struct(&[i32t.const_int(ctx.priority.decr().get() as u64, false).into(), f.as_global_value().as_pointer_value().into(), i8tp.const_zero().into()])]));
+                                g.set_initializer(
+                                    &st.const_array(&[st.const_named_struct(&[
+                                        i32t.const_int(ctx.priority.decr().get() as u64, false)
+                                            .into(),
+                                        f.as_global_value().as_pointer_value().into(),
+                                        i8tp.const_zero().into(),
+                                    ])]),
+                                );
                             }
-                            ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::new(
-                                Some(PointerValue(gv.as_pointer_value())),
-                                None,
-                                Type::Reference(ops::maybe_mut(Box::new(dt), self.is_mut))
-                            ).freeze(self.loc), VariableData::with_vis(self.loc, vs))))
-                        }
-                        else {
+                            ctx.with_vars(|v| {
+                                v.insert(
+                                    &self.name,
+                                    Symbol(
+                                        Value::new(
+                                            Some(PointerValue(gv.as_pointer_value())),
+                                            None,
+                                            Type::Reference(ops::maybe_mut(
+                                                Box::new(dt),
+                                                self.is_mut,
+                                            )),
+                                        )
+                                        .freeze(self.loc),
+                                        VariableData::with_vis(self.loc, vs),
+                                    ),
+                                )
+                            })
+                        } else {
                             val.inter_val = None;
                             unsafe {
                                 gv.delete();
                                 f.delete();
                             }
-                            if dt != Type::Error {errs.push(CobaltError::TypeIsConstOnly {ty: dt.to_string(), loc: self.type_.as_ref().unwrap_or(&self.val).loc()})}
-                            ctx.with_vars(|v| v.insert(&self.name, Symbol(val.freeze(self.loc), VariableData::with_vis(self.loc, false))))
+                            if dt != Type::Error {
+                                errs.push(CobaltError::TypeIsConstOnly {
+                                    ty: dt.to_string(),
+                                    loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
+                                })
+                            }
+                            ctx.with_vars(|v| {
+                                v.insert(
+                                    &self.name,
+                                    Symbol(
+                                        val.freeze(self.loc),
+                                        VariableData::with_vis(self.loc, false),
+                                    ),
+                                )
+                            })
                         }
-                    }
-                    else {
+                    } else {
                         let old_scope = ctx.push_scope(&self.name);
-                        if dt != Type::Error {errs.push(CobaltError::TypeIsConstOnly {ty: dt.to_string(), loc: self.type_.as_ref().unwrap_or(&self.val).loc()})}
+                        if dt != Type::Error {
+                            errs.push(CobaltError::TypeIsConstOnly {
+                                ty: dt.to_string(),
+                                loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
+                            })
+                        }
                         let val = self.val.codegen_errs(ctx, &mut errs);
                         let t2 = val.data_type.clone();
                         let dt = if let Some(t) = self.type_.as_ref().map(|t| {
                             let oic = ctx.is_const.replace(true);
-                            let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or(Type::Error, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+                            let t = ops::impl_convert(
+                                t.loc(),
+                                (t.codegen_errs(ctx, &mut errs), None),
+                                (Type::TypeData, None),
+                                ctx,
+                            )
+                            .map_or(Type::Error, |v| {
+                                if let Some(InterData::Type(t)) = v.inter_val {
+                                    *t
+                                } else {
+                                    Type::Error
+                                }
+                            });
                             ctx.is_const.set(oic);
                             t
-                        }) {t} else {ops::decay(t2)};
-                        let val = ops::impl_convert(self.val.loc(), (val, None), (dt, None), ctx).unwrap_or_else(|e| {
-                            errs.push(e);
-                            Value::error()
-                        });
+                        }) {
+                            t
+                        } else {
+                            ops::decay(t2)
+                        };
+                        let val = ops::impl_convert(self.val.loc(), (val, None), (dt, None), ctx)
+                            .unwrap_or_else(|e| {
+                                errs.push(e);
+                                Value::error()
+                            });
                         ctx.restore_scope(old_scope);
-                        ctx.with_vars(|v| v.insert(&self.name, Symbol(val.freeze(self.loc), VariableData::with_vis(self.loc, vs))))
+                        ctx.with_vars(|v| {
+                            v.insert(
+                                &self.name,
+                                Symbol(val.freeze(self.loc), VariableData::with_vis(self.loc, vs)),
+                            )
+                        })
                     }
                 };
                 match res {
@@ -460,7 +819,7 @@ impl AST for VarDefAST {
                     Err(RedefVariable::NotAModule(x, _)) => {
                         errs.push(CobaltError::NotAModule {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string()
+                            name: self.name.start(x).to_string(),
                         });
                         (Value::error(), errs)
                     }
@@ -468,67 +827,140 @@ impl AST for VarDefAST {
                         errs.push(CobaltError::RedefVariable {
                             loc: self.name.ids[x].1,
                             name: self.name.start(x).to_string(),
-                            prev: d
+                            prev: d,
                         });
                         (Value::error(), errs)
                     }
-                } 
+                }
             }
-        }
-        else {
+        } else {
             if let Some(loc) = is_extern {
-                errs.push(CobaltError::MustBeGlobal {name: "extern", loc});
+                errs.push(CobaltError::MustBeGlobal {
+                    name: "extern",
+                    loc,
+                });
             }
             if let Some((_, loc)) = link_type {
-                errs.push(CobaltError::MustBeGlobal {name: "link", loc});
+                errs.push(CobaltError::MustBeGlobal { name: "link", loc });
             }
             if let Some((_, loc)) = linkas {
-                errs.push(CobaltError::MustBeGlobal {name: "linkas", loc});
+                errs.push(CobaltError::MustBeGlobal {
+                    name: "linkas",
+                    loc,
+                });
             }
             let old_scope = ctx.push_scope(&self.name);
             let val = self.val.codegen_errs(ctx, &mut errs);
             let t2 = val.data_type.clone();
             let dt = if let Some(t) = self.type_.as_ref().map(|t| {
                 let oic = ctx.is_const.replace(true);
-                let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+                let t = ops::impl_convert(
+                    t.loc(),
+                    (t.codegen_errs(ctx, &mut errs), None),
+                    (Type::TypeData, None),
+                    ctx,
+                )
+                .map_or_else(
+                    |e| {
+                        errs.push(e);
+                        Type::Error
+                    },
+                    |v| {
+                        if let Some(InterData::Type(t)) = v.inter_val {
+                            *t
+                        } else {
+                            Type::Error
+                        }
+                    },
+                );
                 ctx.is_const.set(oic);
                 t
-            }) {t} else {ops::decay(t2)};
-            let mut val = ops::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx).unwrap_or_else(|e| {
-                errs.push(e);
-                Value::error()
-            });
-            ops::mark_move(&val, cfg::Location::current(ctx).unwrap(), ctx, self.val.loc());
+            }) {
+                t
+            } else {
+                ops::decay(t2)
+            };
+            let mut val = ops::impl_convert(self.val.loc(), (val, None), (dt.clone(), None), ctx)
+                .unwrap_or_else(|e| {
+                    errs.push(e);
+                    Value::error()
+                });
+            ops::mark_move(
+                &val,
+                cfg::Location::current(ctx).unwrap(),
+                ctx,
+                self.val.loc(),
+            );
             ctx.restore_scope(old_scope);
             val.comp_val = val.value(ctx);
-            val.name = self.name.ids.get(0).map(|x| (x.0.clone(), ctx.lex_scope.get()));
+            val.name = self
+                .name
+                .ids
+                .get(0)
+                .map(|x| (x.0.clone(), ctx.lex_scope.get()));
             val.frozen = (!self.is_mut).then_some(self.loc);
             match if ctx.is_const.get() || !self.is_mut {
-                ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData {scope: ctx.var_scope.get().try_into().ok(), ..VariableData::with_vis(self.loc, false)})))
-            } 
-            else if let (Some(t), Some(v)) = (val.data_type.llvm_type(ctx), val.comp_val) {
+                ctx.with_vars(|v| {
+                    v.insert(
+                        &self.name,
+                        Symbol(
+                            val,
+                            VariableData {
+                                scope: ctx.var_scope.get().try_into().ok(),
+                                ..VariableData::with_vis(self.loc, false)
+                            },
+                        ),
+                    )
+                })
+            } else if let (Some(t), Some(v)) = (val.data_type.llvm_type(ctx), val.comp_val) {
                 let a = val.addr(ctx).unwrap_or_else(|| {
-                    let a = ctx.builder.build_alloca(t, self.name.ids.last().map_or("", |(x, _)| x.as_str()));
+                    let a = ctx
+                        .builder
+                        .build_alloca(t, self.name.ids.last().map_or("", |(x, _)| x.as_str()));
                     ctx.builder.build_store(a, v);
                     a
                 });
                 let mut val = Value::new(
                     Some(PointerValue(a)),
                     val.inter_val,
-                    *ops::maybe_mut(Box::new(val.data_type), self.is_mut)
+                    *ops::maybe_mut(Box::new(val.data_type), self.is_mut),
                 );
-                val.name = self.name.ids.get(0).map(|x| (x.0.clone(), ctx.lex_scope.get()));
-                ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData::with_vis(self.loc, false))))
-            }
-            else {
-                if dt != Type::Error {errs.push(CobaltError::TypeIsConstOnly {ty: dt.to_string(), loc: self.type_.as_ref().unwrap_or(&self.val).loc()})}
-                ctx.with_vars(|v| v.insert(&self.name, Symbol(val, VariableData {scope: ctx.var_scope.get().try_into().ok(), ..VariableData::with_vis(self.loc, false)})))
+                val.name = self
+                    .name
+                    .ids
+                    .get(0)
+                    .map(|x| (x.0.clone(), ctx.lex_scope.get()));
+                ctx.with_vars(|v| {
+                    v.insert(
+                        &self.name,
+                        Symbol(val, VariableData::with_vis(self.loc, false)),
+                    )
+                })
+            } else {
+                if dt != Type::Error {
+                    errs.push(CobaltError::TypeIsConstOnly {
+                        ty: dt.to_string(),
+                        loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
+                    })
+                }
+                ctx.with_vars(|v| {
+                    v.insert(
+                        &self.name,
+                        Symbol(
+                            val,
+                            VariableData {
+                                scope: ctx.var_scope.get().try_into().ok(),
+                                ..VariableData::with_vis(self.loc, false)
+                            },
+                        ),
+                    )
+                })
             } {
                 Ok(x) => (x.0.clone(), errs),
                 Err(RedefVariable::NotAModule(x, _)) => {
                     errs.push(CobaltError::NotAModule {
                         loc: self.name.ids[x].1,
-                        name: self.name.start(x).to_string()
+                        name: self.name.start(x).to_string(),
                     });
                     (Value::error(), errs)
                 }
@@ -536,22 +968,43 @@ impl AST for VarDefAST {
                     errs.push(CobaltError::RedefVariable {
                         loc: self.name.ids[x].1,
                         name: self.name.start(x).to_string(),
-                        prev: d
+                        prev: d,
                     });
                     (Value::error(), errs)
                 }
             }
         }
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
-        writeln!(f, "let{}: {}", if self.is_mut {" (mut)"} else {""}, self.name)?;
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
+        writeln!(
+            f,
+            "let{}: {}",
+            if self.is_mut { " (mut)" } else { "" },
+            self.name
+        )?;
         writeln!(f, "{pre}├── annotations:")?;
         pre.push(false);
         for (n, (name, arg, _)) in self.annotations.iter().enumerate() {
-            writeln!(f, "{pre}{}@{name}{}", if n + 1 < self.annotations.len() {"├── "} else {"└── "}, arg.as_ref().map(|x| format!("({x})")).unwrap_or_default())?;
+            writeln!(
+                f,
+                "{pre}{}@{name}{}",
+                if n + 1 < self.annotations.len() {
+                    "├── "
+                } else {
+                    "└── "
+                },
+                arg.as_ref().map(|x| format!("({x})")).unwrap_or_default()
+            )?;
         }
         pre.pop();
-        if let Some(ref ast) = self.type_ {print_ast_child(f, pre, &**ast, false, file)?}
+        if let Some(ref ast) = self.type_ {
+            print_ast_child(f, pre, &**ast, false, file)?
+        }
         print_ast_child(f, pre, &*self.val, true, file)
     }
 }
@@ -562,31 +1015,67 @@ pub struct ConstDefAST {
     pub val: Box<dyn AST>,
     pub type_: Option<Box<dyn AST>>,
     pub annotations: Vec<(String, Option<String>, SourceSpan)>,
-    lastmissing: CellExt<HashSet<String>>
+    lastmissing: CellExt<HashSet<String>>,
 }
 impl ConstDefAST {
-    pub fn new(loc: SourceSpan, name: DottedName, val: Box<dyn AST>, type_: Option<Box<dyn AST>>, annotations: Vec<(String, Option<String>, SourceSpan)>) -> Self {ConstDefAST {loc, name, val, type_, annotations, lastmissing: CellExt::default()}}
+    pub fn new(
+        loc: SourceSpan,
+        name: DottedName,
+        val: Box<dyn AST>,
+        type_: Option<Box<dyn AST>>,
+        annotations: Vec<(String, Option<String>, SourceSpan)>,
+    ) -> Self {
+        ConstDefAST {
+            loc,
+            name,
+            val,
+            type_,
+            annotations,
+            lastmissing: CellExt::default(),
+        }
+    }
 }
 impl AST for ConstDefAST {
-    fn loc(&self) -> SourceSpan {merge_spans(self.loc, self.val.loc())}
-    fn nodes(&self) -> usize {self.val.nodes() + self.type_.as_ref().map_or(0, |x| x.nodes()) + 1}
+    fn loc(&self) -> SourceSpan {
+        merge_spans(self.loc, self.val.loc())
+    }
+    fn nodes(&self) -> usize {
+        self.val.nodes() + self.type_.as_ref().map_or(0, |x| x.nodes()) + 1
+    }
     fn varfwd_prepass(&self, ctx: &CompCtx) {
         let mut target_match = 2u8;
         for (ann, arg, _) in self.annotations.iter() {
             if ann.as_str() == "target" {
                 if let Some(arg) = arg {
                     let mut arg = arg.as_str();
-                    let negate = if arg.as_bytes().first() == Some(&0x21) {arg = &arg[1..]; true} else {false};
+                    let negate = if arg.as_bytes().first() == Some(&0x21) {
+                        arg = &arg[1..];
+                        true
+                    } else {
+                        false
+                    };
                     if let Ok(pat) = Pattern::new(arg) {
                         if target_match != 1 {
-                            target_match = u8::from(negate ^ pat.matches(&ctx.module.get_triple().as_str().to_string_lossy()))
+                            target_match = u8::from(
+                                negate
+                                    ^ pat.matches(
+                                        &ctx.module.get_triple().as_str().to_string_lossy(),
+                                    ),
+                            )
                         }
                     }
                 }
             }
         }
-        if target_match == 0 {return}
-        let _ = ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::error(), VariableData::uninit(self.loc))));
+        if target_match == 0 {
+            return;
+        }
+        let _ = ctx.with_vars(|v| {
+            v.insert(
+                &self.name,
+                Symbol(Value::error(), VariableData::uninit(self.loc)),
+            )
+        });
     }
     fn constinit_prepass(&self, ctx: &CompCtx, needs_another: &mut bool) {
         let mut target_match = 2u8;
@@ -594,20 +1083,32 @@ impl AST for ConstDefAST {
             if ann.as_str() == "target" {
                 if let Some(arg) = arg {
                     let mut arg = arg.as_str();
-                    let negate = if arg.as_bytes().first() == Some(&0x21) {arg = &arg[1..]; true} else {false};
+                    let negate = if arg.as_bytes().first() == Some(&0x21) {
+                        arg = &arg[1..];
+                        true
+                    } else {
+                        false
+                    };
                     if let Ok(pat) = Pattern::new(arg) {
                         if target_match != 1 {
-                            target_match = u8::from(negate ^ pat.matches(&ctx.module.get_triple().as_str().to_string_lossy()))
+                            target_match = u8::from(
+                                negate
+                                    ^ pat.matches(
+                                        &ctx.module.get_triple().as_str().to_string_lossy(),
+                                    ),
+                            )
                         }
                     }
                 }
             }
         }
-        if target_match == 0 {return}
+        if target_match == 0 {
+            return;
+        }
         let mut missing = HashSet::new();
         let pp = ctx.prepass.replace(true);
         for err in self.codegen(ctx).1 {
-            if let CobaltError::UninitializedGlobal {name, ..} = err {
+            if let CobaltError::UninitializedGlobal { name, .. } = err {
                 missing.insert(name);
             }
         }
@@ -627,18 +1128,35 @@ impl AST for ConstDefAST {
                 "target" => {
                     if let Some(arg) = arg {
                         let mut arg = arg.as_str();
-                        let negate = if arg.as_bytes().first() == Some(&0x21) {arg = &arg[1..]; true} else {false};
+                        let negate = if arg.as_bytes().first() == Some(&0x21) {
+                            arg = &arg[1..];
+                            true
+                        } else {
+                            false
+                        };
                         match Pattern::new(arg) {
-                            Ok(pat) => if target_match != 1 {target_match = u8::from(negate ^ pat.matches(&ctx.module.get_triple().as_str().to_string_lossy()))},
-                            Err(err) => errs.push(CobaltError::GlobPatternError {pos: err.pos, msg: err.msg.to_string(), loc})
+                            Ok(pat) => {
+                                if target_match != 1 {
+                                    target_match = u8::from(
+                                        negate
+                                            ^ pat.matches(
+                                                &ctx.module.get_triple().as_str().to_string_lossy(),
+                                            ),
+                                    )
+                                }
+                            }
+                            Err(err) => errs.push(CobaltError::GlobPatternError {
+                                pos: err.pos,
+                                msg: err.msg.to_string(),
+                                loc,
+                            }),
                         }
-                    }
-                    else {
+                    } else {
                         errs.push(CobaltError::InvalidAnnArgument {
                             name: "target",
                             found: arg.clone(),
                             expected: Some("target glob"),
-                            loc
+                            loc,
                         });
                     }
                 }
@@ -646,19 +1164,21 @@ impl AST for ConstDefAST {
                     if let Some((_, prev)) = vis_spec {
                         errs.push(CobaltError::RedefAnnArgument {
                             name: "export",
-                            loc, prev
+                            loc,
+                            prev,
                         });
-                    }
-                    else {
+                    } else {
                         match arg.as_deref() {
-                            None | Some("true") | Some("1") | Some("") => vis_spec = Some((true, loc)),
+                            None | Some("true") | Some("1") | Some("") => {
+                                vis_spec = Some((true, loc))
+                            }
                             Some("false") | Some("0") => vis_spec = Some((false, loc)),
                             Some(_) => errs.push(CobaltError::InvalidAnnArgument {
                                 name: "export",
                                 found: arg.clone(),
                                 expected: Some(r#"no argument, "true", or "false""#),
-                                loc
-                            })
+                                loc,
+                            }),
                         }
                     }
                 }
@@ -666,47 +1186,92 @@ impl AST for ConstDefAST {
                     if let Some((_, prev)) = vis_spec {
                         errs.push(CobaltError::RedefAnnArgument {
                             name: "private",
-                            loc, prev
+                            loc,
+                            prev,
                         });
-                    }
-                    else {
+                    } else {
                         match arg.as_deref() {
-                            None | Some("true") | Some("1") | Some("") => vis_spec = Some((false, loc)),
+                            None | Some("true") | Some("1") | Some("") => {
+                                vis_spec = Some((false, loc))
+                            }
                             Some("false") | Some("0") => vis_spec = Some((true, loc)),
                             Some(_) => errs.push(CobaltError::InvalidAnnArgument {
                                 name: "private",
                                 found: arg.clone(),
                                 expected: Some(r#"no argument, "true", or "false""#),
-                                loc
-                            })
+                                loc,
+                            }),
                         }
                     }
                 }
-                _ => errs.push(CobaltError::UnknownAnnotation {loc, name: ann.clone(), def: "constant"})
+                _ => errs.push(CobaltError::UnknownAnnotation {
+                    loc,
+                    name: ann.clone(),
+                    def: "constant",
+                }),
             }
         }
         let vs = vis_spec.map_or(ctx.export.get(), |(v, _)| v);
-        if target_match == 0 {return (Value::null(), errs)}
+        if target_match == 0 {
+            return (Value::null(), errs);
+        }
         let old_is_const = ctx.is_const.replace(true);
         let old_scope = ctx.push_scope(&self.name);
         let val = self.val.codegen_errs(ctx, &mut errs);
         let t2 = val.data_type.clone();
         let dt = if let Some(t) = self.type_.as_ref().map(|t| {
-            let t = ops::impl_convert(t.loc(), (t.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+            let t = ops::impl_convert(
+                t.loc(),
+                (t.codegen_errs(ctx, &mut errs), None),
+                (Type::TypeData, None),
+                ctx,
+            )
+            .map_or_else(
+                |e| {
+                    errs.push(e);
+                    Type::Error
+                },
+                |v| {
+                    if let Some(InterData::Type(t)) = v.inter_val {
+                        *t
+                    } else {
+                        Type::Error
+                    }
+                },
+            );
             t
-        }) {t} else {ops::decay(t2)};
-        let val = ops::impl_convert(self.val.loc(), (val, None), (dt, None), ctx).unwrap_or_else(|e| {
-            errs.push(e);
-            Value::error()
-        });
+        }) {
+            t
+        } else {
+            ops::decay(t2)
+        };
+        let val =
+            ops::impl_convert(self.val.loc(), (val, None), (dt, None), ctx).unwrap_or_else(|e| {
+                errs.push(e);
+                Value::error()
+            });
         ctx.restore_scope(old_scope);
         ctx.is_const.set(old_is_const);
-        match ctx.with_vars(|v| v.insert(&self.name, Symbol(val.freeze(self.loc), VariableData {fwd: ctx.prepass.get(), init: !errs.iter().any(|e| matches!(e, CobaltError::UninitializedGlobal {..})), ..VariableData::with_vis(self.loc, vs)}))) {
+        match ctx.with_vars(|v| {
+            v.insert(
+                &self.name,
+                Symbol(
+                    val.freeze(self.loc),
+                    VariableData {
+                        fwd: ctx.prepass.get(),
+                        init: !errs
+                            .iter()
+                            .any(|e| matches!(e, CobaltError::UninitializedGlobal { .. })),
+                        ..VariableData::with_vis(self.loc, vs)
+                    },
+                ),
+            )
+        }) {
             Ok(x) => (x.0.clone(), errs),
             Err(RedefVariable::NotAModule(x, _)) => {
                 errs.push(CobaltError::NotAModule {
                     loc: self.name.ids[x].1,
-                    name: self.name.start(x).to_string()
+                    name: self.name.start(x).to_string(),
                 });
                 (Value::error(), errs)
             }
@@ -714,21 +1279,37 @@ impl AST for ConstDefAST {
                 errs.push(CobaltError::RedefVariable {
                     loc: self.name.ids[x].1,
                     name: self.name.start(x).to_string(),
-                    prev: d
+                    prev: d,
                 });
                 (Value::error(), errs)
             }
         }
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
         writeln!(f, "const: {}", self.name)?;
         writeln!(f, "{pre}├── annotations:")?;
         pre.push(false);
         for (n, (name, arg, _)) in self.annotations.iter().enumerate() {
-            writeln!(f, "{pre}{}@{name}{}", if n + 1 < self.annotations.len() {"├── "} else {"└── "}, arg.as_ref().map(|x| format!("({x})")).unwrap_or_default())?;
+            writeln!(
+                f,
+                "{pre}{}@{name}{}",
+                if n + 1 < self.annotations.len() {
+                    "├── "
+                } else {
+                    "└── "
+                },
+                arg.as_ref().map(|x| format!("({x})")).unwrap_or_default()
+            )?;
         }
         pre.pop();
-        if let Some(ref ast) = self.type_ {print_ast_child(f, pre, &**ast, false, file)?}
+        if let Some(ref ast) = self.type_ {
+            print_ast_child(f, pre, &**ast, false, file)?
+        }
         print_ast_child(f, pre, &*self.val, true, file)
     }
 }
@@ -739,14 +1320,33 @@ pub struct TypeDefAST {
     pub val: Box<dyn AST>,
     pub annotations: Vec<(String, Option<String>, SourceSpan)>,
     pub methods: Vec<Box<dyn AST>>,
-    lastmissing: CellExt<HashSet<String>>
+    lastmissing: CellExt<HashSet<String>>,
 }
 impl TypeDefAST {
-    pub fn new(loc: SourceSpan, name: DottedName, val: Box<dyn AST>, annotations: Vec<(String, Option<String>, SourceSpan)>, methods: Vec<Box<dyn AST>>) -> Self {TypeDefAST {loc, name, val, annotations, methods, lastmissing: CellExt::default()}}
+    pub fn new(
+        loc: SourceSpan,
+        name: DottedName,
+        val: Box<dyn AST>,
+        annotations: Vec<(String, Option<String>, SourceSpan)>,
+        methods: Vec<Box<dyn AST>>,
+    ) -> Self {
+        TypeDefAST {
+            loc,
+            name,
+            val,
+            annotations,
+            methods,
+            lastmissing: CellExt::default(),
+        }
+    }
 }
 impl AST for TypeDefAST {
-    fn loc(&self) -> SourceSpan {self.loc}
-    fn nodes(&self) -> usize {self.val.nodes() + self.methods.iter().map(|x| x.nodes()).sum::<usize>() + 1}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn nodes(&self) -> usize {
+        self.val.nodes() + self.methods.iter().map(|x| x.nodes()).sum::<usize>() + 1
+    }
     fn varfwd_prepass(&self, ctx: &CompCtx) {
         let mut target_match = 2u8;
         let mut no_auto_drop = true;
@@ -755,10 +1355,20 @@ impl AST for TypeDefAST {
                 "target" => {
                     if let Some(arg) = arg {
                         let mut arg = arg.as_str();
-                        let negate = if arg.as_bytes().first() == Some(&0x21) {arg = &arg[1..]; true} else {false};
+                        let negate = if arg.as_bytes().first() == Some(&0x21) {
+                            arg = &arg[1..];
+                            true
+                        } else {
+                            false
+                        };
                         if let Ok(pat) = Pattern::new(arg) {
                             if target_match != 1 {
-                                target_match = u8::from(negate ^ pat.matches(&ctx.module.get_triple().as_str().to_string_lossy()))
+                                target_match = u8::from(
+                                    negate
+                                        ^ pat.matches(
+                                            &ctx.module.get_triple().as_str().to_string_lossy(),
+                                        ),
+                                )
                             }
                         }
                     }
@@ -767,13 +1377,33 @@ impl AST for TypeDefAST {
                 _ => {}
             }
         }
-        if target_match == 0 {return}
-        let _ = ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::error(), VariableData::uninit(self.loc))));
+        if target_match == 0 {
+            return;
+        }
+        let _ = ctx.with_vars(|v| {
+            v.insert(
+                &self.name,
+                Symbol(Value::error(), VariableData::uninit(self.loc)),
+            )
+        });
         let mangled = ctx.format(&self.name);
         ctx.map_vars(|v| {
             let mut vm = VarMap::new(Some(v));
             let mut noms = ctx.nominals.borrow_mut();
-            if let Some(data) = noms.get_mut(&mangled) {vm.symbols.extend(data.2.clone().into_iter().map(|(k, v)| (k, Symbol(v, VariableData {fwd: true, ..Default::default()}))))}
+            if let Some(data) = noms.get_mut(&mangled) {
+                vm.symbols.extend(data.2.clone().into_iter().map(|(k, v)| {
+                    (
+                        k,
+                        Symbol(
+                            v,
+                            VariableData {
+                                fwd: true,
+                                ..Default::default()
+                            },
+                        ),
+                    )
+                }))
+            }
             Box::new(vm)
         });
         let pp = ctx.prepass.replace(true);
@@ -781,17 +1411,35 @@ impl AST for TypeDefAST {
         ctx.nom_info.borrow_mut().push(Default::default());
         ctx.nom_info.borrow_mut().last_mut().unwrap().no_auto_drop = no_auto_drop;
         ctx.with_vars(|v| {
-            v.symbols.insert("base_t".to_string(), Value::make_type(Type::Null).freeze(self.loc).into());
-            v.symbols.insert("self_t".to_string(), Value::make_type(Type::Nominal(mangled.clone())).freeze(self.loc).into());
+            v.symbols.insert(
+                "base_t".to_string(),
+                Value::make_type(Type::Null).freeze(self.loc).into(),
+            );
+            v.symbols.insert(
+                "self_t".to_string(),
+                Value::make_type(Type::Nominal(mangled.clone()))
+                    .freeze(self.loc)
+                    .into(),
+            );
         });
         {
             let mut noms = ctx.nominals.borrow_mut();
-            if !noms.contains_key(&mangled) {noms.insert(mangled.clone(), (Type::Null, true, Default::default(), Default::default()));}
+            if !noms.contains_key(&mangled) {
+                noms.insert(
+                    mangled.clone(),
+                    (Type::Null, true, Default::default(), Default::default()),
+                );
+            }
         }
         self.methods.iter().for_each(|a| a.varfwd_prepass(ctx));
         let mut noms = ctx.nominals.borrow_mut();
         ctx.restore_scope(old_scope);
-        noms.get_mut(&mangled).unwrap().2 = ctx.map_split_vars(|v| (v.parent.unwrap(), v.symbols.into_iter().map(|(k, v)| (k, v.0)).collect()));
+        noms.get_mut(&mangled).unwrap().2 = ctx.map_split_vars(|v| {
+            (
+                v.parent.unwrap(),
+                v.symbols.into_iter().map(|(k, v)| (k, v.0)).collect(),
+            )
+        });
         noms.get_mut(&mangled).unwrap().3 = ctx.nom_info.borrow_mut().pop().unwrap();
         ctx.prepass.set(pp);
     }
@@ -803,10 +1451,20 @@ impl AST for TypeDefAST {
                 "target" => {
                     if let Some(arg) = arg {
                         let mut arg = arg.as_str();
-                        let negate = if arg.as_bytes().first() == Some(&0x21) {arg = &arg[1..]; true} else {false};
+                        let negate = if arg.as_bytes().first() == Some(&0x21) {
+                            arg = &arg[1..];
+                            true
+                        } else {
+                            false
+                        };
                         if let Ok(pat) = Pattern::new(arg) {
                             if target_match != 1 {
-                                target_match = u8::from(negate ^ pat.matches(&ctx.module.get_triple().as_str().to_string_lossy()))
+                                target_match = u8::from(
+                                    negate
+                                        ^ pat.matches(
+                                            &ctx.module.get_triple().as_str().to_string_lossy(),
+                                        ),
+                                )
                             }
                         }
                     }
@@ -815,11 +1473,13 @@ impl AST for TypeDefAST {
                 _ => {}
             }
         }
-        if target_match == 0 {return}
+        if target_match == 0 {
+            return;
+        }
         let mut missing = HashSet::new();
         let pp = ctx.prepass.replace(true);
         for err in self.codegen(ctx).1 {
-            if let CobaltError::UninitializedGlobal {name, ..} = err {
+            if let CobaltError::UninitializedGlobal { name, .. } = err {
                 missing.insert(name);
             }
         }
@@ -831,24 +1491,57 @@ impl AST for TypeDefAST {
         ctx.map_vars(|v| {
             let mut vm = VarMap::new(Some(v));
             let mut noms = ctx.nominals.borrow_mut();
-            if let Some(data) = noms.get_mut(&mangled) {vm.symbols.extend(data.2.clone().into_iter().map(|(k, v)| (k, Symbol(v, VariableData {fwd: true, ..Default::default()}))))}
+            if let Some(data) = noms.get_mut(&mangled) {
+                vm.symbols.extend(data.2.clone().into_iter().map(|(k, v)| {
+                    (
+                        k,
+                        Symbol(
+                            v,
+                            VariableData {
+                                fwd: true,
+                                ..Default::default()
+                            },
+                        ),
+                    )
+                }))
+            }
             Box::new(vm)
         });
         let old_scope = ctx.push_scope(&self.name);
         ctx.nom_info.borrow_mut().push(Default::default());
         ctx.nom_info.borrow_mut().last_mut().unwrap().no_auto_drop = no_auto_drop;
         ctx.with_vars(|v| {
-            v.symbols.insert("base_t".to_string(), Value::make_type(Type::Null).freeze(self.loc).into());
-            v.symbols.insert("self_t".to_string(), Value::make_type(Type::Nominal(mangled.clone())).freeze(self.loc).into());
+            v.symbols.insert(
+                "base_t".to_string(),
+                Value::make_type(Type::Null).freeze(self.loc).into(),
+            );
+            v.symbols.insert(
+                "self_t".to_string(),
+                Value::make_type(Type::Nominal(mangled.clone()))
+                    .freeze(self.loc)
+                    .into(),
+            );
         });
         {
             let mut noms = ctx.nominals.borrow_mut();
-            if !noms.contains_key(&mangled) {noms.insert(mangled.clone(), (Type::Null, true, Default::default(), Default::default()));}
+            if !noms.contains_key(&mangled) {
+                noms.insert(
+                    mangled.clone(),
+                    (Type::Null, true, Default::default(), Default::default()),
+                );
+            }
         }
-        self.methods.iter().for_each(|a| a.constinit_prepass(ctx, needs_another));
+        self.methods
+            .iter()
+            .for_each(|a| a.constinit_prepass(ctx, needs_another));
         let mut noms = ctx.nominals.borrow_mut();
         ctx.restore_scope(old_scope);
-        noms.get_mut(&mangled).unwrap().2 = ctx.map_split_vars(|v| (v.parent.unwrap(), v.symbols.into_iter().map(|(k, v)| (k, v.0)).collect()));
+        noms.get_mut(&mangled).unwrap().2 = ctx.map_split_vars(|v| {
+            (
+                v.parent.unwrap(),
+                v.symbols.into_iter().map(|(k, v)| (k, v.0)).collect(),
+            )
+        });
         noms.get_mut(&mangled).unwrap().3 = ctx.nom_info.borrow_mut().pop().unwrap();
         ctx.prepass.set(pp);
     }
@@ -861,10 +1554,20 @@ impl AST for TypeDefAST {
                 "target" => {
                     if let Some(arg) = arg {
                         let mut arg = arg.as_str();
-                        let negate = if arg.as_bytes().first() == Some(&0x21) {arg = &arg[1..]; true} else {false};
+                        let negate = if arg.as_bytes().first() == Some(&0x21) {
+                            arg = &arg[1..];
+                            true
+                        } else {
+                            false
+                        };
                         if let Ok(pat) = Pattern::new(arg) {
                             if target_match != 1 {
-                                target_match = u8::from(negate ^ pat.matches(&ctx.module.get_triple().as_str().to_string_lossy()))
+                                target_match = u8::from(
+                                    negate
+                                        ^ pat.matches(
+                                            &ctx.module.get_triple().as_str().to_string_lossy(),
+                                        ),
+                                )
                             }
                         }
                     }
@@ -891,30 +1594,68 @@ impl AST for TypeDefAST {
                 _ => {}
             }
         }
-        if target_match == 0 {return}
+        if target_match == 0 {
+            return;
+        }
         let mangled = ctx.format(&self.name);
         ctx.map_vars(|v| {
             let mut vm = VarMap::new(Some(v));
             let mut noms = ctx.nominals.borrow_mut();
-            if let Some(data) = noms.get_mut(&mangled) {vm.symbols.extend(data.2.clone().into_iter().map(|(k, v)| (k, Symbol(v, VariableData {fwd: true, ..Default::default()}))))}
+            if let Some(data) = noms.get_mut(&mangled) {
+                vm.symbols.extend(data.2.clone().into_iter().map(|(k, v)| {
+                    (
+                        k,
+                        Symbol(
+                            v,
+                            VariableData {
+                                fwd: true,
+                                ..Default::default()
+                            },
+                        ),
+                    )
+                }))
+            }
             Box::new(vm)
         });
         let old_scope = ctx.push_scope(&self.name);
         ctx.nom_info.borrow_mut().push(Default::default());
         ctx.nom_info.borrow_mut().last_mut().unwrap().no_auto_drop = no_auto_drop;
-        let ty = ops::impl_convert(unreachable_span(), (self.val.const_codegen(ctx).0, None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).unwrap_or(Type::Error);
+        let ty = ops::impl_convert(
+            unreachable_span(),
+            (self.val.const_codegen(ctx).0, None),
+            (Type::TypeData, None),
+            ctx,
+        )
+        .ok()
+        .and_then(Value::into_type)
+        .unwrap_or(Type::Error);
         ctx.with_vars(|v| {
-            v.symbols.insert("base_t".to_string(), Value::make_type(ty.clone()).freeze(self.loc).into());
-            v.symbols.insert("self_t".to_string(), Value::make_type(Type::Nominal(mangled.clone())).freeze(self.loc).into());
+            v.symbols.insert(
+                "base_t".to_string(),
+                Value::make_type(ty.clone()).freeze(self.loc).into(),
+            );
+            v.symbols.insert(
+                "self_t".to_string(),
+                Value::make_type(Type::Nominal(mangled.clone()))
+                    .freeze(self.loc)
+                    .into(),
+            );
         });
         match ctx.nominals.borrow_mut().entry(mangled.clone()) {
             Entry::Occupied(mut x) => x.get_mut().0 = ty,
-            Entry::Vacant(x) => {x.insert((ty, true, Default::default(), Default::default()));}
+            Entry::Vacant(x) => {
+                x.insert((ty, true, Default::default(), Default::default()));
+            }
         }
         self.methods.iter().for_each(|a| a.fwddef_prepass(ctx));
         let mut noms = ctx.nominals.borrow_mut();
         ctx.restore_scope(old_scope);
-        noms.get_mut(&mangled).unwrap().2 = ctx.map_split_vars(|v| (v.parent.unwrap(), v.symbols.into_iter().map(|(k, v)| (k, v.0)).collect()));
+        noms.get_mut(&mangled).unwrap().2 = ctx.map_split_vars(|v| {
+            (
+                v.parent.unwrap(),
+                v.symbols.into_iter().map(|(k, v)| (k, v.0)).collect(),
+            )
+        });
         noms.get_mut(&mangled).unwrap().3 = ctx.nom_info.borrow_mut().pop().unwrap();
     }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
@@ -928,18 +1669,35 @@ impl AST for TypeDefAST {
                 "target" => {
                     if let Some(arg) = arg {
                         let mut arg = arg.as_str();
-                        let negate = if arg.as_bytes().first() == Some(&0x21) {arg = &arg[1..]; true} else {false};
+                        let negate = if arg.as_bytes().first() == Some(&0x21) {
+                            arg = &arg[1..];
+                            true
+                        } else {
+                            false
+                        };
                         match Pattern::new(arg) {
-                            Ok(pat) => if target_match != 1 {target_match = u8::from(negate ^ pat.matches(&ctx.module.get_triple().as_str().to_string_lossy()))},
-                            Err(err) => errs.push(CobaltError::GlobPatternError {pos: err.pos, msg: err.msg.to_string(), loc})
+                            Ok(pat) => {
+                                if target_match != 1 {
+                                    target_match = u8::from(
+                                        negate
+                                            ^ pat.matches(
+                                                &ctx.module.get_triple().as_str().to_string_lossy(),
+                                            ),
+                                    )
+                                }
+                            }
+                            Err(err) => errs.push(CobaltError::GlobPatternError {
+                                pos: err.pos,
+                                msg: err.msg.to_string(),
+                                loc,
+                            }),
                         }
-                    }
-                    else {
+                    } else {
                         errs.push(CobaltError::InvalidAnnArgument {
                             name: "target",
                             found: arg.clone(),
                             expected: Some("target glob"),
-                            loc
+                            loc,
                         });
                     }
                 }
@@ -947,19 +1705,21 @@ impl AST for TypeDefAST {
                     if let Some((_, prev)) = vis_spec {
                         errs.push(CobaltError::RedefAnnArgument {
                             name: "export",
-                            loc, prev
+                            loc,
+                            prev,
                         });
-                    }
-                    else {
+                    } else {
                         match arg.as_deref() {
-                            None | Some("true") | Some("1") | Some("") => vis_spec = Some((true, loc)),
+                            None | Some("true") | Some("1") | Some("") => {
+                                vis_spec = Some((true, loc))
+                            }
                             Some("false") | Some("0") => vis_spec = Some((false, loc)),
                             Some(_) => errs.push(CobaltError::InvalidAnnArgument {
                                 name: "export",
                                 found: arg.clone(),
                                 expected: Some(r#"no argument, "true", or "false""#),
-                                loc
-                            })
+                                loc,
+                            }),
                         }
                     }
                 }
@@ -967,19 +1727,21 @@ impl AST for TypeDefAST {
                     if let Some((_, prev)) = vis_spec {
                         errs.push(CobaltError::RedefAnnArgument {
                             name: "private",
-                            loc, prev
+                            loc,
+                            prev,
                         });
-                    }
-                    else {
+                    } else {
                         match arg.as_deref() {
-                            None | Some("true") | Some("1") | Some("") => vis_spec = Some((false, loc)),
+                            None | Some("true") | Some("1") | Some("") => {
+                                vis_spec = Some((false, loc))
+                            }
                             Some("false") | Some("0") => vis_spec = Some((true, loc)),
                             Some(_) => errs.push(CobaltError::InvalidAnnArgument {
                                 name: "private",
                                 found: arg.clone(),
                                 expected: Some(r#"no argument, "true", or "false""#),
-                                loc
-                            })
+                                loc,
+                            }),
                         }
                     }
                 }
@@ -987,57 +1749,127 @@ impl AST for TypeDefAST {
                     if let Some(prev) = no_auto_drop {
                         errs.push(CobaltError::RedefAnnArgument {
                             name: "no_auto_drop",
-                            loc, prev
+                            loc,
+                            prev,
                         });
-                    }
-                    else {
+                    } else {
                         if arg.is_some() {
                             errs.push(CobaltError::InvalidAnnArgument {
                                 name: "no_auto_drop",
                                 found: arg.clone(),
                                 expected: None,
-                                loc
+                                loc,
                             })
                         }
                         no_auto_drop = Some(loc);
                     }
                 }
-                _ => errs.push(CobaltError::UnknownAnnotation {loc, name: ann.clone(), def: "type"})
+                _ => errs.push(CobaltError::UnknownAnnotation {
+                    loc,
+                    name: ann.clone(),
+                    def: "type",
+                }),
             }
         }
         let vs = vis_spec.map_or(ctx.export.get(), |(v, _)| v);
-        if target_match == 0 {return (Value::null(), errs)}
-        let ty = ops::impl_convert(self.val.loc(), (self.val.codegen_errs(ctx, &mut errs), None), (Type::TypeData, None), ctx).map_or_else(|e| {errs.push(e); Type::Error}, |v| if let Some(InterData::Type(t)) = v.inter_val {*t} else {Type::Error});
+        if target_match == 0 {
+            return (Value::null(), errs);
+        }
+        let ty = ops::impl_convert(
+            self.val.loc(),
+            (self.val.codegen_errs(ctx, &mut errs), None),
+            (Type::TypeData, None),
+            ctx,
+        )
+        .map_or_else(
+            |e| {
+                errs.push(e);
+                Type::Error
+            },
+            |v| {
+                if let Some(InterData::Type(t)) = v.inter_val {
+                    *t
+                } else {
+                    Type::Error
+                }
+            },
+        );
         let mangled = ctx.format(&self.name);
         ctx.map_vars(|v| {
             let mut vm = VarMap::new(Some(v));
             let mut noms = ctx.nominals.borrow_mut();
-            if let Some(data) = noms.get_mut(&mangled) {vm.symbols.extend(data.2.clone().into_iter().map(|(k, v)| (k, Symbol(v, VariableData {fwd: true, ..Default::default()}))))}
+            if let Some(data) = noms.get_mut(&mangled) {
+                vm.symbols.extend(data.2.clone().into_iter().map(|(k, v)| {
+                    (
+                        k,
+                        Symbol(
+                            v,
+                            VariableData {
+                                fwd: true,
+                                ..Default::default()
+                            },
+                        ),
+                    )
+                }))
+            }
             Box::new(vm)
         });
         let old_scope = ctx.push_scope(&self.name);
         ctx.nom_info.borrow_mut().push(Default::default());
         ctx.nom_info.borrow_mut().last_mut().unwrap().no_auto_drop = no_auto_drop.is_some();
         ctx.with_vars(|v| {
-            v.symbols.insert("base_t".to_string(), Value::make_type(ty.clone()).freeze(self.loc).into());
-            v.symbols.insert("self_t".to_string(), Value::make_type(Type::Nominal(mangled.clone())).freeze(self.loc).into());
+            v.symbols.insert(
+                "base_t".to_string(),
+                Value::make_type(ty.clone()).freeze(self.loc).into(),
+            );
+            v.symbols.insert(
+                "self_t".to_string(),
+                Value::make_type(Type::Nominal(mangled.clone()))
+                    .freeze(self.loc)
+                    .into(),
+            );
         });
         match ctx.nominals.borrow_mut().entry(mangled.clone()) {
             Entry::Occupied(mut x) => x.get_mut().0 = ty,
-            Entry::Vacant(x) => {x.insert((ty, true, Default::default(), Default::default()));}
+            Entry::Vacant(x) => {
+                x.insert((ty, true, Default::default(), Default::default()));
+            }
         }
-        if !ctx.prepass.get() {self.methods.iter().for_each(|a| {a.codegen_errs(ctx, &mut errs);});}
+        if !ctx.prepass.get() {
+            self.methods.iter().for_each(|a| {
+                a.codegen_errs(ctx, &mut errs);
+            });
+        }
         let mut noms = ctx.nominals.borrow_mut();
         ctx.restore_scope(old_scope);
-        noms.get_mut(&mangled).unwrap().2 = ctx.map_split_vars(|v| (v.parent.unwrap(), v.symbols.into_iter().map(|(k, v)| (k, v.0)).collect()));
+        noms.get_mut(&mangled).unwrap().2 = ctx.map_split_vars(|v| {
+            (
+                v.parent.unwrap(),
+                v.symbols.into_iter().map(|(k, v)| (k, v.0)).collect(),
+            )
+        });
         noms.get_mut(&mangled).unwrap().3 = ctx.nom_info.borrow_mut().pop().unwrap();
-        match ctx.with_vars(|v| v.insert(&self.name, Symbol(Value::make_type(Type::Nominal(mangled.clone())).freeze(self.loc), VariableData {fwd: ctx.prepass.get(), init: !errs.iter().any(|e| matches!(e, CobaltError::UninitializedGlobal {..})), ..VariableData::with_vis(self.loc, vs)}))) {
+        match ctx.with_vars(|v| {
+            v.insert(
+                &self.name,
+                Symbol(
+                    Value::make_type(Type::Nominal(mangled.clone())).freeze(self.loc),
+                    VariableData {
+                        fwd: ctx.prepass.get(),
+                        init: !errs
+                            .iter()
+                            .any(|e| matches!(e, CobaltError::UninitializedGlobal { .. })),
+                        ..VariableData::with_vis(self.loc, vs)
+                    },
+                ),
+            )
+        }) {
             Ok(x) => (x.0.clone(), errs),
             Err(RedefVariable::NotAModule(x, _)) => {
                 noms.remove(&mangled);
                 errs.push(CobaltError::NotAModule {
                     loc: self.name.ids[x].1,
-                    name: self.name.start(x).to_string()
+                    name: self.name.start(x).to_string(),
                 });
                 (Value::error(), errs)
             }
@@ -1046,18 +1878,32 @@ impl AST for TypeDefAST {
                 errs.push(CobaltError::RedefVariable {
                     loc: self.name.ids[x].1,
                     name: self.name.start(x).to_string(),
-                    prev: d
+                    prev: d,
                 });
                 (Value::error(), errs)
             }
         }
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, pre: &mut TreePrefix, file: Option<CobaltFile>) -> std::fmt::Result {
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
         writeln!(f, "type: {}", self.name)?;
         writeln!(f, "{pre}├── annotations:")?;
         pre.push(false);
         for (n, (name, arg, _)) in self.annotations.iter().enumerate() {
-            writeln!(f, "{pre}{}@{name}{}", if n + 1 < self.annotations.len() {"├── "} else {"└── "}, arg.as_ref().map(|x| format!("({x})")).unwrap_or_default())?;
+            writeln!(
+                f,
+                "{pre}{}@{name}{}",
+                if n + 1 < self.annotations.len() {
+                    "├── "
+                } else {
+                    "└── "
+                },
+                arg.as_ref().map(|x| format!("({x})")).unwrap_or_default()
+            )?;
         }
         pre.pop();
         print_ast_child(f, pre, &*self.val, self.methods.is_empty(), file)?;
@@ -1078,28 +1924,52 @@ impl AST for TypeDefAST {
 pub struct VarGetAST {
     loc: SourceSpan,
     pub name: String,
-    pub global: bool
+    pub global: bool,
 }
 impl VarGetAST {
-    pub fn new(loc: SourceSpan, name: String, global: bool) -> Self {VarGetAST {loc, name, global}}
+    pub fn new(loc: SourceSpan, name: String, global: bool) -> Self {
+        VarGetAST { loc, name, global }
+    }
 }
 impl AST for VarGetAST {
-    fn loc(&self) -> SourceSpan {self.loc}
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         match ctx.lookup(&self.name, self.global) {
-            Some(Symbol(x, d)) if d.scope.map_or(true, |x| x.get() == ctx.var_scope.get()) => (x.clone(), if d.init {vec![]} else {vec![CobaltError::UninitializedGlobal {
-                name: self.name.clone(),
-                loc: self.loc
-            }]}),
-            _ => (Value::error(), vec![CobaltError::VariableDoesNotExist {
-                name: self.name.clone(),
-                module: String::new(),
-                container: "",
-                loc: self.loc
-            }])
+            Some(Symbol(x, d)) if d.scope.map_or(true, |x| x.get() == ctx.var_scope.get()) => (
+                x.clone(),
+                if d.init {
+                    vec![]
+                } else {
+                    vec![CobaltError::UninitializedGlobal {
+                        name: self.name.clone(),
+                        loc: self.loc,
+                    }]
+                },
+            ),
+            _ => (
+                Value::error(),
+                vec![CobaltError::VariableDoesNotExist {
+                    name: self.name.clone(),
+                    module: String::new(),
+                    container: "",
+                    loc: self.loc,
+                }],
+            ),
         }
     }
-    fn print_impl(&self, f: &mut std::fmt::Formatter, _pre: &mut TreePrefix, _file: Option<CobaltFile>) -> std::fmt::Result {
-        writeln!(f, "var: {}{}", if self.global {"."} else {""}, self.name)
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        _pre: &mut TreePrefix,
+        _file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
+        writeln!(
+            f,
+            "var: {}{}",
+            if self.global { "." } else { "" },
+            self.name
+        )
     }
 }

--- a/cobalt-ast/src/context.rs
+++ b/cobalt-ast/src/context.rs
@@ -1,13 +1,13 @@
-use inkwell::{context::Context, module::Module, builder::Builder};
 use crate::*;
-use std::pin::Pin;
-use std::mem::MaybeUninit;
-use std::cell::{Cell, RefCell};
-use std::collections::hash_map::{HashMap, Entry};
-use std::collections::HashSet;
-use std::io::{self, Write, Read, BufRead};
 use either::Either::{self, *};
+use inkwell::{builder::Builder, context::Context, module::Module};
 use owned_chars::OwnedCharsExt;
+use std::cell::{Cell, RefCell};
+use std::collections::hash_map::{Entry, HashMap};
+use std::collections::HashSet;
+use std::io::{self, BufRead, Read, Write};
+use std::mem::MaybeUninit;
+use std::pin::Pin;
 pub struct CompCtx<'ctx> {
     pub flags: Flags,
     pub context: &'ctx Context,
@@ -21,13 +21,14 @@ pub struct CompCtx<'ctx> {
     pub priority: Counter<i32>,
     pub var_scope: Counter<usize>,
     pub lex_scope: Counter<usize>,
-    pub nominals: RefCell<HashMap<String, (Type, bool, HashMap<String, Value<'ctx>>, NominalInfo<'ctx>)>>,
+    pub nominals:
+        RefCell<HashMap<String, (Type, bool, HashMap<String, Value<'ctx>>, NominalInfo<'ctx>)>>,
     pub moves: RefCell<(HashSet<cfg::Use<'ctx>>, HashSet<cfg::Store<'ctx>>)>,
     pub nom_info: RefCell<Vec<NominalInfo<'ctx>>>,
     pub to_drop: RefCell<Vec<Vec<Value<'ctx>>>>,
     int_types: Cell<MaybeUninit<HashMap<(u16, bool), Symbol<'ctx>>>>,
     vars: Cell<Option<Pin<Box<VarMap<'ctx>>>>>,
-    name: Cell<MaybeUninit<String>>
+    name: Cell<MaybeUninit<String>>,
 }
 impl<'ctx> CompCtx<'ctx> {
     pub fn new(ctx: &'ctx Context, name: &str) -> Self {
@@ -49,18 +50,48 @@ impl<'ctx> CompCtx<'ctx> {
             nom_info: RefCell::default(),
             to_drop: RefCell::default(),
             int_types: Cell::new(MaybeUninit::new(HashMap::new())),
-            vars: Cell::new(Some(Box::pin(VarMap::new(Some([
-                ("true", Value::interpreted(ctx.bool_type().const_int(1, false).into(), InterData::Int(1), Type::Int(1, false)).into()),
-                ("false", Value::interpreted(ctx.bool_type().const_int(0, false).into(), InterData::Int(0), Type::Int(1, false)).into()),
-                ("bool", Value::make_type(Type::Int(1, false)).into()),
-                ("f16", Value::make_type(Type::Float16).into()),
-                ("f32", Value::make_type(Type::Float32).into()),
-                ("f64", Value::make_type(Type::Float64).into()),
-                ("f128", Value::make_type(Type::Float128).into()),
-                ("isize", Value::make_type(Type::Int(std::mem::size_of::<isize>() as u16 * 8, false)).into()),
-                ("usize", Value::make_type(Type::Int(std::mem::size_of::<isize>() as u16 * 8, true)).into()),
-            ].into_iter().map(|(k, v)| (k.to_string(), v)).collect::<HashMap<_, _>>().into()))))),
-            name: Cell::new(MaybeUninit::new(".".to_string()))
+            vars: Cell::new(Some(Box::pin(VarMap::new(Some(
+                [
+                    (
+                        "true",
+                        Value::interpreted(
+                            ctx.bool_type().const_int(1, false).into(),
+                            InterData::Int(1),
+                            Type::Int(1, false),
+                        )
+                        .into(),
+                    ),
+                    (
+                        "false",
+                        Value::interpreted(
+                            ctx.bool_type().const_int(0, false).into(),
+                            InterData::Int(0),
+                            Type::Int(1, false),
+                        )
+                        .into(),
+                    ),
+                    ("bool", Value::make_type(Type::Int(1, false)).into()),
+                    ("f16", Value::make_type(Type::Float16).into()),
+                    ("f32", Value::make_type(Type::Float32).into()),
+                    ("f64", Value::make_type(Type::Float64).into()),
+                    ("f128", Value::make_type(Type::Float128).into()),
+                    (
+                        "isize",
+                        Value::make_type(Type::Int(std::mem::size_of::<isize>() as u16 * 8, false))
+                            .into(),
+                    ),
+                    (
+                        "usize",
+                        Value::make_type(Type::Int(std::mem::size_of::<isize>() as u16 * 8, true))
+                            .into(),
+                    ),
+                ]
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect::<HashMap<_, _>>()
+                .into(),
+            ))))),
+            name: Cell::new(MaybeUninit::new(".".to_string())),
         }
     }
     pub fn with_flags(ctx: &'ctx Context, name: &str, flags: Flags) -> Self {
@@ -81,75 +112,124 @@ impl<'ctx> CompCtx<'ctx> {
             nom_info: RefCell::default(),
             to_drop: RefCell::default(),
             int_types: Cell::new(MaybeUninit::new(HashMap::new())),
-            vars: Cell::new(Some(Box::pin(VarMap::new(Some([
-                ("true", Value::interpreted(ctx.bool_type().const_int(1, false).into(), InterData::Int(1), Type::Int(1, false)).into()),
-                ("false", Value::interpreted(ctx.bool_type().const_int(0, false).into(), InterData::Int(0), Type::Int(1, false)).into()),
-                ("bool", Value::make_type(Type::Int(1, false)).into()),
-                ("f16", Value::make_type(Type::Float16).into()),
-                ("f32", Value::make_type(Type::Float32).into()),
-                ("f64", Value::make_type(Type::Float64).into()),
-                ("f128", Value::make_type(Type::Float128).into()),
-                ("isize", Value::make_type(Type::Int(flags.word_size * 8, false)).into()),
-                ("usize", Value::make_type(Type::Int(flags.word_size * 8, true)).into()),
-            ].into_iter().map(|(k, v)| (k.to_string(), v)).collect::<HashMap<_, _>>().into()))))),
+            vars: Cell::new(Some(Box::pin(VarMap::new(Some(
+                [
+                    (
+                        "true",
+                        Value::interpreted(
+                            ctx.bool_type().const_int(1, false).into(),
+                            InterData::Int(1),
+                            Type::Int(1, false),
+                        )
+                        .into(),
+                    ),
+                    (
+                        "false",
+                        Value::interpreted(
+                            ctx.bool_type().const_int(0, false).into(),
+                            InterData::Int(0),
+                            Type::Int(1, false),
+                        )
+                        .into(),
+                    ),
+                    ("bool", Value::make_type(Type::Int(1, false)).into()),
+                    ("f16", Value::make_type(Type::Float16).into()),
+                    ("f32", Value::make_type(Type::Float32).into()),
+                    ("f64", Value::make_type(Type::Float64).into()),
+                    ("f128", Value::make_type(Type::Float128).into()),
+                    (
+                        "isize",
+                        Value::make_type(Type::Int(flags.word_size * 8, false)).into(),
+                    ),
+                    (
+                        "usize",
+                        Value::make_type(Type::Int(flags.word_size * 8, true)).into(),
+                    ),
+                ]
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect::<HashMap<_, _>>()
+                .into(),
+            ))))),
             name: Cell::new(MaybeUninit::new(".".to_string())),
-            flags
+            flags,
         }
     }
     pub fn with_vars<'a, R, F: FnOnce(&'a mut VarMap<'ctx>) -> R>(&'a self, f: F) -> R {
         let mut val = self.vars.take().expect("recursive access to VarMap!");
-        let out = f(unsafe {std::mem::transmute(val.as_mut().get_mut())}); // reference stuff
+        let out = f(unsafe { std::mem::transmute(val.as_mut().get_mut()) }); // reference stuff
         self.vars.set(Some(val));
         out
     }
     pub fn map_vars<F: FnOnce(Box<VarMap<'ctx>>) -> Box<VarMap<'ctx>>>(&self, f: F) -> &Self {
-        self.vars.set(Some(Pin::new(f(Pin::into_inner(self.vars.take().expect("recursive access to VarMap!"))))));
+        self.vars.set(Some(Pin::new(f(Pin::into_inner(
+            self.vars.take().expect("recursive access to VarMap!"),
+        )))));
         self
     }
-    pub fn map_split_vars<R, F: FnOnce(Box<VarMap<'ctx>>) -> (Box<VarMap<'ctx>>, R)>(&self, f: F) -> R {
-        let (v, out) = f(Pin::into_inner(self.vars.take().expect("recursive access to VarMap!")));
+    pub fn map_split_vars<R, F: FnOnce(Box<VarMap<'ctx>>) -> (Box<VarMap<'ctx>>, R)>(
+        &self,
+        f: F,
+    ) -> R {
+        let (v, out) = f(Pin::into_inner(
+            self.vars.take().expect("recursive access to VarMap!"),
+        ));
         self.vars.set(Some(Pin::new(v)));
         out
     }
     pub fn is_cfunc(&self, name: &DottedName) -> bool {
-        name.ids.len() == 1 && (name.global || unsafe {
-            let base = self.name.replace(MaybeUninit::uninit()).assume_init();
-            let b = base == ".";
-            self.name.set(MaybeUninit::new(base));
-            b
-        }) && matches!(name.ids.last().unwrap().0.as_str(), "main") // this match will become larger if more intrinisic stuff is needed
+        name.ids.len() == 1
+            && (name.global
+                || unsafe {
+                    let base = self.name.replace(MaybeUninit::uninit()).assume_init();
+                    let b = base == ".";
+                    self.name.set(MaybeUninit::new(base));
+                    b
+                })
+            && matches!(name.ids.last().unwrap().0.as_str(), "main") // this match will become larger if more intrinisic stuff is needed
     }
     pub fn mangle(&self, name: &DottedName) -> String {
-        let raw = 
-            if name.global {format!("{name}")}
-            else {
-                unsafe {
-                    let base = self.name.replace(MaybeUninit::uninit()).assume_init();
-                    let out = format!("{base}{name}");
-                    self.name.set(MaybeUninit::new(base));
-                    out
-                }
-            };
-        if self.flags.dbg_mangle {raw}
-        else {
-            std::iter::once("_C".to_string()).chain(raw.split('.').skip(1).map(|x| format!("{}{}", x.len(), x))).flat_map(|x| x.into_chars()).collect()
-        }
-    }
-    pub fn format(&self, name: &DottedName) -> String {
-        (if name.global {format!("{name}")}
-        else {
+        let raw = if name.global {
+            format!("{name}")
+        } else {
             unsafe {
                 let base = self.name.replace(MaybeUninit::uninit()).assume_init();
                 let out = format!("{base}{name}");
                 self.name.set(MaybeUninit::new(base));
                 out
             }
-        })[1..].to_string()
+        };
+        if self.flags.dbg_mangle {
+            raw
+        } else {
+            std::iter::once("_C".to_string())
+                .chain(raw.split('.').skip(1).map(|x| format!("{}{}", x.len(), x)))
+                .flat_map(|x| x.into_chars())
+                .collect()
+        }
+    }
+    pub fn format(&self, name: &DottedName) -> String {
+        (if name.global {
+            format!("{name}")
+        } else {
+            unsafe {
+                let base = self.name.replace(MaybeUninit::uninit()).assume_init();
+                let out = format!("{base}{name}");
+                self.name.set(MaybeUninit::new(base));
+                out
+            }
+        })[1..]
+            .to_string()
     }
     pub fn push_scope(&self, name: &DottedName) -> Either<usize, String> {
         unsafe {
-            if name.global {Right(self.name.replace(MaybeUninit::new(name.to_string())).assume_init())}
-            else {
+            if name.global {
+                Right(
+                    self.name
+                        .replace(MaybeUninit::new(name.to_string()))
+                        .assume_init(),
+                )
+            } else {
                 let mut old = self.name.replace(MaybeUninit::uninit()).assume_init();
                 let len = old.len();
                 old += &format!("{name}.");
@@ -165,7 +245,7 @@ impl<'ctx> CompCtx<'ctx> {
                 old.truncate(len);
                 self.name.set(MaybeUninit::new(old));
             },
-            Right(old) => self.name.set(MaybeUninit::new(old))
+            Right(old) => self.name.set(MaybeUninit::new(old)),
         }
     }
     pub fn get_int_symbol(&self, size: u16, unsigned: bool) -> &Symbol<'ctx> {
@@ -173,41 +253,72 @@ impl<'ctx> CompCtx<'ctx> {
             let mut val = self.int_types.replace(MaybeUninit::uninit()).assume_init();
             let out = std::mem::transmute::<&mut _, &'ctx _>(match val.entry((size, unsigned)) {
                 Entry::Occupied(x) => x.into_mut(),
-                Entry::Vacant(x) => x.insert(Value::make_type(Type::Int(size, unsigned)).into())
+                Entry::Vacant(x) => x.insert(Value::make_type(Type::Int(size, unsigned)).into()),
             });
             self.int_types.set(MaybeUninit::new(val));
             out
         }
     }
     pub fn lookup(&self, name: &str, global: bool) -> Option<&Symbol<'ctx>> {
-        self.with_vars(|v| v.lookup(name, global)).or_else(|| match name {
-            x if x.as_bytes()[0] == 0x69 && x.len() > 1 && x[1..].chars().all(char::is_numeric) => Some(self.get_int_symbol(x[1..].parse().unwrap_or(64), false)),
-            x if x.as_bytes()[0] == 0x75 && x.len() > 1 && x[1..].chars().all(char::is_numeric) => Some(self.get_int_symbol(x[1..].parse().unwrap_or(64), true)),
-            _ => None
-        })
+        self.with_vars(|v| v.lookup(name, global))
+            .or_else(|| match name {
+                x if x.as_bytes()[0] == 0x69
+                    && x.len() > 1
+                    && x[1..].chars().all(char::is_numeric) =>
+                {
+                    Some(self.get_int_symbol(x[1..].parse().unwrap_or(64), false))
+                }
+                x if x.as_bytes()[0] == 0x75
+                    && x.len() > 1
+                    && x[1..].chars().all(char::is_numeric) =>
+                {
+                    Some(self.get_int_symbol(x[1..].parse().unwrap_or(64), true))
+                }
+                _ => None,
+            })
     }
     pub fn lookup_full(&self, name: &DottedName) -> Option<Value<'ctx>> {
         let v = self.lookup(&name.ids.first()?.0, name.global)?;
-        if !v.1.init {return None}
+        if !v.1.init {
+            return None;
+        }
         let mut v = v.0.clone();
         for name in name.ids[1..].iter() {
             v = match v {
-                Value {data_type: Type::Module, inter_val: Some(InterData::Module(s, i, _)), ..} => self.with_vars(|v| VarMap::lookup_in_mod((&s, &i), &name.0, v)).and_then(|Symbol(v, d)| if d.init {Some(v)} else {None})?.clone(),
-                Value {data_type: Type::TypeData, inter_val: Some(InterData::Type(t)), ..} => {
+                Value {
+                    data_type: Type::Module,
+                    inter_val: Some(InterData::Module(s, i, _)),
+                    ..
+                } => self
+                    .with_vars(|v| VarMap::lookup_in_mod((&s, &i), &name.0, v))
+                    .and_then(|Symbol(v, d)| if d.init { Some(v) } else { None })?
+                    .clone(),
+                Value {
+                    data_type: Type::TypeData,
+                    inter_val: Some(InterData::Type(t)),
+                    ..
+                } => {
                     if let Type::Nominal(n) = *t {
                         self.nominals.borrow()[&n].2.get(&name.0)?.clone()
-                    }
-                    else {
-                        return None
+                    } else {
+                        return None;
                     }
                 }
-                x => ops::attr((x, unreachable_span()), (&name.0, unreachable_span()), self).ok()?
+                x => {
+                    ops::attr((x, unreachable_span()), (&name.0, unreachable_span()), self).ok()?
+                }
             };
         }
         Some(v)
     }
     pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {
-        self.with_vars(|v| v.symbols.values().for_each(|s| if s.1.export {s.0.data_type.export(self)}));
+        self.with_vars(|v| {
+            v.symbols.values().for_each(|s| {
+                if s.1.export {
+                    s.0.data_type.export(self)
+                }
+            })
+        });
         for (n, (t, e, m, i)) in self.nominals.borrow().iter() {
             if *e {
                 out.write_all(n.as_bytes())?;
@@ -227,23 +338,46 @@ impl<'ctx> CompCtx<'ctx> {
     }
     pub fn load<R: Read + BufRead>(&self, buf: &mut R) -> io::Result<Vec<String>> {
         let mut out = vec![];
-        while !buf.fill_buf()?.is_empty() { // stable implementation of BufRead::has_data_left
+        while !buf.fill_buf()?.is_empty() {
+            // stable implementation of BufRead::has_data_left
             loop {
                 let mut vec = vec![];
                 buf.read_until(0, &mut vec)?;
-                if vec.last() == Some(&0) {vec.pop();}
-                if vec.is_empty() {break}
-                let name = String::from_utf8(std::mem::take(&mut vec)).expect("Nominal types should be valid UTF-8");
+                if vec.last() == Some(&0) {
+                    vec.pop();
+                }
+                if vec.is_empty() {
+                    break;
+                }
+                let name = String::from_utf8(std::mem::take(&mut vec))
+                    .expect("Nominal types should be valid UTF-8");
                 let t = Type::load(buf)?;
                 let i = NominalInfo::load(buf, self)?;
-                if self.nominals.borrow().get(&name).map_or(false, |x| x.0.unwrapped(self) == t.unwrapped(self)) {out.push(name.clone())}
-                self.nominals.borrow_mut().insert(name.clone(), (t, false, Default::default(), i));
+                if self
+                    .nominals
+                    .borrow()
+                    .get(&name)
+                    .map_or(false, |x| x.0.unwrapped(self) == t.unwrapped(self))
+                {
+                    out.push(name.clone())
+                }
+                self.nominals
+                    .borrow_mut()
+                    .insert(name.clone(), (t, false, Default::default(), i));
                 let mut ms = HashMap::new();
                 loop {
                     buf.read_until(0, &mut vec)?;
-                    if vec.last() == Some(&0) {vec.pop();}
-                    if vec.is_empty() {break}
-                    ms.insert(String::from_utf8(std::mem::take(&mut vec)).expect("Nominal types should be valid UTF-8"), Value::load(buf, self)?);
+                    if vec.last() == Some(&0) {
+                        vec.pop();
+                    }
+                    if vec.is_empty() {
+                        break;
+                    }
+                    ms.insert(
+                        String::from_utf8(std::mem::take(&mut vec))
+                            .expect("Nominal types should be valid UTF-8"),
+                        Value::load(buf, self)?,
+                    );
                 }
                 self.nominals.borrow_mut().get_mut(&name).unwrap().2 = ms;
             }
@@ -256,7 +390,9 @@ impl<'ctx> Drop for CompCtx<'ctx> {
     fn drop(&mut self) {
         unsafe {
             self.name.replace(MaybeUninit::uninit()).assume_init_drop();
-            self.int_types.replace(MaybeUninit::uninit()).assume_init_drop();
+            self.int_types
+                .replace(MaybeUninit::uninit())
+                .assume_init_drop();
         }
     }
 }

--- a/cobalt-ast/src/lib.rs
+++ b/cobalt-ast/src/lib.rs
@@ -1,20 +1,20 @@
 #![allow(clippy::type_complexity)]
 pub mod ast;
+pub mod cfg;
 pub mod context;
 pub mod dottedname;
 pub mod ops;
 pub mod types;
-pub mod varmap;
 pub mod value;
-pub mod cfg;
+pub mod varmap;
 
-pub use dottedname::*;
-pub use context::*;
 pub use ast::AST;
-pub use types::*;
-pub use varmap::*;
-pub use value::*;
 use ast::{print_ast_child, TreePrefix};
-use cobalt_utils::*;
 use cobalt_errors::*;
 use cobalt_llvm::*;
+use cobalt_utils::*;
+pub use context::*;
+pub use dottedname::*;
+pub use types::*;
+pub use value::*;
+pub use varmap::*;

--- a/cobalt-ast/src/ops.rs
+++ b/cobalt-ast/src/ops.rs
@@ -1,70 +1,162 @@
 use crate::*;
-use std::cmp::{min, max, Ordering};
-use std::collections::VecDeque;
-use inkwell::values::{BasicValueEnum::{self, *}, BasicMetadataValueEnum, BasicValue};
-use inkwell::types::{BasicType, BasicMetadataTypeEnum, BasicTypeEnum::StructType};
-use inkwell::{
-    IntPredicate::{SLT, ULT, SGT, UGT, SLE, ULE, SGE, UGE, EQ, NE},
-    FloatPredicate::{OLT, OGT, OLE, OGE, OEQ, ONE}
+use inkwell::types::{BasicMetadataTypeEnum, BasicType, BasicTypeEnum::StructType};
+use inkwell::values::{
+    BasicMetadataValueEnum, BasicValue,
+    BasicValueEnum::{self, *},
 };
-pub fn mark_move<'ctx>(val: &Value<'ctx>, inst: cfg::Location<'ctx>, ctx: &CompCtx<'ctx>, loc: SourceSpan) {
+use inkwell::{
+    FloatPredicate::{OEQ, OGE, OGT, OLE, OLT, ONE},
+    IntPredicate::{EQ, NE, SGE, SGT, SLE, SLT, UGE, UGT, ULE, ULT},
+};
+use std::cmp::{max, min, Ordering};
+use std::collections::VecDeque;
+pub fn mark_move<'ctx>(
+    val: &Value<'ctx>,
+    inst: cfg::Location<'ctx>,
+    ctx: &CompCtx<'ctx>,
+    loc: SourceSpan,
+) {
     if !ctx.is_const.get() {
-        if let (Some(name), true) = (&val.name, ctx.flags.all_move_metadata || val.data_type.has_dtor(ctx)) {
+        if let (Some(name), true) = (
+            &val.name,
+            ctx.flags.all_move_metadata || val.data_type.has_dtor(ctx),
+        ) {
             ctx.moves.borrow_mut().0.insert(cfg::Use {
                 is_move: true,
                 name: name.clone(),
                 real: !ctx.flags.all_move_metadata || val.data_type.has_dtor(ctx),
-                inst, loc
+                inst,
+                loc,
             });
         }
     }
 }
-pub fn mark_use<'ctx>(val: &Value<'ctx>, inst: cfg::Location<'ctx>, ctx: &CompCtx<'ctx>, loc: SourceSpan) {
+pub fn mark_use<'ctx>(
+    val: &Value<'ctx>,
+    inst: cfg::Location<'ctx>,
+    ctx: &CompCtx<'ctx>,
+    loc: SourceSpan,
+) {
     if !ctx.is_const.get() {
-        if let (Some(name), true) = (&val.name, ctx.flags.all_move_metadata || val.data_type.has_dtor(ctx)) {
+        if let (Some(name), true) = (
+            &val.name,
+            ctx.flags.all_move_metadata || val.data_type.has_dtor(ctx),
+        ) {
             ctx.moves.borrow_mut().0.insert(cfg::Use {
                 is_move: false,
                 name: name.clone(),
                 real: !ctx.flags.all_move_metadata || val.data_type.has_dtor(ctx),
-                inst, loc
+                inst,
+                loc,
             });
         }
     }
 }
 pub fn impl_convertible(base: &Type, target: &Type, ctx: &CompCtx) -> bool {
-    base == target || *target == Type::Null || *target == Type::Error || match base {
-        Type::IntLiteral => matches!(target, Type::Int(..) | Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128),
-        Type::Int(s, _) => match target {Type::Int(s2, _) if s2 >= s => true, Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128 => true, _ => false},
-        Type::Float16 => matches!(target, Type::Float32 | Type::Float64 | Type::Float128),
-        Type::Float32 => matches!(target, Type::Float64 | Type::Float128),
-        Type::Float64 => *target == Type::Float128,
-        Type::Pointer(lb) => if let Type::Pointer(rb) = target {covariant(lb, rb)} else {false},
-        Type::Reference(lb) => (if let Type::Reference(rb) = target {covariant(lb, rb)} else {false}) || (impl_convertible(lb, target, ctx) && !lb.has_dtor(ctx)),
-        Type::Mut(b) => impl_convertible(b, target, ctx),
-        Type::Null => *target == Type::TypeData,
-        Type::Error => true,
-        _ => false
-    }
+    base == target
+        || *target == Type::Null
+        || *target == Type::Error
+        || match base {
+            Type::IntLiteral => matches!(
+                target,
+                Type::Int(..) | Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128
+            ),
+            Type::Int(s, _) => match target {
+                Type::Int(s2, _) if s2 >= s => true,
+                Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128 => true,
+                _ => false,
+            },
+            Type::Float16 => matches!(target, Type::Float32 | Type::Float64 | Type::Float128),
+            Type::Float32 => matches!(target, Type::Float64 | Type::Float128),
+            Type::Float64 => *target == Type::Float128,
+            Type::Pointer(lb) => {
+                if let Type::Pointer(rb) = target {
+                    covariant(lb, rb)
+                } else {
+                    false
+                }
+            }
+            Type::Reference(lb) => {
+                (if let Type::Reference(rb) = target {
+                    covariant(lb, rb)
+                } else {
+                    false
+                }) || (impl_convertible(lb, target, ctx) && !lb.has_dtor(ctx))
+            }
+            Type::Mut(b) => impl_convertible(b, target, ctx),
+            Type::Null => *target == Type::TypeData,
+            Type::Error => true,
+            _ => false,
+        }
 }
 pub fn expl_convertible(base: &Type, target: &Type, ctx: &CompCtx) -> bool {
-    base == target || *target == Type::Null || *target == Type::Error || match base {
-        Type::IntLiteral => matches!(target, Type::Int(..) | Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128),
-        Type::Int(..) => matches!(target, Type::Int(..) | Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128 | Type::Pointer(..)),
-        Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128 => matches!(target, Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128),
-        Type::Pointer(lb) => if let Type::Pointer(rb) = target {**lb == Type::Null || covariant(lb, rb)} else {false},
-        Type::Reference(lb) => (if let Type::Reference(rb) = target {covariant(lb, rb)} else {false}) || (expl_convertible(lb, target, ctx) && !lb.has_dtor(ctx)),
-        Type::Mut(b) => expl_convertible(b, target, ctx),
-        Type::Null => matches!(target, Type::TypeData | Type::IntLiteral | Type::Int(..) | Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128 | Type::Pointer(_)),
-        Type::Error => true,
-        _ => false
-    }
+    base == target
+        || *target == Type::Null
+        || *target == Type::Error
+        || match base {
+            Type::IntLiteral => matches!(
+                target,
+                Type::Int(..) | Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128
+            ),
+            Type::Int(..) => matches!(
+                target,
+                Type::Int(..)
+                    | Type::Float16
+                    | Type::Float32
+                    | Type::Float64
+                    | Type::Float128
+                    | Type::Pointer(..)
+            ),
+            Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128 => matches!(
+                target,
+                Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128
+            ),
+            Type::Pointer(lb) => {
+                if let Type::Pointer(rb) = target {
+                    **lb == Type::Null || covariant(lb, rb)
+                } else {
+                    false
+                }
+            }
+            Type::Reference(lb) => {
+                (if let Type::Reference(rb) = target {
+                    covariant(lb, rb)
+                } else {
+                    false
+                }) || (expl_convertible(lb, target, ctx) && !lb.has_dtor(ctx))
+            }
+            Type::Mut(b) => expl_convertible(b, target, ctx),
+            Type::Null => matches!(
+                target,
+                Type::TypeData
+                    | Type::IntLiteral
+                    | Type::Int(..)
+                    | Type::Float16
+                    | Type::Float32
+                    | Type::Float64
+                    | Type::Float128
+                    | Type::Pointer(_)
+            ),
+            Type::Error => true,
+            _ => false,
+        }
 }
-pub fn bin_op<'ctx>(loc: SourceSpan, (mut lhs, lloc): (Value<'ctx>, SourceSpan), (mut rhs, rloc): (Value<'ctx>, SourceSpan), op: &str, ctx: &CompCtx<'ctx>, left_move: bool, right_move: bool) -> Result<Value<'ctx>, CobaltError> {
+pub fn bin_op<'ctx>(
+    loc: SourceSpan,
+    (mut lhs, lloc): (Value<'ctx>, SourceSpan),
+    (mut rhs, rloc): (Value<'ctx>, SourceSpan),
+    op: &str,
+    ctx: &CompCtx<'ctx>,
+    left_move: bool,
+    right_move: bool,
+) -> Result<Value<'ctx>, CobaltError> {
     let err = CobaltError::BinOpNotDefined {
         lhs: lhs.data_type.to_string(),
         rhs: rhs.data_type.to_string(),
         op: op.to_string(),
-        lloc, rloc, oloc: loc
+        lloc,
+        rloc,
+        oloc: loc,
     };
     let ldt = lhs.data_type.clone();
     let rdt = rhs.data_type.clone();
@@ -73,10 +165,11 @@ pub fn bin_op<'ctx>(loc: SourceSpan, (mut lhs, lloc): (Value<'ctx>, SourceSpan),
         (Type::Reference(l), _r) => {
             lhs.data_type = *l;
             if !(ctx.is_const.get() || matches!(lhs.data_type, Type::Mut(_))) {
-                if let (Some(t), Some(PointerValue(v))) = (lhs.data_type.llvm_type(ctx), lhs.comp_val) {
+                if let (Some(t), Some(PointerValue(v))) =
+                    (lhs.data_type.llvm_type(ctx), lhs.comp_val)
+                {
                     lhs.comp_val = Some(ctx.builder.build_load(t, v, ""));
-                }
-                else {
+                } else {
                     lhs.comp_val = None;
                 }
             }
@@ -89,390 +182,762 @@ pub fn bin_op<'ctx>(loc: SourceSpan, (mut lhs, lloc): (Value<'ctx>, SourceSpan),
                 }
                 lhs.inter_val = None;
                 Ok(lhs)
-            }
-            else {
+            } else {
                 let left_move = !lhs.data_type.has_dtor(ctx);
-                bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, left_move, right_move)
+                bin_op(
+                    loc,
+                    (lhs, lloc),
+                    (rhs, rloc),
+                    op,
+                    ctx,
+                    left_move,
+                    right_move,
+                )
             }
         }
         (_l, Type::Reference(r)) => {
             rhs.data_type = *r;
             if !(ctx.is_const.get() || matches!(rhs.data_type, Type::Mut(_))) {
-                if let (Some(t), Some(PointerValue(v))) = (rhs.data_type.llvm_type(ctx), rhs.comp_val) {
+                if let (Some(t), Some(PointerValue(v))) =
+                    (rhs.data_type.llvm_type(ctx), rhs.comp_val)
+                {
                     rhs.comp_val = Some(ctx.builder.build_load(t, v, ""));
-                }
-                else {
+                } else {
                     rhs.comp_val = None;
                 }
             }
             let right_move = !rhs.data_type.has_dtor(ctx);
-            bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, left_move, right_move)
+            bin_op(
+                loc,
+                (lhs, lloc),
+                (rhs, rloc),
+                op,
+                ctx,
+                left_move,
+                right_move,
+            )
         }
-        (Type::Mut(l), r) => if op == "=" {
-            mark_move(&rhs, cfg::Location::current(ctx).unwrap(), ctx, loc);
-            rhs = impl_convert(rloc, (rhs, None), (*l, Some(lloc)), ctx)?;
-            if let (Some(PointerValue(lv)), Some(rv)) = (lhs.comp_val, rhs.value(ctx)) {
-                let inst = ctx.builder.build_store(lv, rv);
-                if let (Some(name), true) = (&lhs.name, ctx.flags.all_move_metadata || lhs.data_type.has_dtor(ctx)) {
-                    ctx.moves.borrow_mut().1.insert(cfg::Store {
-                        inst: inst.into(),
-                        name: name.clone(),
-                        real: !ctx.flags.all_move_metadata || lhs.data_type.has_dtor(ctx) // don't check for dtor twice if we can avoid it
-                    });
-                }
-            }
-            lhs.inter_val = None;
-            Ok(lhs)
-        }
-        else {
-            match (*l, r) {
-                (Type::IntLiteral, _) => panic!("There shouldn't be a reference to an integer literal"),
-                (l @ Type::Int(..), r @ Type::IntLiteral) => match op {
-                    "+=" => {
-                        if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) = (lhs.value(ctx), rhs.inter_val, ctx.is_const.get()) {
-                            let rv = l.llvm_type(ctx).unwrap().into_int_type().const_int(r as u64, true);
-                            let v1 = ctx.builder.build_load(l.llvm_type(ctx).unwrap(), lv, "").into_int_value();
-                            let v2 = ctx.builder.build_int_add(v1, rv, "");
-                            ctx.builder.build_store(lv, v2);
-                        }
-                        lhs.inter_val = None;
-                        Ok(lhs)
-                    }
-                    "-=" => {
-                        if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) = (lhs.value(ctx), rhs.inter_val, ctx.is_const.get()) {
-                            let rv = l.llvm_type(ctx).unwrap().into_int_type().const_int(r as u64, true);
-                            let v1 = ctx.builder.build_load(l.llvm_type(ctx).unwrap(), lv, "").into_int_value();
-                            let v2 = ctx.builder.build_int_sub(v1, rv, "");
-                            ctx.builder.build_store(lv, v2);
-                        }
-                        lhs.inter_val = None;
-                        Ok(lhs)
-                    }
-                    "*=" => {
-                        if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) = (lhs.value(ctx), rhs.inter_val, ctx.is_const.get()) {
-                            let rv = l.llvm_type(ctx).unwrap().into_int_type().const_int(r as u64, true);
-                            let v1 = ctx.builder.build_load(l.llvm_type(ctx).unwrap(), lv, "").into_int_value();
-                            let v2 = ctx.builder.build_int_mul(v1, rv, "");
-                            ctx.builder.build_store(lv, v2);
-                        }
-                        lhs.inter_val = None;
-                        Ok(lhs)
-                    }
-                    "/=" => {
-                        let unsigned = if let Type::Int(s, true) = r {rhs.data_type = Type::Int(s, true); true}
-                        else {rhs.data_type = r; false};
-                        if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) = (lhs.value(ctx), rhs.inter_val, ctx.is_const.get()) {
-                            let rv = l.llvm_type(ctx).unwrap().into_int_type().const_int(r as u64, true);
-                            let v1 = ctx.builder.build_load(l.llvm_type(ctx).unwrap(), lv, "").into_int_value();
-                            let v2 = if unsigned {ctx.builder.build_int_unsigned_div(v1, rv, "")} else {ctx.builder.build_int_signed_div(v1, rv, "")};
-                            ctx.builder.build_store(lv, v2);
-                        }
-                        lhs.inter_val = None;
-                        Ok(lhs)
-                    }
-                    "%=" => {
-                        let unsigned = if let Type::Int(s, true) = r {rhs.data_type = Type::Int(s, true); true}
-                        else {rhs.data_type = r; false};
-                        if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) = (lhs.value(ctx), rhs.inter_val, ctx.is_const.get()) {
-                            let rv = l.llvm_type(ctx).unwrap().into_int_type().const_int(r as u64, true);
-                            let v1 = ctx.builder.build_load(l.llvm_type(ctx).unwrap(), lv, "").into_int_value();
-                            let v2 = if unsigned {ctx.builder.build_int_unsigned_rem(v1, rv, "")} else {ctx.builder.build_int_signed_rem(v1, rv, "")};
-                            ctx.builder.build_store(lv, v2);
-                        }
-                        lhs.inter_val = None;
-                        Ok(lhs)
-                    }
-                    "&=" => {
-                        if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) = (lhs.value(ctx), rhs.inter_val, ctx.is_const.get()) {
-                            let rv = l.llvm_type(ctx).unwrap().into_int_type().const_int(r as u64, true);
-                            let v1 = ctx.builder.build_load(l.llvm_type(ctx).unwrap(), lv, "").into_int_value();
-                            let v2 = ctx.builder.build_and(v1, rv, "");
-                            ctx.builder.build_store(lv, v2);
-                        }
-                        lhs.inter_val = None;
-                        Ok(lhs)
-                    }
-                    "|=" => {
-                        if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) = (lhs.value(ctx), rhs.inter_val, ctx.is_const.get()) {
-                            let rv = l.llvm_type(ctx).unwrap().into_int_type().const_int(r as u64, true);
-                            let v1 = ctx.builder.build_load(l.llvm_type(ctx).unwrap(), lv, "").into_int_value();
-                            let v2 = ctx.builder.build_or(v1, rv, "");
-                            ctx.builder.build_store(lv, v2);
-                        }
-                        lhs.inter_val = None;
-                        Ok(lhs)
-                    }
-                    "^=" => {
-                        if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) = (lhs.value(ctx), rhs.inter_val, ctx.is_const.get()) {
-                            let rv = l.llvm_type(ctx).unwrap().into_int_type().const_int(r as u64, true);
-                            let v1 = ctx.builder.build_load(l.llvm_type(ctx).unwrap(), lv, "").into_int_value();
-                            let v2 = ctx.builder.build_xor(v1, rv, "");
-                            ctx.builder.build_store(lv, v2);
-                        }
-                        lhs.inter_val = None;
-                        Ok(lhs)
-                    }
-                    "<<=" => {
-                        if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) = (lhs.value(ctx), rhs.inter_val, ctx.is_const.get()) {
-                            let rv = l.llvm_type(ctx).unwrap().into_int_type().const_int(r as u64, true);
-                            let v1 = ctx.builder.build_load(l.llvm_type(ctx).unwrap(), lv, "").into_int_value();
-                            let v2 = ctx.builder.build_left_shift(v1, rv, "");
-                            ctx.builder.build_store(lv, v2);
-                        }
-                        lhs.inter_val = None;
-                        Ok(lhs)
-                    }
-                    ">>=" => {
-                        if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) = (lhs.value(ctx), rhs.inter_val, ctx.is_const.get()) {
-                            let rv = l.llvm_type(ctx).unwrap().into_int_type().const_int(r as u64, true);
-                            let v1 = ctx.builder.build_load(l.llvm_type(ctx).unwrap(), lv, "").into_int_value();
-                            let v2 = ctx.builder.build_right_shift(v1, rv, false, "");
-                            ctx.builder.build_store(lv, v2);
-                        }
-                        lhs.inter_val = None;
-                        Ok(lhs)
-                    }
-                    _ => {
-                        lhs.data_type = l;
-                        if !ctx.is_const.get() {
-                            if let Some(PointerValue(v)) = lhs.comp_val {
-                                lhs.comp_val = Some(ctx.builder.build_load(lhs.data_type.llvm_type(ctx).unwrap(), v, ""));
-                            }
-                        }
-                        bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, true)
+        (Type::Mut(l), r) => {
+            if op == "=" {
+                mark_move(&rhs, cfg::Location::current(ctx).unwrap(), ctx, loc);
+                rhs = impl_convert(rloc, (rhs, None), (*l, Some(lloc)), ctx)?;
+                if let (Some(PointerValue(lv)), Some(rv)) = (lhs.comp_val, rhs.value(ctx)) {
+                    let inst = ctx.builder.build_store(lv, rv);
+                    if let (Some(name), true) = (
+                        &lhs.name,
+                        ctx.flags.all_move_metadata || lhs.data_type.has_dtor(ctx),
+                    ) {
+                        ctx.moves.borrow_mut().1.insert(cfg::Store {
+                            inst: inst.into(),
+                            name: name.clone(),
+                            real: !ctx.flags.all_move_metadata || lhs.data_type.has_dtor(ctx), // don't check for dtor twice if we can avoid it
+                        });
                     }
                 }
-                (Type::Int(ls, lu), Type::Int(rs, ru)) => {
-                    match ls.cmp(&rs) {
-                        Ordering::Less => return Err(err),
-                        Ordering::Greater => if let Some(IntValue(rv)) = rhs.comp_val {
-                            let lt = ctx.context.custom_width_int_type(ls as u32);
-                            rhs.comp_val = Some(if ru {ctx.builder.build_int_z_extend(rv, lt, "")} else {ctx.builder.build_int_s_extend(rv, lt, "")}.into());
-                        }
-                        Ordering::Equal => {}
+                lhs.inter_val = None;
+                Ok(lhs)
+            } else {
+                match (*l, r) {
+                    (Type::IntLiteral, _) => {
+                        panic!("There shouldn't be a reference to an integer literal")
                     }
-                    match op {
+                    (l @ Type::Int(..), r @ Type::IntLiteral) => match op {
                         "+=" => {
-                            if let (Some(PointerValue(l)), Some(r), false) =  (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                                let v1 = ctx.builder.build_load(ctx.context.custom_width_int_type(ls as u32), l, "").into_int_value();
-                                let v2 = ctx.builder.build_int_add(v1, r.into_int_value(), "");
-                                ctx.builder.build_store(l, v2);
+                            if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) =
+                                (lhs.value(ctx), rhs.inter_val, ctx.is_const.get())
+                            {
+                                let rv = l
+                                    .llvm_type(ctx)
+                                    .unwrap()
+                                    .into_int_type()
+                                    .const_int(r as u64, true);
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(l.llvm_type(ctx).unwrap(), lv, "")
+                                    .into_int_value();
+                                let v2 = ctx.builder.build_int_add(v1, rv, "");
+                                ctx.builder.build_store(lv, v2);
                             }
                             lhs.inter_val = None;
                             Ok(lhs)
                         }
                         "-=" => {
-                            if let (Some(PointerValue(l)), Some(r), false) =  (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                                let v1 = ctx.builder.build_load(ctx.context.custom_width_int_type(ls as u32), l, "").into_int_value();
-                                let v2 = ctx.builder.build_int_sub(v1, r.into_int_value(), "");
-                                ctx.builder.build_store(l, v2);
+                            if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) =
+                                (lhs.value(ctx), rhs.inter_val, ctx.is_const.get())
+                            {
+                                let rv = l
+                                    .llvm_type(ctx)
+                                    .unwrap()
+                                    .into_int_type()
+                                    .const_int(r as u64, true);
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(l.llvm_type(ctx).unwrap(), lv, "")
+                                    .into_int_value();
+                                let v2 = ctx.builder.build_int_sub(v1, rv, "");
+                                ctx.builder.build_store(lv, v2);
                             }
                             lhs.inter_val = None;
                             Ok(lhs)
                         }
                         "*=" => {
-                            if let (Some(PointerValue(l)), Some(r), false) =  (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                                let v1 = ctx.builder.build_load(ctx.context.custom_width_int_type(ls as u32), l, "").into_int_value();
-                                let v2 = ctx.builder.build_int_mul(v1, r.into_int_value(), "");
-                                ctx.builder.build_store(l, v2);
+                            if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) =
+                                (lhs.value(ctx), rhs.inter_val, ctx.is_const.get())
+                            {
+                                let rv = l
+                                    .llvm_type(ctx)
+                                    .unwrap()
+                                    .into_int_type()
+                                    .const_int(r as u64, true);
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(l.llvm_type(ctx).unwrap(), lv, "")
+                                    .into_int_value();
+                                let v2 = ctx.builder.build_int_mul(v1, rv, "");
+                                ctx.builder.build_store(lv, v2);
                             }
                             lhs.inter_val = None;
                             Ok(lhs)
                         }
                         "/=" => {
-                            if let (Some(PointerValue(l)), Some(r), false) = (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                                let v1 = ctx.builder.build_load(ctx.context.custom_width_int_type(ls as u32), l, "").into_int_value();
-                                let v2 = if ru {ctx.builder.build_int_unsigned_div(v1, r.into_int_value(), "")} else {ctx.builder.build_int_signed_div(v1, r.into_int_value(), "")};
-                                ctx.builder.build_store(l, v2);
+                            let unsigned = if let Type::Int(s, true) = r {
+                                rhs.data_type = Type::Int(s, true);
+                                true
+                            } else {
+                                rhs.data_type = r;
+                                false
+                            };
+                            if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) =
+                                (lhs.value(ctx), rhs.inter_val, ctx.is_const.get())
+                            {
+                                let rv = l
+                                    .llvm_type(ctx)
+                                    .unwrap()
+                                    .into_int_type()
+                                    .const_int(r as u64, true);
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(l.llvm_type(ctx).unwrap(), lv, "")
+                                    .into_int_value();
+                                let v2 = if unsigned {
+                                    ctx.builder.build_int_unsigned_div(v1, rv, "")
+                                } else {
+                                    ctx.builder.build_int_signed_div(v1, rv, "")
+                                };
+                                ctx.builder.build_store(lv, v2);
                             }
                             lhs.inter_val = None;
                             Ok(lhs)
                         }
                         "%=" => {
-                            if let (Some(PointerValue(l)), Some(r), false) = (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                                let v1 = ctx.builder.build_load(ctx.context.custom_width_int_type(ls as u32), l, "").into_int_value();
-                                let v2 = if ru {ctx.builder.build_int_unsigned_rem(v1, r.into_int_value(), "")} else {ctx.builder.build_int_signed_rem(v1, r.into_int_value(), "")};
-                                ctx.builder.build_store(l, v2);
+                            let unsigned = if let Type::Int(s, true) = r {
+                                rhs.data_type = Type::Int(s, true);
+                                true
+                            } else {
+                                rhs.data_type = r;
+                                false
+                            };
+                            if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) =
+                                (lhs.value(ctx), rhs.inter_val, ctx.is_const.get())
+                            {
+                                let rv = l
+                                    .llvm_type(ctx)
+                                    .unwrap()
+                                    .into_int_type()
+                                    .const_int(r as u64, true);
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(l.llvm_type(ctx).unwrap(), lv, "")
+                                    .into_int_value();
+                                let v2 = if unsigned {
+                                    ctx.builder.build_int_unsigned_rem(v1, rv, "")
+                                } else {
+                                    ctx.builder.build_int_signed_rem(v1, rv, "")
+                                };
+                                ctx.builder.build_store(lv, v2);
                             }
                             lhs.inter_val = None;
                             Ok(lhs)
                         }
                         "&=" => {
-                            if let (Some(PointerValue(l)), Some(r), false) =  (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                                let v1 = ctx.builder.build_load(ctx.context.custom_width_int_type(ls as u32), l, "").into_int_value();
-                                let v2 = ctx.builder.build_and(v1, r.into_int_value(), "");
-                                ctx.builder.build_store(l, v2);
+                            if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) =
+                                (lhs.value(ctx), rhs.inter_val, ctx.is_const.get())
+                            {
+                                let rv = l
+                                    .llvm_type(ctx)
+                                    .unwrap()
+                                    .into_int_type()
+                                    .const_int(r as u64, true);
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(l.llvm_type(ctx).unwrap(), lv, "")
+                                    .into_int_value();
+                                let v2 = ctx.builder.build_and(v1, rv, "");
+                                ctx.builder.build_store(lv, v2);
                             }
                             lhs.inter_val = None;
                             Ok(lhs)
                         }
                         "|=" => {
-                            if let (Some(PointerValue(l)), Some(r), false) =  (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                                let v1 = ctx.builder.build_load(ctx.context.custom_width_int_type(ls as u32), l, "").into_int_value();
-                                let v2 = ctx.builder.build_or(v1, r.into_int_value(), "");
-                                ctx.builder.build_store(l, v2);
+                            if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) =
+                                (lhs.value(ctx), rhs.inter_val, ctx.is_const.get())
+                            {
+                                let rv = l
+                                    .llvm_type(ctx)
+                                    .unwrap()
+                                    .into_int_type()
+                                    .const_int(r as u64, true);
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(l.llvm_type(ctx).unwrap(), lv, "")
+                                    .into_int_value();
+                                let v2 = ctx.builder.build_or(v1, rv, "");
+                                ctx.builder.build_store(lv, v2);
                             }
                             lhs.inter_val = None;
                             Ok(lhs)
                         }
                         "^=" => {
-                            if let (Some(PointerValue(l)), Some(r), false) =  (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                                let v1 = ctx.builder.build_load(ctx.context.custom_width_int_type(ls as u32), l, "").into_int_value();
-                                let v2 = ctx.builder.build_xor(v1, r.into_int_value(), "");
-                                ctx.builder.build_store(l, v2);
+                            if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) =
+                                (lhs.value(ctx), rhs.inter_val, ctx.is_const.get())
+                            {
+                                let rv = l
+                                    .llvm_type(ctx)
+                                    .unwrap()
+                                    .into_int_type()
+                                    .const_int(r as u64, true);
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(l.llvm_type(ctx).unwrap(), lv, "")
+                                    .into_int_value();
+                                let v2 = ctx.builder.build_xor(v1, rv, "");
+                                ctx.builder.build_store(lv, v2);
                             }
                             lhs.inter_val = None;
                             Ok(lhs)
                         }
                         "<<=" => {
-                            if let (Some(PointerValue(l)), Some(r), false) =  (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                                let v1 = ctx.builder.build_load(ctx.context.custom_width_int_type(ls as u32), l, "").into_int_value();
-                                let v2 = ctx.builder.build_left_shift(v1, r.into_int_value(), "");
-                                ctx.builder.build_store(l, v2);
+                            if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) =
+                                (lhs.value(ctx), rhs.inter_val, ctx.is_const.get())
+                            {
+                                let rv = l
+                                    .llvm_type(ctx)
+                                    .unwrap()
+                                    .into_int_type()
+                                    .const_int(r as u64, true);
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(l.llvm_type(ctx).unwrap(), lv, "")
+                                    .into_int_value();
+                                let v2 = ctx.builder.build_left_shift(v1, rv, "");
+                                ctx.builder.build_store(lv, v2);
                             }
                             lhs.inter_val = None;
                             Ok(lhs)
                         }
                         ">>=" => {
-                            if let (Some(PointerValue(l)), Some(r), false) =  (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                                let v1 = ctx.builder.build_load(ctx.context.custom_width_int_type(ls as u32), l, "").into_int_value();
-                                let v2 = ctx.builder.build_right_shift(v1, r.into_int_value(), false, "");
-                                ctx.builder.build_store(l, v2);
+                            if let (Some(PointerValue(lv)), Some(InterData::Int(r)), false) =
+                                (lhs.value(ctx), rhs.inter_val, ctx.is_const.get())
+                            {
+                                let rv = l
+                                    .llvm_type(ctx)
+                                    .unwrap()
+                                    .into_int_type()
+                                    .const_int(r as u64, true);
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(l.llvm_type(ctx).unwrap(), lv, "")
+                                    .into_int_value();
+                                let v2 = ctx.builder.build_right_shift(v1, rv, false, "");
+                                ctx.builder.build_store(lv, v2);
                             }
                             lhs.inter_val = None;
                             Ok(lhs)
                         }
                         _ => {
-                            lhs.data_type = Type::Int(ls, lu);
+                            lhs.data_type = l;
                             if !ctx.is_const.get() {
                                 if let Some(PointerValue(v)) = lhs.comp_val {
-                                    lhs.comp_val = Some(ctx.builder.build_load(ctx.context.custom_width_int_type(ls as u32), v, ""));
+                                    lhs.comp_val = Some(ctx.builder.build_load(
+                                        lhs.data_type.llvm_type(ctx).unwrap(),
+                                        v,
+                                        "",
+                                    ));
                                 }
                             }
                             bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, true)
                         }
-                    }
-                }
-                (x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128), r @ (Type::IntLiteral | Type::Int(..))) => match op {
-                    "+=" => {
-                        lhs.inter_val = None;
-                        if let (Some(PointerValue(l)), Some(IntValue(rv)), false) = (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                            let v1 = match r {
-                                Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), ""),
-                                _ => ctx.builder.build_unsigned_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), "")
-                            };
-                            let v2 = ctx.builder.build_load(x.llvm_type(ctx).unwrap(), l, "").into_float_value();
-                            let v3 = ctx.builder.build_float_add(v1, v2, "");
-                            ctx.builder.build_store(l, v3);
+                    },
+                    (Type::Int(ls, lu), Type::Int(rs, ru)) => {
+                        match ls.cmp(&rs) {
+                            Ordering::Less => return Err(err),
+                            Ordering::Greater => {
+                                if let Some(IntValue(rv)) = rhs.comp_val {
+                                    let lt = ctx.context.custom_width_int_type(ls as u32);
+                                    rhs.comp_val = Some(
+                                        if ru {
+                                            ctx.builder.build_int_z_extend(rv, lt, "")
+                                        } else {
+                                            ctx.builder.build_int_s_extend(rv, lt, "")
+                                        }
+                                        .into(),
+                                    );
+                                }
+                            }
+                            Ordering::Equal => {}
                         }
-                        Ok(lhs)
-                    }
-                    "-=" => {
-                        lhs.inter_val = None;
-                        if let (Some(PointerValue(l)), Some(IntValue(rv)), false) = (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                            let v1 = match r {
-                                Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), ""),
-                                _ => ctx.builder.build_unsigned_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), "")
-                            };
-                            let v2 = ctx.builder.build_load(x.llvm_type(ctx).unwrap(), l, "").into_float_value();
-                            let v3 = ctx.builder.build_float_sub(v1, v2, "");
-                            ctx.builder.build_store(l, v3);
-                        }
-                        Ok(lhs)
-                    }
-                    "*=" => {
-                        lhs.inter_val = None;
-                        if let (Some(PointerValue(l)), Some(IntValue(rv)), false) = (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                            let v1 = match r {
-                                Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), ""),
-                                _ => ctx.builder.build_unsigned_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), "")
-                            };
-                            let v2 = ctx.builder.build_load(x.llvm_type(ctx).unwrap(), l, "").into_float_value();
-                            let v3 = ctx.builder.build_float_mul(v1, v2, "");
-                            ctx.builder.build_store(l, v3);
-                        }
-                        Ok(lhs)
-                    }
-                    "/=" => {
-                        lhs.inter_val = None;
-                        if let (Some(PointerValue(l)), Some(IntValue(rv)), false) = (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                            let v1 = match r {
-                                Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), ""),
-                                _ => ctx.builder.build_unsigned_int_to_float(rv, x.llvm_type(ctx).unwrap().into_float_type(), "")
-                            };
-                            let v2 = ctx.builder.build_load(x.llvm_type(ctx).unwrap(), l, "").into_float_value();
-                            let v3 = ctx.builder.build_float_div(v1, v2, "");
-                            ctx.builder.build_store(l, v3);
-                        }
-                        Ok(lhs)
-                    }
-                    "%=" => Err(err), // TODO: implement fmod
-                    _ => {
-                        lhs.data_type = x;
-                        if let Some(v) = lhs.comp_val {
-                            lhs.comp_val = Some(ctx.builder.build_load(lhs.data_type.llvm_type(ctx).unwrap(), v.into_pointer_value(), ""));
-                        }
-                        bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, true)
-                    }
-                }
-                (Type::Pointer(b), Type::IntLiteral | Type::Int(..)) => match op {
-                    "+=" => {
-                        lhs.inter_val = None;
-                        if let (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) = (lhs.comp_val, rhs.comp_val, b.size(ctx), ctx.is_const.get()) {
-                            unsafe {
-                                let lv = ctx.builder.build_load(ctx.null_type.ptr_type(Default::default()), l, "").into_pointer_value();
-                                let v = ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), lv, &[r], "");
-                                ctx.builder.build_store(l, v);
+                        match op {
+                            "+=" => {
+                                if let (Some(PointerValue(l)), Some(r), false) =
+                                    (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get())
+                                {
+                                    let v1 = ctx
+                                        .builder
+                                        .build_load(
+                                            ctx.context.custom_width_int_type(ls as u32),
+                                            l,
+                                            "",
+                                        )
+                                        .into_int_value();
+                                    let v2 = ctx.builder.build_int_add(v1, r.into_int_value(), "");
+                                    ctx.builder.build_store(l, v2);
+                                }
+                                lhs.inter_val = None;
+                                Ok(lhs)
+                            }
+                            "-=" => {
+                                if let (Some(PointerValue(l)), Some(r), false) =
+                                    (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get())
+                                {
+                                    let v1 = ctx
+                                        .builder
+                                        .build_load(
+                                            ctx.context.custom_width_int_type(ls as u32),
+                                            l,
+                                            "",
+                                        )
+                                        .into_int_value();
+                                    let v2 = ctx.builder.build_int_sub(v1, r.into_int_value(), "");
+                                    ctx.builder.build_store(l, v2);
+                                }
+                                lhs.inter_val = None;
+                                Ok(lhs)
+                            }
+                            "*=" => {
+                                if let (Some(PointerValue(l)), Some(r), false) =
+                                    (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get())
+                                {
+                                    let v1 = ctx
+                                        .builder
+                                        .build_load(
+                                            ctx.context.custom_width_int_type(ls as u32),
+                                            l,
+                                            "",
+                                        )
+                                        .into_int_value();
+                                    let v2 = ctx.builder.build_int_mul(v1, r.into_int_value(), "");
+                                    ctx.builder.build_store(l, v2);
+                                }
+                                lhs.inter_val = None;
+                                Ok(lhs)
+                            }
+                            "/=" => {
+                                if let (Some(PointerValue(l)), Some(r), false) =
+                                    (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get())
+                                {
+                                    let v1 = ctx
+                                        .builder
+                                        .build_load(
+                                            ctx.context.custom_width_int_type(ls as u32),
+                                            l,
+                                            "",
+                                        )
+                                        .into_int_value();
+                                    let v2 = if ru {
+                                        ctx.builder.build_int_unsigned_div(
+                                            v1,
+                                            r.into_int_value(),
+                                            "",
+                                        )
+                                    } else {
+                                        ctx.builder.build_int_signed_div(v1, r.into_int_value(), "")
+                                    };
+                                    ctx.builder.build_store(l, v2);
+                                }
+                                lhs.inter_val = None;
+                                Ok(lhs)
+                            }
+                            "%=" => {
+                                if let (Some(PointerValue(l)), Some(r), false) =
+                                    (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get())
+                                {
+                                    let v1 = ctx
+                                        .builder
+                                        .build_load(
+                                            ctx.context.custom_width_int_type(ls as u32),
+                                            l,
+                                            "",
+                                        )
+                                        .into_int_value();
+                                    let v2 = if ru {
+                                        ctx.builder.build_int_unsigned_rem(
+                                            v1,
+                                            r.into_int_value(),
+                                            "",
+                                        )
+                                    } else {
+                                        ctx.builder.build_int_signed_rem(v1, r.into_int_value(), "")
+                                    };
+                                    ctx.builder.build_store(l, v2);
+                                }
+                                lhs.inter_val = None;
+                                Ok(lhs)
+                            }
+                            "&=" => {
+                                if let (Some(PointerValue(l)), Some(r), false) =
+                                    (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get())
+                                {
+                                    let v1 = ctx
+                                        .builder
+                                        .build_load(
+                                            ctx.context.custom_width_int_type(ls as u32),
+                                            l,
+                                            "",
+                                        )
+                                        .into_int_value();
+                                    let v2 = ctx.builder.build_and(v1, r.into_int_value(), "");
+                                    ctx.builder.build_store(l, v2);
+                                }
+                                lhs.inter_val = None;
+                                Ok(lhs)
+                            }
+                            "|=" => {
+                                if let (Some(PointerValue(l)), Some(r), false) =
+                                    (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get())
+                                {
+                                    let v1 = ctx
+                                        .builder
+                                        .build_load(
+                                            ctx.context.custom_width_int_type(ls as u32),
+                                            l,
+                                            "",
+                                        )
+                                        .into_int_value();
+                                    let v2 = ctx.builder.build_or(v1, r.into_int_value(), "");
+                                    ctx.builder.build_store(l, v2);
+                                }
+                                lhs.inter_val = None;
+                                Ok(lhs)
+                            }
+                            "^=" => {
+                                if let (Some(PointerValue(l)), Some(r), false) =
+                                    (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get())
+                                {
+                                    let v1 = ctx
+                                        .builder
+                                        .build_load(
+                                            ctx.context.custom_width_int_type(ls as u32),
+                                            l,
+                                            "",
+                                        )
+                                        .into_int_value();
+                                    let v2 = ctx.builder.build_xor(v1, r.into_int_value(), "");
+                                    ctx.builder.build_store(l, v2);
+                                }
+                                lhs.inter_val = None;
+                                Ok(lhs)
+                            }
+                            "<<=" => {
+                                if let (Some(PointerValue(l)), Some(r), false) =
+                                    (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get())
+                                {
+                                    let v1 = ctx
+                                        .builder
+                                        .build_load(
+                                            ctx.context.custom_width_int_type(ls as u32),
+                                            l,
+                                            "",
+                                        )
+                                        .into_int_value();
+                                    let v2 =
+                                        ctx.builder.build_left_shift(v1, r.into_int_value(), "");
+                                    ctx.builder.build_store(l, v2);
+                                }
+                                lhs.inter_val = None;
+                                Ok(lhs)
+                            }
+                            ">>=" => {
+                                if let (Some(PointerValue(l)), Some(r), false) =
+                                    (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get())
+                                {
+                                    let v1 = ctx
+                                        .builder
+                                        .build_load(
+                                            ctx.context.custom_width_int_type(ls as u32),
+                                            l,
+                                            "",
+                                        )
+                                        .into_int_value();
+                                    let v2 = ctx.builder.build_right_shift(
+                                        v1,
+                                        r.into_int_value(),
+                                        false,
+                                        "",
+                                    );
+                                    ctx.builder.build_store(l, v2);
+                                }
+                                lhs.inter_val = None;
+                                Ok(lhs)
+                            }
+                            _ => {
+                                lhs.data_type = Type::Int(ls, lu);
+                                if !ctx.is_const.get() {
+                                    if let Some(PointerValue(v)) = lhs.comp_val {
+                                        lhs.comp_val = Some(ctx.builder.build_load(
+                                            ctx.context.custom_width_int_type(ls as u32),
+                                            v,
+                                            "",
+                                        ));
+                                    }
+                                }
+                                bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, true)
                             }
                         }
-                        Ok(lhs)
                     }
-                    "-=" => {
-                        lhs.inter_val = None;
-                        if let (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) = (lhs.comp_val, rhs.comp_val, b.size(ctx), ctx.is_const.get()) {
-                            unsafe {
-                                let lv = ctx.builder.build_load(ctx.null_type.ptr_type(Default::default()), l, "").into_pointer_value();
-                                let rv = ctx.builder.build_int_neg(r, "");
-                                let v = ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), lv, &[rv], "");
-                                ctx.builder.build_store(l, v);
+                    (
+                        x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128),
+                        r @ (Type::IntLiteral | Type::Int(..)),
+                    ) => match op {
+                        "+=" => {
+                            lhs.inter_val = None;
+                            if let (Some(PointerValue(l)), Some(IntValue(rv)), false) =
+                                (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get())
+                            {
+                                let v1 = match r {
+                                    Type::IntLiteral | Type::Int(_, false) => {
+                                        ctx.builder.build_signed_int_to_float(
+                                            rv,
+                                            x.llvm_type(ctx).unwrap().into_float_type(),
+                                            "",
+                                        )
+                                    }
+                                    _ => ctx.builder.build_unsigned_int_to_float(
+                                        rv,
+                                        x.llvm_type(ctx).unwrap().into_float_type(),
+                                        "",
+                                    ),
+                                };
+                                let v2 = ctx
+                                    .builder
+                                    .build_load(x.llvm_type(ctx).unwrap(), l, "")
+                                    .into_float_value();
+                                let v3 = ctx.builder.build_float_add(v1, v2, "");
+                                ctx.builder.build_store(l, v3);
                             }
+                            Ok(lhs)
                         }
-                        Ok(lhs)
-                    }
-                    _ => {
-                        lhs.data_type = Type::Pointer(b);
-                        if !ctx.is_const.get() {
+                        "-=" => {
+                            lhs.inter_val = None;
+                            if let (Some(PointerValue(l)), Some(IntValue(rv)), false) =
+                                (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get())
+                            {
+                                let v1 = match r {
+                                    Type::IntLiteral | Type::Int(_, false) => {
+                                        ctx.builder.build_signed_int_to_float(
+                                            rv,
+                                            x.llvm_type(ctx).unwrap().into_float_type(),
+                                            "",
+                                        )
+                                    }
+                                    _ => ctx.builder.build_unsigned_int_to_float(
+                                        rv,
+                                        x.llvm_type(ctx).unwrap().into_float_type(),
+                                        "",
+                                    ),
+                                };
+                                let v2 = ctx
+                                    .builder
+                                    .build_load(x.llvm_type(ctx).unwrap(), l, "")
+                                    .into_float_value();
+                                let v3 = ctx.builder.build_float_sub(v1, v2, "");
+                                ctx.builder.build_store(l, v3);
+                            }
+                            Ok(lhs)
+                        }
+                        "*=" => {
+                            lhs.inter_val = None;
+                            if let (Some(PointerValue(l)), Some(IntValue(rv)), false) =
+                                (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get())
+                            {
+                                let v1 = match r {
+                                    Type::IntLiteral | Type::Int(_, false) => {
+                                        ctx.builder.build_signed_int_to_float(
+                                            rv,
+                                            x.llvm_type(ctx).unwrap().into_float_type(),
+                                            "",
+                                        )
+                                    }
+                                    _ => ctx.builder.build_unsigned_int_to_float(
+                                        rv,
+                                        x.llvm_type(ctx).unwrap().into_float_type(),
+                                        "",
+                                    ),
+                                };
+                                let v2 = ctx
+                                    .builder
+                                    .build_load(x.llvm_type(ctx).unwrap(), l, "")
+                                    .into_float_value();
+                                let v3 = ctx.builder.build_float_mul(v1, v2, "");
+                                ctx.builder.build_store(l, v3);
+                            }
+                            Ok(lhs)
+                        }
+                        "/=" => {
+                            lhs.inter_val = None;
+                            if let (Some(PointerValue(l)), Some(IntValue(rv)), false) =
+                                (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get())
+                            {
+                                let v1 = match r {
+                                    Type::IntLiteral | Type::Int(_, false) => {
+                                        ctx.builder.build_signed_int_to_float(
+                                            rv,
+                                            x.llvm_type(ctx).unwrap().into_float_type(),
+                                            "",
+                                        )
+                                    }
+                                    _ => ctx.builder.build_unsigned_int_to_float(
+                                        rv,
+                                        x.llvm_type(ctx).unwrap().into_float_type(),
+                                        "",
+                                    ),
+                                };
+                                let v2 = ctx
+                                    .builder
+                                    .build_load(x.llvm_type(ctx).unwrap(), l, "")
+                                    .into_float_value();
+                                let v3 = ctx.builder.build_float_div(v1, v2, "");
+                                ctx.builder.build_store(l, v3);
+                            }
+                            Ok(lhs)
+                        }
+                        "%=" => Err(err), // TODO: implement fmod
+                        _ => {
+                            lhs.data_type = x;
                             if let Some(v) = lhs.comp_val {
-                                lhs.comp_val = Some(ctx.builder.build_load(ctx.null_type.ptr_type(Default::default()), v.into_pointer_value(), ""));
+                                lhs.comp_val = Some(ctx.builder.build_load(
+                                    lhs.data_type.llvm_type(ctx).unwrap(),
+                                    v.into_pointer_value(),
+                                    "",
+                                ));
+                            }
+                            bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, true)
+                        }
+                    },
+                    (Type::Pointer(b), Type::IntLiteral | Type::Int(..)) => match op {
+                        "+=" => {
+                            lhs.inter_val = None;
+                            if let (
+                                Some(PointerValue(l)),
+                                Some(IntValue(r)),
+                                SizeType::Static(_),
+                                false,
+                            ) = (lhs.comp_val, rhs.comp_val, b.size(ctx), ctx.is_const.get())
+                            {
+                                unsafe {
+                                    let lv = ctx
+                                        .builder
+                                        .build_load(
+                                            ctx.null_type.ptr_type(Default::default()),
+                                            l,
+                                            "",
+                                        )
+                                        .into_pointer_value();
+                                    let v = ctx.builder.build_gep(
+                                        b.llvm_type(ctx).unwrap(),
+                                        lv,
+                                        &[r],
+                                        "",
+                                    );
+                                    ctx.builder.build_store(l, v);
+                                }
+                            }
+                            Ok(lhs)
+                        }
+                        "-=" => {
+                            lhs.inter_val = None;
+                            if let (
+                                Some(PointerValue(l)),
+                                Some(IntValue(r)),
+                                SizeType::Static(_),
+                                false,
+                            ) = (lhs.comp_val, rhs.comp_val, b.size(ctx), ctx.is_const.get())
+                            {
+                                unsafe {
+                                    let lv = ctx
+                                        .builder
+                                        .build_load(
+                                            ctx.null_type.ptr_type(Default::default()),
+                                            l,
+                                            "",
+                                        )
+                                        .into_pointer_value();
+                                    let rv = ctx.builder.build_int_neg(r, "");
+                                    let v = ctx.builder.build_gep(
+                                        b.llvm_type(ctx).unwrap(),
+                                        lv,
+                                        &[rv],
+                                        "",
+                                    );
+                                    ctx.builder.build_store(l, v);
+                                }
+                            }
+                            Ok(lhs)
+                        }
+                        _ => {
+                            lhs.data_type = Type::Pointer(b);
+                            if !ctx.is_const.get() {
+                                if let Some(v) = lhs.comp_val {
+                                    lhs.comp_val = Some(ctx.builder.build_load(
+                                        ctx.null_type.ptr_type(Default::default()),
+                                        v.into_pointer_value(),
+                                        "",
+                                    ));
+                                }
+                            }
+                            bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, true)
+                        }
+                    },
+                    (Type::Tuple(xv), Type::Tuple(yv)) if xv == yv && op == "=" => {
+                        if let (Some(PointerValue(lv)), Some(rv)) = (lhs.value(ctx), rhs.value(ctx))
+                        {
+                            if !ctx.is_const.get() {
+                                ctx.builder.build_store(lv, rv);
                             }
                         }
-                        bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, true)
+                        lhs.inter_val = None;
+                        Ok(lhs)
                     }
-                }
-                (Type::Tuple(xv), Type::Tuple(yv)) if xv == yv && op == "=" => {
-                    if let (Some(PointerValue(lv)), Some(rv)) = (lhs.value(ctx), rhs.value(ctx)) {
-                        if !ctx.is_const.get() {
-                            ctx.builder.build_store(lv, rv);
-                        }
-                    }
-                    lhs.inter_val = None;
-                    Ok(lhs)
-                }
-                (l, _) => {
-                    if left_move {
-                        lhs.data_type = l;
-                        if !ctx.is_const.get() {
-                            if let Some(PointerValue(v)) = lhs.comp_val {
-                                lhs.comp_val = Some(ctx.builder.build_load(lhs.data_type.llvm_type(ctx).unwrap(), v, ""));
+                    (l, _) => {
+                        if left_move {
+                            lhs.data_type = l;
+                            if !ctx.is_const.get() {
+                                if let Some(PointerValue(v)) = lhs.comp_val {
+                                    lhs.comp_val = Some(ctx.builder.build_load(
+                                        lhs.data_type.llvm_type(ctx).unwrap(),
+                                        v,
+                                        "",
+                                    ));
+                                } else {
+                                    lhs.comp_val = None;
+                                }
                             }
-                            else {
-                                lhs.comp_val = None;
-                            }
+                            bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, right_move)
+                        } else {
+                            Err(CobaltError::CantMoveFromReference {
+                                loc: lloc,
+                                ty: lhs.data_type.to_string(),
+                            })
                         }
-                        bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, right_move)
-                    }
-                    else {
-                        Err(CobaltError::CantMoveFromReference {loc: lloc, ty: lhs.data_type.to_string()})
                     }
                 }
             }
@@ -482,30 +947,57 @@ pub fn bin_op<'ctx>(loc: SourceSpan, (mut lhs, lloc): (Value<'ctx>, SourceSpan),
                 rhs.data_type = *r;
                 if !ctx.is_const.get() {
                     if let Some(PointerValue(v)) = rhs.comp_val {
-                        rhs.comp_val = Some(ctx.builder.build_load(rhs.data_type.llvm_type(ctx).unwrap(), v, ""));
-                    }
-                    else {
+                        rhs.comp_val = Some(ctx.builder.build_load(
+                            rhs.data_type.llvm_type(ctx).unwrap(),
+                            v,
+                            "",
+                        ));
+                    } else {
                         rhs.comp_val = None;
                     }
                 }
                 bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, left_move, true)
+            } else {
+                Err(CobaltError::CantMoveFromReference {
+                    loc: rloc,
+                    ty: rhs.data_type.to_string(),
+                })
             }
-            else {
-                Err(CobaltError::CantMoveFromReference {loc: rloc, ty: rhs.data_type.to_string()})
-            }
-        } 
+        }
         (Type::Int(ls, _), Type::Int(rs, ru)) if ls > rs => {
             if let (Some(IntValue(val)), false) = (rhs.value(ctx), ctx.is_const.get()) {
-                rhs.comp_val = Some(IntValue(if ru {ctx.builder.build_int_z_extend(val, ctx.context.custom_width_int_type(ls as u32), "")}
-                else {ctx.builder.build_int_s_extend(val, ctx.context.custom_width_int_type(ls as u32), "")}));
+                rhs.comp_val = Some(IntValue(if ru {
+                    ctx.builder.build_int_z_extend(
+                        val,
+                        ctx.context.custom_width_int_type(ls as u32),
+                        "",
+                    )
+                } else {
+                    ctx.builder.build_int_s_extend(
+                        val,
+                        ctx.context.custom_width_int_type(ls as u32),
+                        "",
+                    )
+                }));
             }
             rhs.data_type = Type::Int(ls, ru);
             bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, true)
         }
         (Type::Int(ls, lu), Type::Int(rs, _)) if ls < rs => {
             if let (Some(IntValue(val)), false) = (lhs.value(ctx), ctx.is_const.get()) {
-                lhs.comp_val = Some(IntValue(if lu {ctx.builder.build_int_z_extend(val, ctx.context.custom_width_int_type(rs as u32), "")}
-                else {ctx.builder.build_int_s_extend(val, ctx.context.custom_width_int_type(rs as u32), "")}));
+                lhs.comp_val = Some(IntValue(if lu {
+                    ctx.builder.build_int_z_extend(
+                        val,
+                        ctx.context.custom_width_int_type(rs as u32),
+                        "",
+                    )
+                } else {
+                    ctx.builder.build_int_s_extend(
+                        val,
+                        ctx.context.custom_width_int_type(rs as u32),
+                        "",
+                    )
+                }));
             }
             lhs.data_type = Type::Int(rs, lu);
             bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, true)
@@ -513,666 +1005,970 @@ pub fn bin_op<'ctx>(loc: SourceSpan, (mut lhs, lloc): (Value<'ctx>, SourceSpan),
         (Type::Int(ls, lu), Type::Int(rs, ru)) if ls == rs => match op {
             "+" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_add(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_add(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l + r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l + r))
+                    }
+                    _ => None,
                 },
-                Type::Int(max(ls, rs), lu && ru)
+                Type::Int(max(ls, rs), lu && ru),
             )),
             "-" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_sub(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_sub(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l - r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l - r))
+                    }
+                    _ => None,
                 },
-                Type::Int(max(ls, rs), lu && ru)
+                Type::Int(max(ls, rs), lu && ru),
             )),
             "*" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_mul(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_mul(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l * r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l * r))
+                    }
+                    _ => None,
                 },
-                Type::Int(max(ls, rs), lu && ru)
+                Type::Int(max(ls, rs), lu && ru),
             )),
             "/" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(if ru {ctx.builder.build_int_unsigned_div(l, r, "")} else {ctx.builder.build_int_signed_div(l, r, "")})),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(if ru {
+                        ctx.builder.build_int_unsigned_div(l, r, "")
+                    } else {
+                        ctx.builder.build_int_signed_div(l, r, "")
+                    })),
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l / r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l / r))
+                    }
+                    _ => None,
                 },
-                Type::Int(max(ls, rs), ru)
+                Type::Int(max(ls, rs), ru),
             )),
             "%" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(if ru {ctx.builder.build_int_unsigned_rem(l, r, "")} else {ctx.builder.build_int_signed_rem(l, r, "")})),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(if ru {
+                        ctx.builder.build_int_unsigned_rem(l, r, "")
+                    } else {
+                        ctx.builder.build_int_signed_rem(l, r, "")
+                    })),
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l % r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l % r))
+                    }
+                    _ => None,
                 },
-                Type::Int(max(ls, rs), ru)
+                Type::Int(max(ls, rs), ru),
             )),
             "&" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_and(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_and(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l & r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l & r))
+                    }
+                    _ => None,
                 },
-                Type::Int(min(ls, rs), lu || ru)
+                Type::Int(min(ls, rs), lu || ru),
             )),
             "|" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_or(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_or(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l | r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l | r))
+                    }
+                    _ => None,
                 },
-                Type::Int(max(ls, rs), lu || ru)
+                Type::Int(max(ls, rs), lu || ru),
             )),
             "^" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_xor(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_xor(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l ^ r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l ^ r))
+                    }
+                    _ => None,
                 },
-                Type::Int(max(ls, rs), lu || ru)
+                Type::Int(max(ls, rs), lu || ru),
             )),
             "<<" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_left_shift(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_left_shift(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l << r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l << r))
+                    }
+                    _ => None,
                 },
-                Type::Int(max(ls, rs), lu || ru)
+                Type::Int(max(ls, rs), lu || ru),
             )),
             ">>" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_right_shift(l, r, false, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_right_shift(l, r, false, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l >> r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l >> r))
+                    }
+                    _ => None,
                 },
-                Type::Int(max(ls, rs), lu || ru)
+                Type::Int(max(ls, rs), lu || ru),
             )),
             "<" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {ULT} else {SLT}, l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(
+                        ctx.builder
+                            .build_int_compare(if lu && ru { ULT } else { SLT }, l, r, ""),
+                    )),
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(i128::from(l < r))),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(i128::from(l < r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             ">" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {UGT} else {SGT}, l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(
+                        ctx.builder
+                            .build_int_compare(if lu && ru { UGT } else { SGT }, l, r, ""),
+                    )),
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(i128::from(l > r))),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(i128::from(l > r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             "<=" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {ULE} else {SLE}, l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(
+                        ctx.builder
+                            .build_int_compare(if lu && ru { ULE } else { SLE }, l, r, ""),
+                    )),
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(i128::from(l <= r))),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(i128::from(l <= r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             ">=" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(if lu && ru {UGE} else {SGE}, l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(
+                        ctx.builder
+                            .build_int_compare(if lu && ru { UGE } else { SGE }, l, r, ""),
+                    )),
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(i128::from(l >= r))),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(i128::from(l >= r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             "==" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(EQ, l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_compare(EQ, l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(i128::from(l == r))),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(i128::from(l == r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             "!=" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(NE, l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_compare(NE, l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(i128::from(l != r))),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(i128::from(l != r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
-            _ => Err(err)
-        }
-        (x @ Type::Int(..), Type::IntLiteral) => bin_op(loc, (Value {data_type: x.clone(), ..lhs}, lloc), (impl_convert(unreachable_span(), (Value {data_type: Type::IntLiteral, ..rhs}, None), (x, None), ctx).unwrap(), rloc), op, ctx, left_move, right_move),
+            _ => Err(err),
+        },
+        (x @ Type::Int(..), Type::IntLiteral) => bin_op(
+            loc,
+            (
+                Value {
+                    data_type: x.clone(),
+                    ..lhs
+                },
+                lloc,
+            ),
+            (
+                impl_convert(
+                    unreachable_span(),
+                    (
+                        Value {
+                            data_type: Type::IntLiteral,
+                            ..rhs
+                        },
+                        None,
+                    ),
+                    (x, None),
+                    ctx,
+                )
+                .unwrap(),
+                rloc,
+            ),
+            op,
+            ctx,
+            left_move,
+            right_move,
+        ),
         (Type::IntLiteral, x @ Type::Int(..)) => {
             let t = x.clone();
             lhs.data_type = Type::IntLiteral;
-            bin_op(loc, (impl_convert(unreachable_span(), (lhs, None), (x, None), ctx).unwrap(), lloc), (Value {data_type: t, ..rhs}, rloc), op, ctx, true, true)
+            bin_op(
+                loc,
+                (
+                    impl_convert(unreachable_span(), (lhs, None), (x, None), ctx).unwrap(),
+                    lloc,
+                ),
+                (
+                    Value {
+                        data_type: t,
+                        ..rhs
+                    },
+                    rloc,
+                ),
+                op,
+                ctx,
+                true,
+                true,
+            )
         }
         (Type::IntLiteral, Type::IntLiteral) => match op {
             "+" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_add(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_add(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l + r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l + r))
+                    }
+                    _ => None,
                 },
-                Type::IntLiteral
+                Type::IntLiteral,
             )),
             "-" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_sub(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_sub(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l - r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l - r))
+                    }
+                    _ => None,
                 },
-                Type::IntLiteral
+                Type::IntLiteral,
             )),
             "*" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_mul(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_mul(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l * r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l * r))
+                    }
+                    _ => None,
                 },
-                Type::IntLiteral
+                Type::IntLiteral,
             )),
             "/" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_signed_div(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_signed_div(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l / r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l / r))
+                    }
+                    _ => None,
                 },
-                Type::IntLiteral
+                Type::IntLiteral,
             )),
             "%" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_signed_rem(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_signed_rem(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l % r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l % r))
+                    }
+                    _ => None,
                 },
-                Type::IntLiteral
+                Type::IntLiteral,
             )),
             "&" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_and(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_and(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l & r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l & r))
+                    }
+                    _ => None,
                 },
-                Type::IntLiteral
+                Type::IntLiteral,
             )),
             "|" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_or(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_or(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l | r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l | r))
+                    }
+                    _ => None,
                 },
-                Type::IntLiteral
+                Type::IntLiteral,
             )),
             "^" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_xor(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_xor(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l ^ r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l ^ r))
+                    }
+                    _ => None,
                 },
-                Type::IntLiteral
+                Type::IntLiteral,
             )),
             "<<" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_left_shift(l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_left_shift(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l << r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l << r))
+                    }
+                    _ => None,
                 },
-                Type::IntLiteral
+                Type::IntLiteral,
             )),
             ">>" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_right_shift(l, r, false, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_right_shift(l, r, false, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(l >> r)),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(l >> r))
+                    }
+                    _ => None,
                 },
-                Type::IntLiteral
+                Type::IntLiteral,
             )),
             "<" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(SLT, l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_compare(SLT, l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(i128::from(l < r))),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(i128::from(l < r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             ">" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(SGT, l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_compare(SGT, l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(i128::from(l > r))),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(i128::from(l > r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             "<=" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(SLE, l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_compare(SLE, l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(i128::from(l <= r))),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(i128::from(l <= r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             ">=" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(SGE, l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_compare(SGE, l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(i128::from(l >= r))),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(i128::from(l >= r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             "==" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(EQ, l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_compare(EQ, l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(i128::from(l == r))),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(i128::from(l == r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             "!=" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(IntValue(l)), Some(IntValue(r)), false) => Some(IntValue(ctx.builder.build_int_compare(NE, l, r, ""))),
-                    _ => None
+                    (Some(IntValue(l)), Some(IntValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_int_compare(NE, l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => Some(InterData::Int(i128::from(l != r))),
-                    _ => None
+                    (Some(InterData::Int(l)), Some(InterData::Int(r))) => {
+                        Some(InterData::Int(i128::from(l != r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         (Type::Pointer(b), Type::Int(..) | Type::IntLiteral) => match op {
             "+" => Ok(Value::new(
                 match (lhs.comp_val, rhs.comp_val, b.size(ctx), ctx.is_const.get()) {
-                    (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) => Some(unsafe {ctx.builder.build_gep(ctx.null_type.ptr_type(Default::default()), l, &[r], "").into()}),
-                    _ => None
+                    (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) => {
+                        Some(unsafe {
+                            ctx.builder
+                                .build_gep(ctx.null_type.ptr_type(Default::default()), l, &[r], "")
+                                .into()
+                        })
+                    }
+                    _ => None,
                 },
                 None,
-                Type::Pointer(b)
+                Type::Pointer(b),
             )),
             "-" => Ok(Value::new(
                 match (lhs.comp_val, rhs.comp_val, b.size(ctx), ctx.is_const.get()) {
-                    (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) => Some(unsafe {
-                        let v = ctx.builder.build_int_neg(r, "");
-                        ctx.builder.build_gep(ctx.null_type.ptr_type(Default::default()), l, &[v], "").into()
-                    }),
-                    _ => None
+                    (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) => {
+                        Some(unsafe {
+                            let v = ctx.builder.build_int_neg(r, "");
+                            ctx.builder
+                                .build_gep(ctx.null_type.ptr_type(Default::default()), l, &[v], "")
+                                .into()
+                        })
+                    }
+                    _ => None,
                 },
                 None,
-                Type::Pointer(b)
+                Type::Pointer(b),
             )),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         (Type::Int(..) | Type::IntLiteral, Type::Pointer(b)) => match op {
             "+" => Ok(Value::new(
-                match (rhs.comp_val, lhs.comp_val, b.size(ctx), ctx.is_const.get()) { // I just swapped the sides here
-                    (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) => Some(unsafe {ctx.builder.build_gep(ctx.null_type.ptr_type(Default::default()), l, &[r], "").into()}),
-                    _ => None
+                match (rhs.comp_val, lhs.comp_val, b.size(ctx), ctx.is_const.get()) {
+                    // I just swapped the sides here
+                    (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) => {
+                        Some(unsafe {
+                            ctx.builder
+                                .build_gep(ctx.null_type.ptr_type(Default::default()), l, &[r], "")
+                                .into()
+                        })
+                    }
+                    _ => None,
                 },
                 None,
-                Type::Pointer(b)
+                Type::Pointer(b),
             )),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         (l @ Type::Pointer(..), r @ Type::Pointer(..)) => match op {
             "-" if l == r => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
-                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32 * 8);
+                        let pt = ctx
+                            .context
+                            .custom_width_int_type(ctx.flags.word_size as u32 * 8);
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_ptr_to_int(r, pt, "");
                         Some(IntValue(ctx.builder.build_int_sub(v1, v2, "")))
-                    },
-                    _ => None
+                    }
+                    _ => None,
                 },
                 None,
-                Type::Int(64, false)
+                Type::Int(64, false),
             )),
             "<" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
-                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32 * 8);
+                        let pt = ctx
+                            .context
+                            .custom_width_int_type(ctx.flags.word_size as u32 * 8);
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_ptr_to_int(r, pt, "");
                         Some(IntValue(ctx.builder.build_int_compare(ULT, v1, v2, "")))
-                    },
-                    _ => None
+                    }
+                    _ => None,
                 },
                 None,
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             ">" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
-                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32 * 8);
+                        let pt = ctx
+                            .context
+                            .custom_width_int_type(ctx.flags.word_size as u32 * 8);
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_ptr_to_int(r, pt, "");
                         Some(IntValue(ctx.builder.build_int_compare(UGT, v1, v2, "")))
-                    },
-                    _ => None
+                    }
+                    _ => None,
                 },
                 None,
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             "<=" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
-                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32 * 8);
+                        let pt = ctx
+                            .context
+                            .custom_width_int_type(ctx.flags.word_size as u32 * 8);
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_ptr_to_int(r, pt, "");
                         Some(IntValue(ctx.builder.build_int_compare(ULE, v1, v2, "")))
-                    },
-                    _ => None
+                    }
+                    _ => None,
                 },
                 None,
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             ">=" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
-                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32 * 8);
+                        let pt = ctx
+                            .context
+                            .custom_width_int_type(ctx.flags.word_size as u32 * 8);
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_ptr_to_int(r, pt, "");
                         Some(IntValue(ctx.builder.build_int_compare(UGE, v1, v2, "")))
-                    },
-                    _ => None
+                    }
+                    _ => None,
                 },
                 None,
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             "==" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
-                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32 * 8);
+                        let pt = ctx
+                            .context
+                            .custom_width_int_type(ctx.flags.word_size as u32 * 8);
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_ptr_to_int(r, pt, "");
                         Some(IntValue(ctx.builder.build_int_compare(EQ, v1, v2, "")))
-                    },
-                    _ => None
+                    }
+                    _ => None,
                 },
                 None,
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             "!=" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
                     (Some(PointerValue(l)), Some(PointerValue(r)), false) => {
-                        let pt = ctx.context.custom_width_int_type(ctx.flags.word_size as u32 * 8);
+                        let pt = ctx
+                            .context
+                            .custom_width_int_type(ctx.flags.word_size as u32 * 8);
                         let v1 = ctx.builder.build_ptr_to_int(l, pt, "");
                         let v2 = ctx.builder.build_ptr_to_int(r, pt, "");
                         Some(IntValue(ctx.builder.build_int_compare(NE, v1, v2, "")))
-                    },
-                    _ => None
+                    }
+                    _ => None,
                 },
                 None,
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
-            _ => Err(err)
-        }
-        (l @ (Type::Float16 | Type::Float32 | Type::Float64), r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128)) if l.size(ctx) < r.size(ctx) => {
+            _ => Err(err),
+        },
+        (
+            l @ (Type::Float16 | Type::Float32 | Type::Float64),
+            r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128),
+        ) if l.size(ctx) < r.size(ctx) => {
             lhs.comp_val = match (lhs.comp_val, ctx.is_const.get()) {
-                (Some(FloatValue(l)), false) => Some(FloatValue(ctx.builder.build_float_cast(l, r.llvm_type(ctx).unwrap().into_float_type(), ""))),
-                _ => None
+                (Some(FloatValue(l)), false) => Some(FloatValue(ctx.builder.build_float_cast(
+                    l,
+                    r.llvm_type(ctx).unwrap().into_float_type(),
+                    "",
+                ))),
+                _ => None,
             };
             lhs.data_type = r.clone();
             rhs.data_type = r;
             bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, true)
         }
-        (l @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128), r @ (Type::Float16 | Type::Float32 | Type::Float64)) if l.size(ctx) > r.size(ctx) => {
+        (
+            l @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128),
+            r @ (Type::Float16 | Type::Float32 | Type::Float64),
+        ) if l.size(ctx) > r.size(ctx) => {
             rhs.comp_val = match (rhs.comp_val, ctx.is_const.get()) {
-                (Some(FloatValue(r)), false) => Some(FloatValue(ctx.builder.build_float_cast(r, l.llvm_type(ctx).unwrap().into_float_type(), ""))),
-                _ => None
+                (Some(FloatValue(r)), false) => Some(FloatValue(ctx.builder.build_float_cast(
+                    r,
+                    l.llvm_type(ctx).unwrap().into_float_type(),
+                    "",
+                ))),
+                _ => None,
             };
             lhs.data_type = l.clone();
             rhs.data_type = l;
             bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, true)
         }
-        (l @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128), r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128)) if l == r => match op {
+        (
+            l @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128),
+            r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128),
+        ) if l == r => match op {
             "+" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(FloatValue(ctx.builder.build_float_add(l, r, ""))),
-                    _ => None
+                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => {
+                        Some(FloatValue(ctx.builder.build_float_add(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l + r)),
-                    _ => None
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => {
+                        Some(InterData::Float(l + r))
+                    }
+                    _ => None,
                 },
-                l
+                l,
             )),
             "-" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(FloatValue(ctx.builder.build_float_sub(l, r, ""))),
-                    _ => None
+                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => {
+                        Some(FloatValue(ctx.builder.build_float_sub(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l - r)),
-                    _ => None
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => {
+                        Some(InterData::Float(l - r))
+                    }
+                    _ => None,
                 },
-                l
+                l,
             )),
             "*" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(FloatValue(ctx.builder.build_float_mul(l, r, ""))),
-                    _ => None
+                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => {
+                        Some(FloatValue(ctx.builder.build_float_mul(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l * r)),
-                    _ => None
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => {
+                        Some(InterData::Float(l * r))
+                    }
+                    _ => None,
                 },
-                l
+                l,
             )),
             "/" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(FloatValue(ctx.builder.build_float_div(l, r, ""))),
-                    _ => None
+                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => {
+                        Some(FloatValue(ctx.builder.build_float_div(l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l / r)),
-                    _ => None
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => {
+                        Some(InterData::Float(l / r))
+                    }
+                    _ => None,
                 },
-                l
+                l,
             )),
             "%" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
                     (Some(FloatValue(_l)), Some(FloatValue(_r)), false) => None, // TODO: implement fmod
-                    _ => None
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Float(l.rem_euclid(r))),
-                    _ => None
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => {
+                        Some(InterData::Float(l.rem_euclid(r)))
+                    }
+                    _ => None,
                 },
-                l
+                l,
             )),
             "<" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OLT, l, r, ""))),
-                    _ => None
+                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_float_compare(OLT, l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(i128::from(l < r))),
-                    _ => None
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => {
+                        Some(InterData::Int(i128::from(l < r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             ">" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OGT, l, r, ""))),
-                    _ => None
+                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_float_compare(OGT, l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(i128::from(l > r))),
-                    _ => None
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => {
+                        Some(InterData::Int(i128::from(l > r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             "<=" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OLE, l, r, ""))),
-                    _ => None
+                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_float_compare(OLE, l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(i128::from(l <= r))),
-                    _ => None
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => {
+                        Some(InterData::Int(i128::from(l <= r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             ">=" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OGE, l, r, ""))),
-                    _ => None
+                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_float_compare(OGE, l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(i128::from(l >= r))),
-                    _ => None
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => {
+                        Some(InterData::Int(i128::from(l >= r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             "==" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(OEQ, l, r, ""))),
-                    _ => None
+                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_float_compare(OEQ, l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(i128::from(l == r))),
-                    _ => None
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => {
+                        Some(InterData::Int(i128::from(l == r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
             "!=" => Ok(Value::new(
                 match (lhs.value(ctx), rhs.value(ctx), ctx.is_const.get()) {
-                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => Some(IntValue(ctx.builder.build_float_compare(ONE, l, r, ""))),
-                    _ => None
+                    (Some(FloatValue(l)), Some(FloatValue(r)), false) => {
+                        Some(IntValue(ctx.builder.build_float_compare(ONE, l, r, "")))
+                    }
+                    _ => None,
                 },
                 match (lhs.inter_val, rhs.inter_val) {
-                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => Some(InterData::Int(i128::from(l != r))),
-                    _ => None
+                    (Some(InterData::Float(l)), Some(InterData::Float(r))) => {
+                        Some(InterData::Int(i128::from(l != r)))
+                    }
+                    _ => None,
                 },
-                Type::Int(1, false)
+                Type::Int(1, false),
             )),
-            _ => Err(err)
-        }
-        (l @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128), r @ (Type::IntLiteral | Type::Int(..))) => {
+            _ => Err(err),
+        },
+        (
+            l @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128),
+            r @ (Type::IntLiteral | Type::Int(..)),
+        ) => {
             if let (Some(IntValue(rv)), false) = (rhs.comp_val, ctx.is_const.get()) {
                 rhs.comp_val = Some(FloatValue(match r {
-                    Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(rv, l.llvm_type(ctx).unwrap().into_float_type(), ""),
-                    _ => ctx.builder.build_unsigned_int_to_float(rv, l.llvm_type(ctx).unwrap().into_float_type(), "")
+                    Type::IntLiteral | Type::Int(_, false) => {
+                        ctx.builder.build_signed_int_to_float(
+                            rv,
+                            l.llvm_type(ctx).unwrap().into_float_type(),
+                            "",
+                        )
+                    }
+                    _ => ctx.builder.build_unsigned_int_to_float(
+                        rv,
+                        l.llvm_type(ctx).unwrap().into_float_type(),
+                        "",
+                    ),
                 }));
             }
             lhs.data_type = l.clone();
             rhs.data_type = l;
             bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, true)
         }
-        (l @ (Type::IntLiteral | Type::Int(..)), r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128)) => {
+        (
+            l @ (Type::IntLiteral | Type::Int(..)),
+            r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128),
+        ) => {
             if let (Some(IntValue(lv)), false) = (lhs.comp_val, ctx.is_const.get()) {
                 lhs.comp_val = Some(FloatValue(match l {
-                    Type::IntLiteral | Type::Int(_, false) => ctx.builder.build_signed_int_to_float(lv, r.llvm_type(ctx).unwrap().into_float_type(), ""),
-                    _ => ctx.builder.build_unsigned_int_to_float(lv, r.llvm_type(ctx).unwrap().into_float_type(), "")
+                    Type::IntLiteral | Type::Int(_, false) => {
+                        ctx.builder.build_signed_int_to_float(
+                            lv,
+                            r.llvm_type(ctx).unwrap().into_float_type(),
+                            "",
+                        )
+                    }
+                    _ => ctx.builder.build_unsigned_int_to_float(
+                        lv,
+                        r.llvm_type(ctx).unwrap().into_float_type(),
+                        "",
+                    ),
                 }));
             }
             lhs.data_type = r.clone();
             rhs.data_type = r;
             bin_op(loc, (lhs, lloc), (rhs, rloc), op, ctx, true, true)
         }
-        _ => Err(err)
+        _ => Err(err),
     };
     out.map_err(|err| {
         let tyname = ldt.to_string();
         let non_mut = !matches!(ldt, Type::Mut(_)) && {
             let oic = ctx.is_const.replace(true);
-            let lhs = Value {data_type: Type::Mut(Box::new(ldt)), ..Value::null()};
-            let rhs = Value {data_type: rdt, ..Value::null()};
+            let lhs = Value {
+                data_type: Type::Mut(Box::new(ldt)),
+                ..Value::null()
+            };
+            let rhs = Value {
+                data_type: rdt,
+                ..Value::null()
+            };
             let uloc = unreachable_span();
             let non_mut = bin_op(uloc, (lhs, uloc), (rhs, uloc), op, ctx, true, true).is_ok();
             ctx.is_const.set(oic);
@@ -1184,35 +1980,49 @@ pub fn bin_op<'ctx>(loc: SourceSpan, (mut lhs, lloc): (Value<'ctx>, SourceSpan),
                 ty: tyname,
                 oloc: Some(loc),
                 op: op.to_string(),
-                floc: lf.unwrap()
+                floc: lf.unwrap(),
             }
-        } else {err}
+        } else {
+            err
+        }
     })
 }
-pub fn pre_op<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, SourceSpan), op: &str, ctx: &CompCtx<'ctx>, can_move: bool) -> Result<Value<'ctx>, CobaltError> {
+pub fn pre_op<'ctx>(
+    loc: SourceSpan,
+    (mut val, vloc): (Value<'ctx>, SourceSpan),
+    op: &str,
+    ctx: &CompCtx<'ctx>,
+    can_move: bool,
+) -> Result<Value<'ctx>, CobaltError> {
     let err = CobaltError::PreOpNotDefined {
         val: val.data_type.to_string(),
         op: op.to_string(),
-        vloc, oloc: loc
+        vloc,
+        oloc: loc,
     };
     let vdt = val.data_type.clone();
     let vf = val.frozen;
     let out = match val.data_type.clone() {
-        Type::Reference(x) => if op == "&" {
-            val.data_type = Type::Pointer(x);
-            Ok(val)
-        }
-        else {
-            val.data_type = *x;
-            let can_move = !val.data_type.has_dtor(ctx);
-            if !(ctx.is_const.get() || matches!(val.data_type, Type::Mut(_))) {
-                if let Some(v) = val.comp_val {
-                    val.comp_val = Some(ctx.builder.build_load(val.data_type.llvm_type(ctx).unwrap(), v.into_pointer_value(), ""));
+        Type::Reference(x) => {
+            if op == "&" {
+                val.data_type = Type::Pointer(x);
+                Ok(val)
+            } else {
+                val.data_type = *x;
+                let can_move = !val.data_type.has_dtor(ctx);
+                if !(ctx.is_const.get() || matches!(val.data_type, Type::Mut(_))) {
+                    if let Some(v) = val.comp_val {
+                        val.comp_val = Some(ctx.builder.build_load(
+                            val.data_type.llvm_type(ctx).unwrap(),
+                            v.into_pointer_value(),
+                            "",
+                        ));
+                    }
                 }
+                val = pre_op(loc, (val, vloc), op, ctx, can_move)?;
+                val.data_type = add_ref(val.data_type);
+                Ok(val)
             }
-            val = pre_op(loc, (val, vloc), op, ctx, can_move)?;
-            val.data_type = add_ref(val.data_type);
-            Ok(val)
         }
         Type::Mut(x) => match *x {
             Type::IntLiteral => panic!("There shouldn't be a reference to an integer literal"),
@@ -1241,12 +2051,16 @@ pub fn pre_op<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, SourceSpan),
                     val.data_type = x;
                     if !ctx.is_const.get() {
                         if let Some(v) = val.comp_val {
-                            val.comp_val = Some(ctx.builder.build_load(val.data_type.llvm_type(ctx).unwrap(), v.into_pointer_value(), ""));
+                            val.comp_val = Some(ctx.builder.build_load(
+                                val.data_type.llvm_type(ctx).unwrap(),
+                                v.into_pointer_value(),
+                                "",
+                            ));
                         }
                     }
                     pre_op(loc, (val, vloc), op, ctx, true)
                 }
-            }
+            },
             x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => match op {
                 "++" => {
                     if let (Some(PointerValue(v)), false) = (val.comp_val, ctx.is_const.get()) {
@@ -1272,28 +2086,50 @@ pub fn pre_op<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, SourceSpan),
                     val.data_type = x;
                     if !ctx.is_const.get() {
                         if let Some(v) = val.comp_val {
-                            val.comp_val = Some(ctx.builder.build_load(val.data_type.llvm_type(ctx).unwrap(), v.into_pointer_value(), ""));
+                            val.comp_val = Some(ctx.builder.build_load(
+                                val.data_type.llvm_type(ctx).unwrap(),
+                                v.into_pointer_value(),
+                                "",
+                            ));
                         }
                     }
                     pre_op(loc, (val, vloc), op, ctx, true)
                 }
-            }
+            },
             Type::Pointer(b) => match op {
                 "++" => {
-                    if let (Some(PointerValue(v)), SizeType::Static(_), false) = (val.comp_val, b.size(ctx), ctx.is_const.get()) {
+                    if let (Some(PointerValue(v)), SizeType::Static(_), false) =
+                        (val.comp_val, b.size(ctx), ctx.is_const.get())
+                    {
                         let pt = ctx.null_type.ptr_type(Default::default());
                         let v1 = ctx.builder.build_load(pt, v, "").into_pointer_value();
-                        let v2 = unsafe {ctx.builder.build_gep(pt, v1, &[ctx.context.i8_type().const_int(1, true)], "")};
+                        let v2 = unsafe {
+                            ctx.builder.build_gep(
+                                pt,
+                                v1,
+                                &[ctx.context.i8_type().const_int(1, true)],
+                                "",
+                            )
+                        };
                         ctx.builder.build_store(v, v2);
                     }
                     val.inter_val = None;
                     Ok(val)
                 }
                 "--" => {
-                    if let (Some(PointerValue(v)), SizeType::Static(_), false) = (val.comp_val, b.size(ctx), ctx.is_const.get()) {
+                    if let (Some(PointerValue(v)), SizeType::Static(_), false) =
+                        (val.comp_val, b.size(ctx), ctx.is_const.get())
+                    {
                         let pt = ctx.null_type.ptr_type(Default::default());
                         let v1 = ctx.builder.build_load(pt, v, "").into_pointer_value();
-                        let v2 = unsafe {ctx.builder.build_gep(pt, v1, &[ctx.context.i8_type().const_int(u64::MAX, true)], "")};
+                        let v2 = unsafe {
+                            ctx.builder.build_gep(
+                                pt,
+                                v1,
+                                &[ctx.context.i8_type().const_int(u64::MAX, true)],
+                                "",
+                            )
+                        };
                         ctx.builder.build_store(v, v2);
                     }
                     val.inter_val = None;
@@ -1303,114 +2139,206 @@ pub fn pre_op<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, SourceSpan),
                     val.data_type = Type::Pointer(b);
                     if !ctx.is_const.get() {
                         if let Some(v) = val.comp_val {
-                            val.comp_val = Some(ctx.builder.build_load(ctx.null_type.ptr_type(Default::default()), v.into_pointer_value(), ""));
+                            val.comp_val = Some(ctx.builder.build_load(
+                                ctx.null_type.ptr_type(Default::default()),
+                                v.into_pointer_value(),
+                                "",
+                            ));
                         }
                     }
                     pre_op(loc, (val, vloc), op, ctx, true)
                 }
-            }
+            },
             x => {
                 if can_move {
                     val.data_type = x;
                     if !ctx.is_const.get() {
                         if let Some(v) = val.comp_val {
-                            val.comp_val = Some(ctx.builder.build_load(val.data_type.llvm_type(ctx).unwrap(), v.into_pointer_value(), ""));
+                            val.comp_val = Some(ctx.builder.build_load(
+                                val.data_type.llvm_type(ctx).unwrap(),
+                                v.into_pointer_value(),
+                                "",
+                            ));
                         }
                     }
                     pre_op(loc, (val, vloc), op, ctx, true)
-                }
-                else {
-                    Err(CobaltError::CantMoveFromReference {loc, ty: val.data_type.to_string()})
+                } else {
+                    Err(CobaltError::CantMoveFromReference {
+                        loc,
+                        ty: val.data_type.to_string(),
+                    })
                 }
             }
-        }
+        },
         Type::IntLiteral => match op {
             "+" => {
                 val.data_type = Type::IntLiteral;
                 Ok(val)
-            },
+            }
             "-" => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(IntValue(ctx.builder.build_int_neg(v, "")))} else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(-v))} else {None},
-                Type::IntLiteral
+                if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {
+                    Some(IntValue(ctx.builder.build_int_neg(v, "")))
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Int(-v))
+                } else {
+                    None
+                },
+                Type::IntLiteral,
             )),
             "~" => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(IntValue(ctx.builder.build_xor(v, ctx.context.i64_type().const_all_ones(), "")))} else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(!v))} else {None},
-                Type::IntLiteral
+                if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {
+                    Some(IntValue(ctx.builder.build_xor(
+                        v,
+                        ctx.context.i64_type().const_all_ones(),
+                        "",
+                    )))
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Int(!v))
+                } else {
+                    None
+                },
+                Type::IntLiteral,
             )),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         Type::Int(s, u) => match op {
             "+" => {
                 val.data_type = Type::Int(s, u);
                 Ok(val)
-            },
+            }
             "-" => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(IntValue(ctx.builder.build_int_neg(v, "")))} else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(-v))} else {None},
-                Type::Int(s, u)
+                if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {
+                    Some(IntValue(ctx.builder.build_int_neg(v, "")))
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Int(-v))
+                } else {
+                    None
+                },
+                Type::Int(s, u),
             )),
             "~" => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(IntValue(ctx.builder.build_xor(v, ctx.context.custom_width_int_type(s as u32).const_all_ones(), "")))} else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(!v))} else {None},
-                Type::Int(s, u)
+                if let (Some(IntValue(v)), false) = (val.comp_val, ctx.is_const.get()) {
+                    Some(IntValue(ctx.builder.build_xor(
+                        v,
+                        ctx.context.custom_width_int_type(s as u32).const_all_ones(),
+                        "",
+                    )))
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Int(!v))
+                } else {
+                    None
+                },
+                Type::Int(s, u),
             )),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => match op {
             "+" => {
                 val.data_type = x;
                 Ok(val)
-            },
+            }
             "-" => Ok(Value::new(
-                if let (Some(FloatValue(v)), false) = (val.comp_val, ctx.is_const.get()) {Some(FloatValue(ctx.builder.build_float_neg(v, "")))} else {None},
-                if let Some(InterData::Float(v)) = val.inter_val {Some(InterData::Float(-v))} else {None},
-                x
+                if let (Some(FloatValue(v)), false) = (val.comp_val, ctx.is_const.get()) {
+                    Some(FloatValue(ctx.builder.build_float_neg(v, "")))
+                } else {
+                    None
+                },
+                if let Some(InterData::Float(v)) = val.inter_val {
+                    Some(InterData::Float(-v))
+                } else {
+                    None
+                },
+                x,
             )),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         Type::Pointer(b) => match op {
             "*" => {
                 val.data_type = Type::Reference(b);
                 Ok(val)
-            },
-            _ => Err(err)
-        }
+            }
+            _ => Err(err),
+        },
         Type::TypeData => match op {
-            "&" => if let Some(InterData::Type(t)) = val.inter_val {Ok(Value::make_type(Type::Reference(weak_decay_boxed(t))))} else {Err(err)}
-            "*" => if let Some(InterData::Type(t)) = val.inter_val {Ok(Value::make_type(Type::Pointer(weak_decay_boxed(t))))} else {Err(err)}
-            "mut" => if let Some(InterData::Type(t)) = val.inter_val {Ok(Value::make_type(Type::Mut(weak_decay_boxed(t))))} else {Err(err)}
-            _ => Err(err)
-        }
+            "&" => {
+                if let Some(InterData::Type(t)) = val.inter_val {
+                    Ok(Value::make_type(Type::Reference(weak_decay_boxed(t))))
+                } else {
+                    Err(err)
+                }
+            }
+            "*" => {
+                if let Some(InterData::Type(t)) = val.inter_val {
+                    Ok(Value::make_type(Type::Pointer(weak_decay_boxed(t))))
+                } else {
+                    Err(err)
+                }
+            }
+            "mut" => {
+                if let Some(InterData::Type(t)) = val.inter_val {
+                    Ok(Value::make_type(Type::Mut(weak_decay_boxed(t))))
+                } else {
+                    Err(err)
+                }
+            }
+            _ => Err(err),
+        },
         Type::Null => match op {
             "&" => Ok(Value::make_type(Type::Reference(Box::new(Type::Null)))),
             "*" => Ok(Value::make_type(Type::Pointer(Box::new(Type::Null)))),
             "mut" => Ok(Value::make_type(Type::Mut(Box::new(Type::Null)))),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         Type::Tuple(v) => {
             if let Some(InterData::Array(a)) = val.inter_val {
                 let mut vec = Vec::with_capacity(v.len());
                 for (iv, dt) in a.into_iter().zip(v) {
-                    vec.push(impl_convert(unreachable_span(), (Value::metaval(iv, dt), None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).ok_or(err.clone())?);
+                    vec.push(
+                        impl_convert(
+                            unreachable_span(),
+                            (Value::metaval(iv, dt), None),
+                            (Type::TypeData, None),
+                            ctx,
+                        )
+                        .ok()
+                        .and_then(Value::into_type)
+                        .ok_or(err.clone())?,
+                    );
                 }
                 match op {
-                    "&" => Ok(Value::make_type(Type::Reference(Box::new(Type::Tuple(vec))))),
+                    "&" => Ok(Value::make_type(Type::Reference(Box::new(Type::Tuple(
+                        vec,
+                    ))))),
                     "*" => Ok(Value::make_type(Type::Pointer(Box::new(Type::Tuple(vec))))),
                     "mut" => Ok(Value::make_type(Type::Mut(Box::new(Type::Tuple(vec))))),
-                    _ => Err(err)
+                    _ => Err(err),
                 }
+            } else {
+                Err(err)
             }
-            else {Err(err)}
         }
-        _ => Err(err)
+        _ => Err(err),
     };
     out.map_err(|err| {
         let tyname = vdt.to_string();
         let non_mut = (!matches!(vdt, Type::Mut(_))) && {
             let oic = ctx.is_const.replace(true);
-            let val = Value {data_type: Type::Mut(Box::new(vdt)), ..Value::null()};
+            let val = Value {
+                data_type: Type::Mut(Box::new(vdt)),
+                ..Value::null()
+            };
             let uloc = unreachable_span();
             let non_mut = post_op(uloc, (val, uloc), op, ctx, true).is_ok();
             ctx.is_const.set(oic);
@@ -1422,17 +2350,26 @@ pub fn pre_op<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, SourceSpan),
                 ty: tyname,
                 oloc: Some(loc),
                 op: op.to_string(),
-                floc: vf.unwrap()
+                floc: vf.unwrap(),
             }
-        } else {err}
+        } else {
+            err
+        }
     })
 }
-pub fn post_op<'ctx>(loc: SourceSpan, (val, vloc): (Value<'ctx>, SourceSpan), op: &str, ctx: &CompCtx<'ctx>, can_move: bool) -> Result<Value<'ctx>, CobaltError> {
+pub fn post_op<'ctx>(
+    loc: SourceSpan,
+    (val, vloc): (Value<'ctx>, SourceSpan),
+    op: &str,
+    ctx: &CompCtx<'ctx>,
+    can_move: bool,
+) -> Result<Value<'ctx>, CobaltError> {
     #![allow(clippy::redundant_clone, clippy::only_used_in_recursion)]
     let err = CobaltError::PostOpNotDefined {
         val: val.data_type.to_string(),
         op: op.to_string(),
-        vloc, oloc: loc
+        vloc,
+        oloc: loc,
     };
     let vdt = val.data_type.clone();
     let vf = val.frozen;
@@ -1441,7 +2378,10 @@ pub fn post_op<'ctx>(loc: SourceSpan, (val, vloc): (Value<'ctx>, SourceSpan), op
         let tyname = vdt.to_string();
         let non_mut = (!matches!(vdt, Type::Mut(_))) && {
             let oic = ctx.is_const.replace(true);
-            let val = Value {data_type: Type::Mut(Box::new(vdt)), ..Value::null()};
+            let val = Value {
+                data_type: Type::Mut(Box::new(vdt)),
+                ..Value::null()
+            };
             let uloc = unreachable_span();
             let non_mut = post_op(uloc, (val, uloc), op, ctx, can_move).is_ok();
             ctx.is_const.set(oic);
@@ -1453,16 +2393,23 @@ pub fn post_op<'ctx>(loc: SourceSpan, (val, vloc): (Value<'ctx>, SourceSpan), op
                 ty: tyname,
                 oloc: Some(loc),
                 op: op.to_string(),
-                floc: vf.unwrap()
+                floc: vf.unwrap(),
             }
-        } else {err}
+        } else {
+            err
+        }
     })
 }
-pub fn subscript<'ctx>((mut val, vloc): (Value<'ctx>, SourceSpan), (mut idx, iloc): (Value<'ctx>, SourceSpan), ctx: &CompCtx<'ctx>) -> Result<Value<'ctx>, CobaltError> {
+pub fn subscript<'ctx>(
+    (mut val, vloc): (Value<'ctx>, SourceSpan),
+    (mut idx, iloc): (Value<'ctx>, SourceSpan),
+    ctx: &CompCtx<'ctx>,
+) -> Result<Value<'ctx>, CobaltError> {
     let err = CobaltError::SubscriptNotDefined {
         val: val.data_type.to_string(),
         sub: idx.data_type.to_string(),
-        vloc, sloc: iloc
+        vloc,
+        sloc: iloc,
     };
     match idx.data_type {
         Type::Reference(x) => {
@@ -1479,377 +2426,1012 @@ pub fn subscript<'ctx>((mut val, vloc): (Value<'ctx>, SourceSpan), (mut idx, ilo
             match val.data_type.clone() {
                 Type::Pointer(b) => match idx.data_type.clone() {
                     Type::IntLiteral | Type::Int(..) => Ok(Value::new(
-                        match (val.comp_val, idx.value(ctx), b.size(ctx), ctx.is_const.get()) {
-                            (Some(PointerValue(l)), Some(IntValue(r)), SizeType::Static(_), false) => Some(unsafe {ctx.builder.build_gep(ctx.null_type.ptr_type(Default::default()), l, &[r], "").into()}),
-                            _ => None
+                        match (
+                            val.comp_val,
+                            idx.value(ctx),
+                            b.size(ctx),
+                            ctx.is_const.get(),
+                        ) {
+                            (
+                                Some(PointerValue(l)),
+                                Some(IntValue(r)),
+                                SizeType::Static(_),
+                                false,
+                            ) => Some(unsafe {
+                                ctx.builder
+                                    .build_gep(
+                                        ctx.null_type.ptr_type(Default::default()),
+                                        l,
+                                        &[r],
+                                        "",
+                                    )
+                                    .into()
+                            }),
+                            _ => None,
                         },
                         None,
-                        Type::Reference(b)
+                        Type::Reference(b),
                     )),
-                    _ => Err(err)
-                }
+                    _ => Err(err),
+                },
                 Type::Reference(b) => match *b {
                     Type::Mut(b) => match *b {
                         Type::Array(b, None) => match idx.data_type.clone() {
                             Type::IntLiteral | Type::Int(_, true) => Ok(Value::new(
-                                if let (Some(StructValue(sv)), Some(IntValue(iv)), SizeType::Static(_), false) = (val.value(ctx), idx.value(ctx), b.size(ctx), ctx.is_const.get()) {
-                                    let raw = ctx.builder.build_extract_value(sv, 0, "").unwrap().into_pointer_value();
+                                if let (
+                                    Some(StructValue(sv)),
+                                    Some(IntValue(iv)),
+                                    SizeType::Static(_),
+                                    false,
+                                ) = (
+                                    val.value(ctx),
+                                    idx.value(ctx),
+                                    b.size(ctx),
+                                    ctx.is_const.get(),
+                                ) {
+                                    let raw = ctx
+                                        .builder
+                                        .build_extract_value(sv, 0, "")
+                                        .unwrap()
+                                        .into_pointer_value();
                                     if ctx.flags.bounds_checks {
-                                        let len = ctx.builder.build_extract_value(sv, 1, "").unwrap().into_int_value();
-                                        let f = ctx.builder.get_insert_block().unwrap().get_parent().unwrap();
+                                        let len = ctx
+                                            .builder
+                                            .build_extract_value(sv, 1, "")
+                                            .unwrap()
+                                            .into_int_value();
+                                        let f = ctx
+                                            .builder
+                                            .get_insert_block()
+                                            .unwrap()
+                                            .get_parent()
+                                            .unwrap();
                                         let ge0 = ctx.context.append_basic_block(f, "idx.ge0"); // greater than or equal to 0
                                         let ltm = ctx.context.append_basic_block(f, "idx.ltm"); // less than max
                                         let bad = ctx.context.append_basic_block(f, "idx.bad");
                                         let merge = ctx.context.append_basic_block(f, "merge");
-                                        let lt0cmp = ctx.builder.build_int_compare(SLT, iv, idx.data_type.llvm_type(ctx).unwrap().const_zero().into_int_value(), "");
+                                        let lt0cmp = ctx.builder.build_int_compare(
+                                            SLT,
+                                            iv,
+                                            idx.data_type
+                                                .llvm_type(ctx)
+                                                .unwrap()
+                                                .const_zero()
+                                                .into_int_value(),
+                                            "",
+                                        );
                                         ctx.builder.build_conditional_branch(lt0cmp, bad, ge0);
                                         ctx.builder.position_at_end(ge0);
-                                        let gtmcmp = ctx.builder.build_int_compare(SLT, iv, len, "");
+                                        let gtmcmp =
+                                            ctx.builder.build_int_compare(SLT, iv, len, "");
                                         ctx.builder.build_conditional_branch(gtmcmp, ltm, bad);
                                         ctx.builder.position_at_end(ltm);
-                                        let val = unsafe {PointerValue(ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], ""))};
+                                        let val = unsafe {
+                                            PointerValue(ctx.builder.build_gep(
+                                                b.llvm_type(ctx).unwrap(),
+                                                raw,
+                                                &[iv],
+                                                "",
+                                            ))
+                                        };
                                         ctx.builder.build_unconditional_branch(merge);
                                         ctx.builder.position_at_end(bad);
-                                        if let Some(ef) = ctx.module.get_function("cobalt.funcs.array_bounds") {
+                                        if let Some(ef) =
+                                            ctx.module.get_function("cobalt.funcs.array_bounds")
+                                        {
                                             let i64t = ctx.context.i64_type();
-                                            ctx.builder.build_call(ef, &[ctx.builder.build_int_cast(iv, i64t, "").into(), ctx.builder.build_int_cast(len, i64t, "").into()], "");
+                                            ctx.builder.build_call(
+                                                ef,
+                                                &[
+                                                    ctx.builder.build_int_cast(iv, i64t, "").into(),
+                                                    ctx.builder
+                                                        .build_int_cast(len, i64t, "")
+                                                        .into(),
+                                                ],
+                                                "",
+                                            );
                                         }
                                         ctx.builder.build_unconditional_branch(merge);
                                         ctx.builder.position_at_end(merge);
                                         let phi = ctx.builder.build_phi(val.get_type(), "");
-                                        phi.add_incoming(&[(&val, ltm), (&val.get_type().const_zero(), bad)]);
+                                        phi.add_incoming(&[
+                                            (&val, ltm),
+                                            (&val.get_type().const_zero(), bad),
+                                        ]);
                                         Some(phi.as_basic_value())
+                                    } else {
+                                        Some(unsafe {
+                                            ctx.builder
+                                                .build_gep(
+                                                    b.llvm_type(ctx).unwrap(),
+                                                    raw,
+                                                    &[iv],
+                                                    "",
+                                                )
+                                                .into()
+                                        })
                                     }
-                                    else {Some(unsafe {ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], "").into()})}
-                                } else {None},
-                                if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) = (val.inter_val, idx.inter_val) {vals.get(val as usize).cloned()} else {None},
-                                Type::Reference(Box::new(Type::Mut(b)))
+                                } else {
+                                    None
+                                },
+                                if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) =
+                                    (val.inter_val, idx.inter_val)
+                                {
+                                    vals.get(val as usize).cloned()
+                                } else {
+                                    None
+                                },
+                                Type::Reference(Box::new(Type::Mut(b))),
                             )),
                             Type::Int(_, false) => Ok(Value::new(
-                                if let (Some(StructValue(sv)), Some(IntValue(iv)), SizeType::Static(_), false) = (val.value(ctx), idx.value(ctx), b.size(ctx), ctx.is_const.get()) {
-                                    let raw = ctx.builder.build_extract_value(sv, 0, "").unwrap().into_pointer_value();
+                                if let (
+                                    Some(StructValue(sv)),
+                                    Some(IntValue(iv)),
+                                    SizeType::Static(_),
+                                    false,
+                                ) = (
+                                    val.value(ctx),
+                                    idx.value(ctx),
+                                    b.size(ctx),
+                                    ctx.is_const.get(),
+                                ) {
+                                    let raw = ctx
+                                        .builder
+                                        .build_extract_value(sv, 0, "")
+                                        .unwrap()
+                                        .into_pointer_value();
                                     if ctx.flags.bounds_checks {
-                                        let len = ctx.builder.build_extract_value(sv, 1, "").unwrap().into_int_value();
-                                        let f = ctx.builder.get_insert_block().unwrap().get_parent().unwrap();
+                                        let len = ctx
+                                            .builder
+                                            .build_extract_value(sv, 1, "")
+                                            .unwrap()
+                                            .into_int_value();
+                                        let f = ctx
+                                            .builder
+                                            .get_insert_block()
+                                            .unwrap()
+                                            .get_parent()
+                                            .unwrap();
                                         let ge0 = ctx.context.append_basic_block(f, "idx.ge0"); // greater than or equal to 0
                                         let ltm = ctx.context.append_basic_block(f, "idx.ltm"); // less than max
                                         let bad = ctx.context.append_basic_block(f, "idx.bad");
                                         let merge = ctx.context.append_basic_block(f, "merge");
-                                        let lt0cmp = ctx.builder.build_int_compare(ULT, iv, idx.data_type.llvm_type(ctx).unwrap().const_zero().into_int_value(), "");
+                                        let lt0cmp = ctx.builder.build_int_compare(
+                                            ULT,
+                                            iv,
+                                            idx.data_type
+                                                .llvm_type(ctx)
+                                                .unwrap()
+                                                .const_zero()
+                                                .into_int_value(),
+                                            "",
+                                        );
                                         ctx.builder.build_conditional_branch(lt0cmp, bad, ge0);
                                         ctx.builder.position_at_end(ge0);
-                                        let gtmcmp = ctx.builder.build_int_compare(ULT, iv, len, "");
+                                        let gtmcmp =
+                                            ctx.builder.build_int_compare(ULT, iv, len, "");
                                         ctx.builder.build_conditional_branch(gtmcmp, ltm, bad);
                                         ctx.builder.position_at_end(ltm);
-                                        let val = unsafe {PointerValue(ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], ""))};
+                                        let val = unsafe {
+                                            PointerValue(ctx.builder.build_gep(
+                                                b.llvm_type(ctx).unwrap(),
+                                                raw,
+                                                &[iv],
+                                                "",
+                                            ))
+                                        };
                                         ctx.builder.build_unconditional_branch(merge);
                                         ctx.builder.position_at_end(bad);
-                                        if let Some(ef) = ctx.module.get_function("cobalt.funcs.array_bounds") {
+                                        if let Some(ef) =
+                                            ctx.module.get_function("cobalt.funcs.array_bounds")
+                                        {
                                             let i64t = ctx.context.i64_type();
-                                            ctx.builder.build_call(ef, &[ctx.builder.build_int_cast(iv, i64t, "").into(), ctx.builder.build_int_cast(len, i64t, "").into()], "");
+                                            ctx.builder.build_call(
+                                                ef,
+                                                &[
+                                                    ctx.builder.build_int_cast(iv, i64t, "").into(),
+                                                    ctx.builder
+                                                        .build_int_cast(len, i64t, "")
+                                                        .into(),
+                                                ],
+                                                "",
+                                            );
                                         }
                                         ctx.builder.build_unconditional_branch(merge);
                                         ctx.builder.position_at_end(merge);
                                         let phi = ctx.builder.build_phi(val.get_type(), "");
-                                        phi.add_incoming(&[(&val, ltm), (&val.get_type().const_zero(), bad)]);
+                                        phi.add_incoming(&[
+                                            (&val, ltm),
+                                            (&val.get_type().const_zero(), bad),
+                                        ]);
                                         Some(phi.as_basic_value())
+                                    } else {
+                                        Some(unsafe {
+                                            ctx.builder
+                                                .build_gep(
+                                                    b.llvm_type(ctx).unwrap(),
+                                                    raw,
+                                                    &[iv],
+                                                    "",
+                                                )
+                                                .into()
+                                        })
                                     }
-                                    else {Some(unsafe {ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], "").into()})}
-                                } else {None},
-                                if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) = (val.inter_val, idx.inter_val) {vals.get(val as usize).cloned()} else {None},
-                                Type::Reference(Box::new(Type::Mut(b)))
+                                } else {
+                                    None
+                                },
+                                if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) =
+                                    (val.inter_val, idx.inter_val)
+                                {
+                                    vals.get(val as usize).cloned()
+                                } else {
+                                    None
+                                },
+                                Type::Reference(Box::new(Type::Mut(b))),
                             )),
-                            _ => Err(err)
-                        }
+                            _ => Err(err),
+                        },
                         Type::Array(b, Some(s)) => match idx.data_type.clone() {
                             Type::IntLiteral | Type::Int(_, true) => Ok(Value::new(
-                                if let (Some(PointerValue(raw)), Some(IntValue(iv)), SizeType::Static(_), false) = (val.value(ctx), idx.value(ctx), b.size(ctx), ctx.is_const.get()) {
+                                if let (
+                                    Some(PointerValue(raw)),
+                                    Some(IntValue(iv)),
+                                    SizeType::Static(_),
+                                    false,
+                                ) = (
+                                    val.value(ctx),
+                                    idx.value(ctx),
+                                    b.size(ctx),
+                                    ctx.is_const.get(),
+                                ) {
                                     if ctx.flags.bounds_checks {
-                                        let len = idx.data_type.llvm_type(ctx).unwrap().into_int_type().const_int(s as u64, false);
-                                        let f = ctx.builder.get_insert_block().unwrap().get_parent().unwrap();
+                                        let len = idx
+                                            .data_type
+                                            .llvm_type(ctx)
+                                            .unwrap()
+                                            .into_int_type()
+                                            .const_int(s as u64, false);
+                                        let f = ctx
+                                            .builder
+                                            .get_insert_block()
+                                            .unwrap()
+                                            .get_parent()
+                                            .unwrap();
                                         let ge0 = ctx.context.append_basic_block(f, "idx.ge0"); // greater than or equal to 0
                                         let ltm = ctx.context.append_basic_block(f, "idx.ltm"); // less than max
                                         let bad = ctx.context.append_basic_block(f, "idx.bad");
                                         let merge = ctx.context.append_basic_block(f, "merge");
-                                        let lt0cmp = ctx.builder.build_int_compare(SLT, iv, idx.data_type.llvm_type(ctx).unwrap().const_zero().into_int_value(), "");
+                                        let lt0cmp = ctx.builder.build_int_compare(
+                                            SLT,
+                                            iv,
+                                            idx.data_type
+                                                .llvm_type(ctx)
+                                                .unwrap()
+                                                .const_zero()
+                                                .into_int_value(),
+                                            "",
+                                        );
                                         ctx.builder.build_conditional_branch(lt0cmp, bad, ge0);
                                         ctx.builder.position_at_end(ge0);
-                                        let gtmcmp = ctx.builder.build_int_compare(SLT, iv, len, "");
+                                        let gtmcmp =
+                                            ctx.builder.build_int_compare(SLT, iv, len, "");
                                         ctx.builder.build_conditional_branch(gtmcmp, ltm, bad);
                                         ctx.builder.position_at_end(ltm);
-                                        let val = unsafe {PointerValue(ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], ""))};
+                                        let val = unsafe {
+                                            PointerValue(ctx.builder.build_gep(
+                                                b.llvm_type(ctx).unwrap(),
+                                                raw,
+                                                &[iv],
+                                                "",
+                                            ))
+                                        };
                                         ctx.builder.build_unconditional_branch(merge);
                                         ctx.builder.position_at_end(bad);
-                                        if let Some(ef) = ctx.module.get_function("cobalt.funcs.array_bounds") {
+                                        if let Some(ef) =
+                                            ctx.module.get_function("cobalt.funcs.array_bounds")
+                                        {
                                             let i64t = ctx.context.i64_type();
-                                            ctx.builder.build_call(ef, &[ctx.builder.build_int_cast(iv, i64t, "").into(), ctx.builder.build_int_cast(len, i64t, "").into()], "");
+                                            ctx.builder.build_call(
+                                                ef,
+                                                &[
+                                                    ctx.builder.build_int_cast(iv, i64t, "").into(),
+                                                    ctx.builder
+                                                        .build_int_cast(len, i64t, "")
+                                                        .into(),
+                                                ],
+                                                "",
+                                            );
                                         }
                                         ctx.builder.build_unconditional_branch(merge);
                                         ctx.builder.position_at_end(merge);
                                         let phi = ctx.builder.build_phi(val.get_type(), "");
-                                        phi.add_incoming(&[(&val, ltm), (&val.get_type().const_zero(), bad)]);
+                                        phi.add_incoming(&[
+                                            (&val, ltm),
+                                            (&val.get_type().const_zero(), bad),
+                                        ]);
                                         Some(phi.as_basic_value())
+                                    } else {
+                                        Some(unsafe {
+                                            ctx.builder
+                                                .build_gep(
+                                                    b.llvm_type(ctx).unwrap(),
+                                                    raw,
+                                                    &[iv],
+                                                    "",
+                                                )
+                                                .into()
+                                        })
                                     }
-                                    else {Some(unsafe {ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], "").into()})}
-                                } else {None},
-                                if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) = (val.inter_val, idx.inter_val) {vals.get(val as usize).cloned()} else {None},
-                                Type::Reference(Box::new(Type::Mut(b)))
+                                } else {
+                                    None
+                                },
+                                if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) =
+                                    (val.inter_val, idx.inter_val)
+                                {
+                                    vals.get(val as usize).cloned()
+                                } else {
+                                    None
+                                },
+                                Type::Reference(Box::new(Type::Mut(b))),
                             )),
                             Type::Int(_, false) => Ok(Value::new(
-                                if let (Some(PointerValue(raw)), Some(IntValue(iv)), SizeType::Static(_), false) = (val.value(ctx), idx.value(ctx), b.size(ctx), ctx.is_const.get()) {
+                                if let (
+                                    Some(PointerValue(raw)),
+                                    Some(IntValue(iv)),
+                                    SizeType::Static(_),
+                                    false,
+                                ) = (
+                                    val.value(ctx),
+                                    idx.value(ctx),
+                                    b.size(ctx),
+                                    ctx.is_const.get(),
+                                ) {
                                     if ctx.flags.bounds_checks {
-                                        let len = idx.data_type.llvm_type(ctx).unwrap().into_int_type().const_int(s as u64, false);
-                                        let f = ctx.builder.get_insert_block().unwrap().get_parent().unwrap();
+                                        let len = idx
+                                            .data_type
+                                            .llvm_type(ctx)
+                                            .unwrap()
+                                            .into_int_type()
+                                            .const_int(s as u64, false);
+                                        let f = ctx
+                                            .builder
+                                            .get_insert_block()
+                                            .unwrap()
+                                            .get_parent()
+                                            .unwrap();
                                         let ge0 = ctx.context.append_basic_block(f, "idx.ge0"); // greater than or equal to 0
                                         let ltm = ctx.context.append_basic_block(f, "idx.ltm"); // less than max
                                         let bad = ctx.context.append_basic_block(f, "idx.bad");
                                         let merge = ctx.context.append_basic_block(f, "merge");
-                                        let lt0cmp = ctx.builder.build_int_compare(ULT, iv, idx.data_type.llvm_type(ctx).unwrap().const_zero().into_int_value(), "");
+                                        let lt0cmp = ctx.builder.build_int_compare(
+                                            ULT,
+                                            iv,
+                                            idx.data_type
+                                                .llvm_type(ctx)
+                                                .unwrap()
+                                                .const_zero()
+                                                .into_int_value(),
+                                            "",
+                                        );
                                         ctx.builder.build_conditional_branch(lt0cmp, bad, ge0);
                                         ctx.builder.position_at_end(ge0);
-                                        let gtmcmp = ctx.builder.build_int_compare(ULT, iv, len, "");
+                                        let gtmcmp =
+                                            ctx.builder.build_int_compare(ULT, iv, len, "");
                                         ctx.builder.build_conditional_branch(gtmcmp, ltm, bad);
                                         ctx.builder.position_at_end(ltm);
-                                        let val = unsafe {PointerValue(ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], ""))};
+                                        let val = unsafe {
+                                            PointerValue(ctx.builder.build_gep(
+                                                b.llvm_type(ctx).unwrap(),
+                                                raw,
+                                                &[iv],
+                                                "",
+                                            ))
+                                        };
                                         ctx.builder.build_unconditional_branch(merge);
                                         ctx.builder.position_at_end(bad);
-                                        if let Some(ef) = ctx.module.get_function("cobalt.funcs.array_bounds") {
+                                        if let Some(ef) =
+                                            ctx.module.get_function("cobalt.funcs.array_bounds")
+                                        {
                                             let i64t = ctx.context.i64_type();
-                                            ctx.builder.build_call(ef, &[ctx.builder.build_int_cast(iv, i64t, "").into(), ctx.builder.build_int_cast(len, i64t, "").into()], "");
+                                            ctx.builder.build_call(
+                                                ef,
+                                                &[
+                                                    ctx.builder.build_int_cast(iv, i64t, "").into(),
+                                                    ctx.builder
+                                                        .build_int_cast(len, i64t, "")
+                                                        .into(),
+                                                ],
+                                                "",
+                                            );
                                         }
                                         ctx.builder.build_unconditional_branch(merge);
                                         ctx.builder.position_at_end(merge);
                                         let phi = ctx.builder.build_phi(val.get_type(), "");
-                                        phi.add_incoming(&[(&val, ltm), (&val.get_type().const_zero(), bad)]);
+                                        phi.add_incoming(&[
+                                            (&val, ltm),
+                                            (&val.get_type().const_zero(), bad),
+                                        ]);
                                         Some(phi.as_basic_value())
+                                    } else {
+                                        Some(unsafe {
+                                            ctx.builder
+                                                .build_gep(
+                                                    b.llvm_type(ctx).unwrap(),
+                                                    raw,
+                                                    &[iv],
+                                                    "",
+                                                )
+                                                .into()
+                                        })
                                     }
-                                    else {Some(unsafe {ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], "").into()})}
-                                } else {None},
-                                if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) = (val.inter_val, idx.inter_val) {vals.get(val as usize).cloned()} else {None},
-                                Type::Reference(Box::new(Type::Mut(b)))
+                                } else {
+                                    None
+                                },
+                                if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) =
+                                    (val.inter_val, idx.inter_val)
+                                {
+                                    vals.get(val as usize).cloned()
+                                } else {
+                                    None
+                                },
+                                Type::Reference(Box::new(Type::Mut(b))),
                             )),
-                            _ => Err(err)
-                        }
+                            _ => Err(err),
+                        },
                         x => {
-                            if !ctx.is_const.get()  {
+                            if !ctx.is_const.get() {
                                 if let Some(PointerValue(v)) = val.comp_val {
-                                    val.comp_val = Some(ctx.builder.build_load(x.llvm_type(ctx).unwrap(), v, ""));
+                                    val.comp_val = Some(ctx.builder.build_load(
+                                        x.llvm_type(ctx).unwrap(),
+                                        v,
+                                        "",
+                                    ));
                                 }
                             }
                             val.data_type = x;
                             subscript((val, vloc), (idx, iloc), ctx)
                         }
-                    }
+                    },
                     Type::Array(b, None) => match idx.data_type.clone() {
                         Type::IntLiteral | Type::Int(_, true) => Ok(Value::new(
-                            if let (Some(StructValue(sv)), Some(IntValue(iv)), SizeType::Static(_), false) = (val.value(ctx), idx.value(ctx), b.size(ctx), ctx.is_const.get()) {
-                                let raw = ctx.builder.build_extract_value(sv, 0, "").unwrap().into_pointer_value();
+                            if let (
+                                Some(StructValue(sv)),
+                                Some(IntValue(iv)),
+                                SizeType::Static(_),
+                                false,
+                            ) = (
+                                val.value(ctx),
+                                idx.value(ctx),
+                                b.size(ctx),
+                                ctx.is_const.get(),
+                            ) {
+                                let raw = ctx
+                                    .builder
+                                    .build_extract_value(sv, 0, "")
+                                    .unwrap()
+                                    .into_pointer_value();
                                 if ctx.flags.bounds_checks {
-                                    let len = ctx.builder.build_extract_value(sv, 1, "").unwrap().into_int_value();
-                                    let f = ctx.builder.get_insert_block().unwrap().get_parent().unwrap();
+                                    let len = ctx
+                                        .builder
+                                        .build_extract_value(sv, 1, "")
+                                        .unwrap()
+                                        .into_int_value();
+                                    let f = ctx
+                                        .builder
+                                        .get_insert_block()
+                                        .unwrap()
+                                        .get_parent()
+                                        .unwrap();
                                     let ge0 = ctx.context.append_basic_block(f, "idx.ge0"); // greater than or equal to 0
                                     let ltm = ctx.context.append_basic_block(f, "idx.ltm"); // less than max
                                     let bad = ctx.context.append_basic_block(f, "idx.bad");
                                     let merge = ctx.context.append_basic_block(f, "merge");
-                                    let lt0cmp = ctx.builder.build_int_compare(SLT, iv, idx.data_type.llvm_type(ctx).unwrap().const_zero().into_int_value(), "");
+                                    let lt0cmp = ctx.builder.build_int_compare(
+                                        SLT,
+                                        iv,
+                                        idx.data_type
+                                            .llvm_type(ctx)
+                                            .unwrap()
+                                            .const_zero()
+                                            .into_int_value(),
+                                        "",
+                                    );
                                     ctx.builder.build_conditional_branch(lt0cmp, bad, ge0);
                                     ctx.builder.position_at_end(ge0);
                                     let gtmcmp = ctx.builder.build_int_compare(SLT, iv, len, "");
                                     ctx.builder.build_conditional_branch(gtmcmp, ltm, bad);
                                     ctx.builder.position_at_end(ltm);
-                                    let val = unsafe {PointerValue(ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], ""))};
+                                    let val = unsafe {
+                                        PointerValue(ctx.builder.build_gep(
+                                            b.llvm_type(ctx).unwrap(),
+                                            raw,
+                                            &[iv],
+                                            "",
+                                        ))
+                                    };
                                     ctx.builder.build_unconditional_branch(merge);
                                     ctx.builder.position_at_end(bad);
-                                    if let Some(ef) = ctx.module.get_function("cobalt.funcs.array_bounds") {
+                                    if let Some(ef) =
+                                        ctx.module.get_function("cobalt.funcs.array_bounds")
+                                    {
                                         let i64t = ctx.context.i64_type();
-                                        ctx.builder.build_call(ef, &[ctx.builder.build_int_cast(iv, i64t, "").into(), ctx.builder.build_int_cast(len, i64t, "").into()], "");
+                                        ctx.builder.build_call(
+                                            ef,
+                                            &[
+                                                ctx.builder.build_int_cast(iv, i64t, "").into(),
+                                                ctx.builder.build_int_cast(len, i64t, "").into(),
+                                            ],
+                                            "",
+                                        );
                                     }
                                     ctx.builder.build_unconditional_branch(merge);
                                     ctx.builder.position_at_end(merge);
                                     let phi = ctx.builder.build_phi(val.get_type(), "");
-                                    phi.add_incoming(&[(&val, ltm), (&val.get_type().const_zero(), bad)]);
+                                    phi.add_incoming(&[
+                                        (&val, ltm),
+                                        (&val.get_type().const_zero(), bad),
+                                    ]);
                                     Some(phi.as_basic_value())
+                                } else {
+                                    Some(unsafe {
+                                        ctx.builder
+                                            .build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], "")
+                                            .into()
+                                    })
                                 }
-                                else {Some(unsafe {ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], "").into()})}
-                            } else {None},
-                            if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) = (val.inter_val, idx.inter_val) {vals.get(val as usize).cloned()} else {None},
-                            Type::Reference(b)
+                            } else {
+                                None
+                            },
+                            if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) =
+                                (val.inter_val, idx.inter_val)
+                            {
+                                vals.get(val as usize).cloned()
+                            } else {
+                                None
+                            },
+                            Type::Reference(b),
                         )),
                         Type::Int(_, false) => Ok(Value::new(
-                            if let (Some(StructValue(sv)), Some(IntValue(iv)), SizeType::Static(_), false) = (val.value(ctx), idx.value(ctx), b.size(ctx), ctx.is_const.get()) {
-                                let raw = ctx.builder.build_extract_value(sv, 0, "").unwrap().into_pointer_value();
+                            if let (
+                                Some(StructValue(sv)),
+                                Some(IntValue(iv)),
+                                SizeType::Static(_),
+                                false,
+                            ) = (
+                                val.value(ctx),
+                                idx.value(ctx),
+                                b.size(ctx),
+                                ctx.is_const.get(),
+                            ) {
+                                let raw = ctx
+                                    .builder
+                                    .build_extract_value(sv, 0, "")
+                                    .unwrap()
+                                    .into_pointer_value();
                                 if ctx.flags.bounds_checks {
-                                    let len = ctx.builder.build_extract_value(sv, 1, "").unwrap().into_int_value();
-                                    let f = ctx.builder.get_insert_block().unwrap().get_parent().unwrap();
+                                    let len = ctx
+                                        .builder
+                                        .build_extract_value(sv, 1, "")
+                                        .unwrap()
+                                        .into_int_value();
+                                    let f = ctx
+                                        .builder
+                                        .get_insert_block()
+                                        .unwrap()
+                                        .get_parent()
+                                        .unwrap();
                                     let ge0 = ctx.context.append_basic_block(f, "idx.ge0"); // greater than or equal to 0
                                     let ltm = ctx.context.append_basic_block(f, "idx.ltm"); // less than max
                                     let bad = ctx.context.append_basic_block(f, "idx.bad");
                                     let merge = ctx.context.append_basic_block(f, "merge");
-                                    let lt0cmp = ctx.builder.build_int_compare(ULT, iv, idx.data_type.llvm_type(ctx).unwrap().const_zero().into_int_value(), "");
+                                    let lt0cmp = ctx.builder.build_int_compare(
+                                        ULT,
+                                        iv,
+                                        idx.data_type
+                                            .llvm_type(ctx)
+                                            .unwrap()
+                                            .const_zero()
+                                            .into_int_value(),
+                                        "",
+                                    );
                                     ctx.builder.build_conditional_branch(lt0cmp, bad, ge0);
                                     ctx.builder.position_at_end(ge0);
                                     let gtmcmp = ctx.builder.build_int_compare(ULT, iv, len, "");
                                     ctx.builder.build_conditional_branch(gtmcmp, ltm, bad);
                                     ctx.builder.position_at_end(ltm);
-                                    let val = unsafe {PointerValue(ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], ""))};
+                                    let val = unsafe {
+                                        PointerValue(ctx.builder.build_gep(
+                                            b.llvm_type(ctx).unwrap(),
+                                            raw,
+                                            &[iv],
+                                            "",
+                                        ))
+                                    };
                                     ctx.builder.build_unconditional_branch(merge);
                                     ctx.builder.position_at_end(bad);
-                                    if let Some(ef) = ctx.module.get_function("cobalt.funcs.array_bounds") {
+                                    if let Some(ef) =
+                                        ctx.module.get_function("cobalt.funcs.array_bounds")
+                                    {
                                         let i64t = ctx.context.i64_type();
-                                        ctx.builder.build_call(ef, &[ctx.builder.build_int_cast(iv, i64t, "").into(), ctx.builder.build_int_cast(len, i64t, "").into()], "");
+                                        ctx.builder.build_call(
+                                            ef,
+                                            &[
+                                                ctx.builder.build_int_cast(iv, i64t, "").into(),
+                                                ctx.builder.build_int_cast(len, i64t, "").into(),
+                                            ],
+                                            "",
+                                        );
                                     }
                                     ctx.builder.build_unconditional_branch(merge);
                                     ctx.builder.position_at_end(merge);
                                     let phi = ctx.builder.build_phi(val.get_type(), "");
-                                    phi.add_incoming(&[(&val, ltm), (&val.get_type().const_zero(), bad)]);
+                                    phi.add_incoming(&[
+                                        (&val, ltm),
+                                        (&val.get_type().const_zero(), bad),
+                                    ]);
                                     Some(phi.as_basic_value())
+                                } else {
+                                    Some(unsafe {
+                                        ctx.builder
+                                            .build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], "")
+                                            .into()
+                                    })
                                 }
-                                else {Some(unsafe {ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], "").into()})}
-                            } else {None},
-                            if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) = (val.inter_val, idx.inter_val) {vals.get(val as usize).cloned()} else {None},
-                            Type::Reference(b)
+                            } else {
+                                None
+                            },
+                            if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) =
+                                (val.inter_val, idx.inter_val)
+                            {
+                                vals.get(val as usize).cloned()
+                            } else {
+                                None
+                            },
+                            Type::Reference(b),
                         )),
-                        _ => Err(err)
-                    }
+                        _ => Err(err),
+                    },
                     Type::Array(b, Some(s)) => match idx.data_type.clone() {
                         Type::IntLiteral | Type::Int(_, true) => Ok(Value::new(
-                            if let (Some(PointerValue(raw)), Some(IntValue(iv)), SizeType::Static(_), false) = (val.value(ctx), idx.value(ctx), b.size(ctx), ctx.is_const.get()) {
+                            if let (
+                                Some(PointerValue(raw)),
+                                Some(IntValue(iv)),
+                                SizeType::Static(_),
+                                false,
+                            ) = (
+                                val.value(ctx),
+                                idx.value(ctx),
+                                b.size(ctx),
+                                ctx.is_const.get(),
+                            ) {
                                 if ctx.flags.bounds_checks {
-                                    let len = idx.data_type.llvm_type(ctx).unwrap().into_int_type().const_int(s as u64, false);
-                                    let f = ctx.builder.get_insert_block().unwrap().get_parent().unwrap();
+                                    let len = idx
+                                        .data_type
+                                        .llvm_type(ctx)
+                                        .unwrap()
+                                        .into_int_type()
+                                        .const_int(s as u64, false);
+                                    let f = ctx
+                                        .builder
+                                        .get_insert_block()
+                                        .unwrap()
+                                        .get_parent()
+                                        .unwrap();
                                     let ge0 = ctx.context.append_basic_block(f, "idx.ge0"); // greater than or equal to 0
                                     let ltm = ctx.context.append_basic_block(f, "idx.ltm"); // less than max
                                     let bad = ctx.context.append_basic_block(f, "idx.bad");
                                     let merge = ctx.context.append_basic_block(f, "merge");
-                                    let lt0cmp = ctx.builder.build_int_compare(SLT, iv, idx.data_type.llvm_type(ctx).unwrap().const_zero().into_int_value(), "");
+                                    let lt0cmp = ctx.builder.build_int_compare(
+                                        SLT,
+                                        iv,
+                                        idx.data_type
+                                            .llvm_type(ctx)
+                                            .unwrap()
+                                            .const_zero()
+                                            .into_int_value(),
+                                        "",
+                                    );
                                     ctx.builder.build_conditional_branch(lt0cmp, bad, ge0);
                                     ctx.builder.position_at_end(ge0);
                                     let gtmcmp = ctx.builder.build_int_compare(SLT, iv, len, "");
                                     ctx.builder.build_conditional_branch(gtmcmp, ltm, bad);
                                     ctx.builder.position_at_end(ltm);
-                                    let val = unsafe {PointerValue(ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], ""))};
+                                    let val = unsafe {
+                                        PointerValue(ctx.builder.build_gep(
+                                            b.llvm_type(ctx).unwrap(),
+                                            raw,
+                                            &[iv],
+                                            "",
+                                        ))
+                                    };
                                     ctx.builder.build_unconditional_branch(merge);
                                     ctx.builder.position_at_end(bad);
-                                    if let Some(ef) = ctx.module.get_function("cobalt.funcs.array_bounds") {
+                                    if let Some(ef) =
+                                        ctx.module.get_function("cobalt.funcs.array_bounds")
+                                    {
                                         let i64t = ctx.context.i64_type();
-                                        ctx.builder.build_call(ef, &[ctx.builder.build_int_cast(iv, i64t, "").into(), ctx.builder.build_int_cast(len, i64t, "").into()], "");
+                                        ctx.builder.build_call(
+                                            ef,
+                                            &[
+                                                ctx.builder.build_int_cast(iv, i64t, "").into(),
+                                                ctx.builder.build_int_cast(len, i64t, "").into(),
+                                            ],
+                                            "",
+                                        );
                                     }
                                     ctx.builder.build_unconditional_branch(merge);
                                     ctx.builder.position_at_end(merge);
                                     let phi = ctx.builder.build_phi(val.get_type(), "");
-                                    phi.add_incoming(&[(&val, ltm), (&val.get_type().const_zero(), bad)]);
+                                    phi.add_incoming(&[
+                                        (&val, ltm),
+                                        (&val.get_type().const_zero(), bad),
+                                    ]);
                                     Some(phi.as_basic_value())
+                                } else {
+                                    Some(unsafe {
+                                        ctx.builder
+                                            .build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], "")
+                                            .into()
+                                    })
                                 }
-                                else {Some(unsafe {ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], "").into()})}
-                            } else {None},
-                            if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) = (val.inter_val, idx.inter_val) {vals.get(val as usize).cloned()} else {None},
-                            Type::Reference(b)
+                            } else {
+                                None
+                            },
+                            if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) =
+                                (val.inter_val, idx.inter_val)
+                            {
+                                vals.get(val as usize).cloned()
+                            } else {
+                                None
+                            },
+                            Type::Reference(b),
                         )),
                         Type::Int(_, false) => Ok(Value::new(
-                            if let (Some(PointerValue(raw)), Some(IntValue(iv)), SizeType::Static(_), false) = (val.value(ctx), idx.value(ctx), b.size(ctx), ctx.is_const.get()) {
+                            if let (
+                                Some(PointerValue(raw)),
+                                Some(IntValue(iv)),
+                                SizeType::Static(_),
+                                false,
+                            ) = (
+                                val.value(ctx),
+                                idx.value(ctx),
+                                b.size(ctx),
+                                ctx.is_const.get(),
+                            ) {
                                 if ctx.flags.bounds_checks {
-                                    let len = idx.data_type.llvm_type(ctx).unwrap().into_int_type().const_int(s as u64, false);
-                                    let f = ctx.builder.get_insert_block().unwrap().get_parent().unwrap();
+                                    let len = idx
+                                        .data_type
+                                        .llvm_type(ctx)
+                                        .unwrap()
+                                        .into_int_type()
+                                        .const_int(s as u64, false);
+                                    let f = ctx
+                                        .builder
+                                        .get_insert_block()
+                                        .unwrap()
+                                        .get_parent()
+                                        .unwrap();
                                     let ge0 = ctx.context.append_basic_block(f, "idx.ge0"); // greater than or equal to 0
                                     let ltm = ctx.context.append_basic_block(f, "idx.ltm"); // less than max
                                     let bad = ctx.context.append_basic_block(f, "idx.bad");
                                     let merge = ctx.context.append_basic_block(f, "merge");
-                                    let lt0cmp = ctx.builder.build_int_compare(ULT, iv, idx.data_type.llvm_type(ctx).unwrap().const_zero().into_int_value(), "");
+                                    let lt0cmp = ctx.builder.build_int_compare(
+                                        ULT,
+                                        iv,
+                                        idx.data_type
+                                            .llvm_type(ctx)
+                                            .unwrap()
+                                            .const_zero()
+                                            .into_int_value(),
+                                        "",
+                                    );
                                     ctx.builder.build_conditional_branch(lt0cmp, bad, ge0);
                                     ctx.builder.position_at_end(ge0);
                                     let gtmcmp = ctx.builder.build_int_compare(ULT, iv, len, "");
                                     ctx.builder.build_conditional_branch(gtmcmp, ltm, bad);
                                     ctx.builder.position_at_end(ltm);
-                                    let val = unsafe {PointerValue(ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], ""))};
+                                    let val = unsafe {
+                                        PointerValue(ctx.builder.build_gep(
+                                            b.llvm_type(ctx).unwrap(),
+                                            raw,
+                                            &[iv],
+                                            "",
+                                        ))
+                                    };
                                     ctx.builder.build_unconditional_branch(merge);
                                     ctx.builder.position_at_end(bad);
-                                    if let Some(ef) = ctx.module.get_function("cobalt.funcs.array_bounds") {
+                                    if let Some(ef) =
+                                        ctx.module.get_function("cobalt.funcs.array_bounds")
+                                    {
                                         let i64t = ctx.context.i64_type();
-                                        ctx.builder.build_call(ef, &[ctx.builder.build_int_cast(iv, i64t, "").into(), ctx.builder.build_int_cast(len, i64t, "").into()], "");
+                                        ctx.builder.build_call(
+                                            ef,
+                                            &[
+                                                ctx.builder.build_int_cast(iv, i64t, "").into(),
+                                                ctx.builder.build_int_cast(len, i64t, "").into(),
+                                            ],
+                                            "",
+                                        );
                                     }
                                     ctx.builder.build_unconditional_branch(merge);
                                     ctx.builder.position_at_end(merge);
                                     let phi = ctx.builder.build_phi(val.get_type(), "");
-                                    phi.add_incoming(&[(&val, ltm), (&val.get_type().const_zero(), bad)]);
+                                    phi.add_incoming(&[
+                                        (&val, ltm),
+                                        (&val.get_type().const_zero(), bad),
+                                    ]);
                                     Some(phi.as_basic_value())
+                                } else {
+                                    Some(unsafe {
+                                        ctx.builder
+                                            .build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], "")
+                                            .into()
+                                    })
                                 }
-                                else {Some(unsafe {ctx.builder.build_gep(b.llvm_type(ctx).unwrap(), raw, &[iv], "").into()})}
-                            } else {None},
-                            if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) = (val.inter_val, idx.inter_val) {vals.get(val as usize).cloned()} else {None},
-                            Type::Reference(b)
+                            } else {
+                                None
+                            },
+                            if let (Some(InterData::Array(vals)), Some(InterData::Int(val))) =
+                                (val.inter_val, idx.inter_val)
+                            {
+                                vals.get(val as usize).cloned()
+                            } else {
+                                None
+                            },
+                            Type::Reference(b),
                         )),
-                        _ => Err(err)
-                    }
+                        _ => Err(err),
+                    },
                     x => {
-                        if !ctx.is_const.get()  {
+                        if !ctx.is_const.get() {
                             if let Some(PointerValue(v)) = val.comp_val {
-                                val.comp_val = Some(ctx.builder.build_load(x.llvm_type(ctx).unwrap(), v, ""));
+                                val.comp_val =
+                                    Some(ctx.builder.build_load(x.llvm_type(ctx).unwrap(), v, ""));
                             }
                         }
                         val.data_type = x;
                         subscript((val, vloc), (idx, iloc), ctx)
                     }
-                }
+                },
                 Type::TypeData => match idx.data_type {
-                    Type::Null => if let Some(InterData::Type(t)) = val.inter_val {Ok(Value::make_type(Type::Array(decay_boxed(t), None)))} else {unreachable!()},
-                    Type::Int(..) | Type::IntLiteral => if let (Some(InterData::Type(t)), Some(InterData::Int(v))) = (val.inter_val, idx.inter_val) {Ok(Value::make_type(Type::Array(decay_boxed(t), Some(v as u32))))} else {Err(CobaltError::NotCompileTime {loc: iloc})},
-                    _ => Err(err)
-                }
+                    Type::Null => {
+                        if let Some(InterData::Type(t)) = val.inter_val {
+                            Ok(Value::make_type(Type::Array(decay_boxed(t), None)))
+                        } else {
+                            unreachable!()
+                        }
+                    }
+                    Type::Int(..) | Type::IntLiteral => {
+                        if let (Some(InterData::Type(t)), Some(InterData::Int(v))) =
+                            (val.inter_val, idx.inter_val)
+                        {
+                            Ok(Value::make_type(Type::Array(
+                                decay_boxed(t),
+                                Some(v as u32),
+                            )))
+                        } else {
+                            Err(CobaltError::NotCompileTime { loc: iloc })
+                        }
+                    }
+                    _ => Err(err),
+                },
                 Type::Null => match idx.data_type {
                     Type::Null => Ok(Value::make_type(Type::Array(Box::new(Type::Null), None))),
-                    Type::Int(..) | Type::IntLiteral => if let Some(InterData::Int(v)) = idx.inter_val {Ok(Value::make_type(Type::Array(Box::new(Type::Null), Some(v as u32))))} else {Err(CobaltError::NotCompileTime {loc: iloc})},
-                    _ => Err(err)
-                }
+                    Type::Int(..) | Type::IntLiteral => {
+                        if let Some(InterData::Int(v)) = idx.inter_val {
+                            Ok(Value::make_type(Type::Array(
+                                Box::new(Type::Null),
+                                Some(v as u32),
+                            )))
+                        } else {
+                            Err(CobaltError::NotCompileTime { loc: iloc })
+                        }
+                    }
+                    _ => Err(err),
+                },
                 Type::Tuple(v) => {
                     if let Some(InterData::Array(a)) = val.inter_val {
                         let mut vec = Vec::with_capacity(v.len());
                         for (iv, dt) in a.into_iter().zip(v) {
-                            vec.push(impl_convert(unreachable_span(), (Value::metaval(iv, dt), None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).ok_or(err.clone())?);
+                            vec.push(
+                                impl_convert(
+                                    unreachable_span(),
+                                    (Value::metaval(iv, dt), None),
+                                    (Type::TypeData, None),
+                                    ctx,
+                                )
+                                .ok()
+                                .and_then(Value::into_type)
+                                .ok_or(err.clone())?,
+                            );
                         }
                         match idx.data_type {
-                            Type::Null => Ok(Value::make_type(Type::Array(Box::new(Type::Tuple(vec)), None))),
-                            Type::Int(..) | Type::IntLiteral => if let Some(InterData::Int(v)) = idx.inter_val {Ok(Value::make_type(Type::Array(Box::new(Type::Tuple(vec)), Some(v as u32))))} else {Err(CobaltError::NotCompileTime {loc: iloc})},
-                            _ => Err(err)
+                            Type::Null => Ok(Value::make_type(Type::Array(
+                                Box::new(Type::Tuple(vec)),
+                                None,
+                            ))),
+                            Type::Int(..) | Type::IntLiteral => {
+                                if let Some(InterData::Int(v)) = idx.inter_val {
+                                    Ok(Value::make_type(Type::Array(
+                                        Box::new(Type::Tuple(vec)),
+                                        Some(v as u32),
+                                    )))
+                                } else {
+                                    Err(CobaltError::NotCompileTime { loc: iloc })
+                                }
+                            }
+                            _ => Err(err),
                         }
+                    } else {
+                        Err(err)
                     }
-                    else {Err(err)}
                 }
-                _ => Err(err)
+                _ => Err(err),
             }
         }
     }
 }
-pub fn impl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option<SourceSpan>), (target, tloc): (Type, Option<SourceSpan>), ctx: &CompCtx<'ctx>) -> Result<Value<'ctx>, CobaltError> {
+pub fn impl_convert<'ctx>(
+    loc: SourceSpan,
+    (mut val, vloc): (Value<'ctx>, Option<SourceSpan>),
+    (target, tloc): (Type, Option<SourceSpan>),
+    ctx: &CompCtx<'ctx>,
+) -> Result<Value<'ctx>, CobaltError> {
     let err = CobaltError::InvalidConversion {
         is_expl: false,
         val: val.data_type.to_string(),
         ty: target.to_string(),
-        vloc, tloc,
-        oloc: loc
+        vloc,
+        tloc,
+        oloc: loc,
     };
-    if val.data_type == target {return Ok(val)}
-    else if target == Type::Null {return Ok(Value::null())}
-    else if target == Type::Error {return Ok(Value::error())}
-    else if let Type::Reference(ref b) = target {
+    if val.data_type == target {
+        return Ok(val);
+    } else if target == Type::Null {
+        return Ok(Value::null());
+    } else if target == Type::Error {
+        return Ok(Value::error());
+    } else if let Type::Reference(ref b) = target {
         if **b == val.data_type {
             mark_use(&val, cfg::Location::current(ctx).unwrap(), ctx, loc);
-            if val.name.is_none() {ctx.to_drop.borrow_mut().last_mut().unwrap().push(val.clone());}
-            return Ok(Value::new(if matches!(val.data_type, Type::Mut(_)) {val.value(ctx)} else {val.addr(ctx).map(From::from)}, None, target))
+            if val.name.is_none() {
+                ctx.to_drop
+                    .borrow_mut()
+                    .last_mut()
+                    .unwrap()
+                    .push(val.clone());
+            }
+            return Ok(Value::new(
+                if matches!(val.data_type, Type::Mut(_)) {
+                    val.value(ctx)
+                } else {
+                    val.addr(ctx).map(From::from)
+                },
+                None,
+                target,
+            ));
         }
         if let Type::Mut(b) = b.as_ref() {
             if **b == val.data_type {
-                return if let Some(floc) = val.frozen {Err(CobaltError::CantMutateImmut {
-                    vloc: vloc.unwrap_or(loc),
-                    ty: val.data_type.to_string(),
-                    oloc: None,
-                    op: "".to_string(),
-                    floc
-                })}
-                else {
+                return if let Some(floc) = val.frozen {
+                    Err(CobaltError::CantMutateImmut {
+                        vloc: vloc.unwrap_or(loc),
+                        ty: val.data_type.to_string(),
+                        oloc: None,
+                        op: "".to_string(),
+                        floc,
+                    })
+                } else {
                     mark_use(&val, cfg::Location::current(ctx).unwrap(), ctx, loc);
-                    if val.name.is_none() {ctx.to_drop.borrow_mut().last_mut().unwrap().push(val.clone());}
+                    if val.name.is_none() {
+                        ctx.to_drop
+                            .borrow_mut()
+                            .last_mut()
+                            .unwrap()
+                            .push(val.clone());
+                    }
                     Ok(Value::new(val.addr(ctx).map(From::from), None, target))
-                }
+                };
             }
         }
     }
@@ -1863,40 +3445,82 @@ pub fn impl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
             match *b {
                 Type::Mut(b) => match *b {
                     Type::Array(b, Some(l)) => match target {
-                        Type::Pointer(b2) if covariant(&b, &b2) => Ok(Value::new(val.comp_val, val.inter_val, Type::Pointer(b))),
-                        Type::Reference(b2) => match *b2 {
-                            Type::Mut(b2) => if b == b2 {
-                                let at = Type::Reference(Box::new(Type::Mut(Box::new(Type::Array(b2, None)))));
-                                Ok(Value::new(
-                                    if let Some(PointerValue(v)) = val.comp_val {
-                                        let llt = at.llvm_type(ctx).unwrap().into_struct_type();
-                                        let v1 = ctx.builder.build_insert_value(llt.const_zero(), v, 0, "").unwrap();
-                                        let v2 = ctx.builder.build_insert_value(v1, ctx.context.i64_type().const_int(l as u64, false), 1, "").unwrap();
-                                        Some(v2.into_struct_value().into())
-                                    } else {None},
-                                    val.inter_val,
-                                    at
-                                ))
-                            }
-                            else {Err(err)}
-                            Type::Array(b2, None) => if b == b2 {
-                                let at = Type::Reference(Box::new(Type::Mut(Box::new(Type::Array(b2, None)))));
-                                Ok(Value::new(
-                                    if let Some(PointerValue(v)) = val.comp_val {
-                                        let llt = at.llvm_type(ctx).unwrap().into_struct_type();
-                                        let v1 = ctx.builder.build_insert_value(llt.const_zero(), v, 0, "").unwrap();
-                                        let v2 = ctx.builder.build_insert_value(v1, ctx.context.i64_type().const_int(l as u64, false), 1, "").unwrap();
-                                        Some(v2.into_struct_value().into())
-                                    } else {None},
-                                    val.inter_val,
-                                    at
-                                ))
-                            }
-                            else {Err(err)}
-                            _ => Err(err)
+                        Type::Pointer(b2) if covariant(&b, &b2) => {
+                            Ok(Value::new(val.comp_val, val.inter_val, Type::Pointer(b)))
                         }
-                        _ => Err(err)
-                    }
+                        Type::Reference(b2) => match *b2 {
+                            Type::Mut(b2) => {
+                                if b == b2 {
+                                    let at = Type::Reference(Box::new(Type::Mut(Box::new(
+                                        Type::Array(b2, None),
+                                    ))));
+                                    Ok(Value::new(
+                                        if let Some(PointerValue(v)) = val.comp_val {
+                                            let llt = at.llvm_type(ctx).unwrap().into_struct_type();
+                                            let v1 = ctx
+                                                .builder
+                                                .build_insert_value(llt.const_zero(), v, 0, "")
+                                                .unwrap();
+                                            let v2 = ctx
+                                                .builder
+                                                .build_insert_value(
+                                                    v1,
+                                                    ctx.context
+                                                        .i64_type()
+                                                        .const_int(l as u64, false),
+                                                    1,
+                                                    "",
+                                                )
+                                                .unwrap();
+                                            Some(v2.into_struct_value().into())
+                                        } else {
+                                            None
+                                        },
+                                        val.inter_val,
+                                        at,
+                                    ))
+                                } else {
+                                    Err(err)
+                                }
+                            }
+                            Type::Array(b2, None) => {
+                                if b == b2 {
+                                    let at = Type::Reference(Box::new(Type::Mut(Box::new(
+                                        Type::Array(b2, None),
+                                    ))));
+                                    Ok(Value::new(
+                                        if let Some(PointerValue(v)) = val.comp_val {
+                                            let llt = at.llvm_type(ctx).unwrap().into_struct_type();
+                                            let v1 = ctx
+                                                .builder
+                                                .build_insert_value(llt.const_zero(), v, 0, "")
+                                                .unwrap();
+                                            let v2 = ctx
+                                                .builder
+                                                .build_insert_value(
+                                                    v1,
+                                                    ctx.context
+                                                        .i64_type()
+                                                        .const_int(l as u64, false),
+                                                    1,
+                                                    "",
+                                                )
+                                                .unwrap();
+                                            Some(v2.into_struct_value().into())
+                                        } else {
+                                            None
+                                        },
+                                        val.inter_val,
+                                        at,
+                                    ))
+                                } else {
+                                    Err(err)
+                                }
+                            }
+                            _ => Err(err),
+                        },
+                        _ => Err(err),
+                    },
                     Type::Array(b, None) => match target {
                         Type::Pointer(b2) if covariant(&b, &b2) => {
                             val.data_type = Type::Reference(Box::new(Type::Array(b, None)));
@@ -1905,41 +3529,69 @@ pub fn impl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
                             }
                             Ok(Value::new(val.comp_val, val.inter_val, Type::Pointer(b2)))
                         }
-                        _ => Err(err)
-                    }
+                        _ => Err(err),
+                    },
                     b => {
-                        if b.has_dtor(ctx) {Err(CobaltError::CantMoveFromReference {loc, ty: val.data_type.to_string() })}
-                        else {
+                        if b.has_dtor(ctx) {
+                            Err(CobaltError::CantMoveFromReference {
+                                loc,
+                                ty: val.data_type.to_string(),
+                            })
+                        } else {
                             if !(ctx.is_const.get() && matches!(b, Type::Mut(_))) {
                                 if let Some(PointerValue(v)) = val.comp_val {
-                                    val.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
+                                    val.comp_val = Some(ctx.builder.build_load(
+                                        b.llvm_type(ctx).unwrap(),
+                                        v,
+                                        "",
+                                    ));
                                 }
                             }
                             val.data_type = b;
                             expl_convert(loc, (val, vloc), (target, tloc), ctx)
                         }
                     }
-                }
+                },
                 Type::Array(b, Some(l)) => match target {
-                    Type::Pointer(b2) if covariant(&b, &b2) => Ok(Value::new(val.comp_val, val.inter_val, Type::Pointer(b2))),
-                    Type::Reference(b2) => if let Type::Array(b2, None) = *b2 {
-                        if b == b2 {
-                            let at = Type::Reference(Box::new(Type::Array(b2, None)));
-                            Ok(Value::new(
-                                if let Some(PointerValue(v)) = val.comp_val {
-                                    let llt = at.llvm_type(ctx).unwrap().into_struct_type();
-                                    let v1 = ctx.builder.build_insert_value(llt.const_zero(), v, 0, "").unwrap();
-                                    let v2 = ctx.builder.build_insert_value(v1, ctx.context.i64_type().const_int(l as u64, false), 1, "").unwrap();
-                                    Some(v2.into_struct_value().into())
-                                } else {None},
-                                val.inter_val,
-                                at
-                            ))
+                    Type::Pointer(b2) if covariant(&b, &b2) => {
+                        Ok(Value::new(val.comp_val, val.inter_val, Type::Pointer(b2)))
+                    }
+                    Type::Reference(b2) => {
+                        if let Type::Array(b2, None) = *b2 {
+                            if b == b2 {
+                                let at = Type::Reference(Box::new(Type::Array(b2, None)));
+                                Ok(Value::new(
+                                    if let Some(PointerValue(v)) = val.comp_val {
+                                        let llt = at.llvm_type(ctx).unwrap().into_struct_type();
+                                        let v1 = ctx
+                                            .builder
+                                            .build_insert_value(llt.const_zero(), v, 0, "")
+                                            .unwrap();
+                                        let v2 = ctx
+                                            .builder
+                                            .build_insert_value(
+                                                v1,
+                                                ctx.context.i64_type().const_int(l as u64, false),
+                                                1,
+                                                "",
+                                            )
+                                            .unwrap();
+                                        Some(v2.into_struct_value().into())
+                                    } else {
+                                        None
+                                    },
+                                    val.inter_val,
+                                    at,
+                                ))
+                            } else {
+                                Err(err)
+                            }
+                        } else {
+                            Err(err)
                         }
-                        else {Err(err)}
-                    } else {Err(err)}
-                    _ => Err(err)
-                }
+                    }
+                    _ => Err(err),
+                },
                 Type::Array(b, None) => match target {
                     Type::Pointer(b2) if covariant(&b, &b2) => {
                         val.data_type = Type::Reference(Box::new(Type::Array(b.clone(), None)));
@@ -1948,14 +3600,19 @@ pub fn impl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
                         }
                         Ok(Value::new(val.comp_val, val.inter_val, Type::Pointer(b)))
                     }
-                    _ => Err(err)
-                }
+                    _ => Err(err),
+                },
                 b => {
-                    if b.has_dtor(ctx) {Err(CobaltError::CantMoveFromReference {loc, ty: val.data_type.to_string() })}
-                    else {
+                    if b.has_dtor(ctx) {
+                        Err(CobaltError::CantMoveFromReference {
+                            loc,
+                            ty: val.data_type.to_string(),
+                        })
+                    } else {
                         if !(ctx.is_const.get() && matches!(b, Type::Mut(_))) {
                             if let Some(PointerValue(v)) = val.comp_val {
-                                val.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
+                                val.comp_val =
+                                    Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
                             }
                         }
                         val.data_type = b;
@@ -1975,119 +3632,290 @@ pub fn impl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
         }
         Type::IntLiteral => match target {
             x @ Type::Int(..) => Ok(Value::new(
-                if let Some(InterData::Int(v)) = val.inter_val {Some(IntValue(x.llvm_type(ctx).unwrap().into_int_type().const_int(v as u64, true)))}
-                            else if let Some(IntValue(v)) = val.comp_val {Some(IntValue(ctx.builder.build_int_z_extend(v, x.llvm_type(ctx).unwrap().into_int_type(), "")))}
-                            else {None},
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(IntValue(
+                        x.llvm_type(ctx)
+                            .unwrap()
+                            .into_int_type()
+                            .const_int(v as u64, true),
+                    ))
+                } else if let Some(IntValue(v)) = val.comp_val {
+                    Some(IntValue(ctx.builder.build_int_z_extend(
+                        v,
+                        x.llvm_type(ctx).unwrap().into_int_type(),
+                        "",
+                    )))
+                } else {
+                    None
+                },
                 val.inter_val,
-                x
+                x,
             )),
             x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Ok(Value::new(
-                if let Some(InterData::Int(v)) = val.inter_val {Some(FloatValue(x.llvm_type(ctx).unwrap().into_float_type().const_float(v as f64)))}
-                            else if let Some(IntValue(v)) = val.comp_val {Some(FloatValue(ctx.builder.build_signed_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "")))}
-                            else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
-                x
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(FloatValue(
+                        x.llvm_type(ctx)
+                            .unwrap()
+                            .into_float_type()
+                            .const_float(v as f64),
+                    ))
+                } else if let Some(IntValue(v)) = val.comp_val {
+                    Some(FloatValue(ctx.builder.build_signed_int_to_float(
+                        v,
+                        x.llvm_type(ctx).unwrap().into_float_type(),
+                        "",
+                    )))
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Float(v as f64))
+                } else {
+                    None
+                },
+                x,
             )),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         Type::Int(ls, true) => match target {
             Type::Int(1, false) => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_compare(NE, v, ctx.context.custom_width_int_type(ls as u32).const_zero(), "").into())} else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
-                Type::Int(1, false)
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_int_compare(
+                                NE,
+                                v,
+                                ctx.context.custom_width_int_type(ls as u32).const_zero(),
+                                "",
+                            )
+                            .into(),
+                    )
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Int(if v == 0 { 0 } else { 1 }))
+                } else {
+                    None
+                },
+                Type::Int(1, false),
             )),
             Type::Int(rs, true) if ls < rs => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_z_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_int_z_extend(v, ctx.context.custom_width_int_type(rs as u32), "")
+                            .into(),
+                    )
+                } else {
+                    None
+                },
                 val.inter_val,
-                Type::Int(rs, true)
+                Type::Int(rs, true),
             )),
             Type::Int(rs, false) if ls < rs => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "")
+                            .into(),
+                    )
+                } else {
+                    None
+                },
                 val.inter_val,
-                Type::Int(rs, false)
+                Type::Int(rs, false),
             )),
             x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_unsigned_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
-                x
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_unsigned_int_to_float(
+                                v,
+                                x.llvm_type(ctx).unwrap().into_float_type(),
+                                "",
+                            )
+                            .into(),
+                    )
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Float(v as f64))
+                } else {
+                    None
+                },
+                x,
             )),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         Type::Int(ls, false) => match target {
             Type::Int(1, false) => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_compare(NE, v, ctx.context.custom_width_int_type(ls as u32).const_zero(), "").into())} else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
-                Type::Int(1, false)
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_int_compare(
+                                NE,
+                                v,
+                                ctx.context.custom_width_int_type(ls as u32).const_zero(),
+                                "",
+                            )
+                            .into(),
+                    )
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Int(if v == 0 { 0 } else { 1 }))
+                } else {
+                    None
+                },
+                Type::Int(1, false),
             )),
             Type::Int(rs, ru) if ls < rs => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "")
+                            .into(),
+                    )
+                } else {
+                    None
+                },
                 val.inter_val,
-                Type::Int(rs, ru)
+                Type::Int(rs, ru),
             )),
             x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_signed_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
-                x
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_signed_int_to_float(
+                                v,
+                                x.llvm_type(ctx).unwrap().into_float_type(),
+                                "",
+                            )
+                            .into(),
+                    )
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Float(v as f64))
+                } else {
+                    None
+                },
+                x,
             )),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         Type::Pointer(lb) => match target {
             Type::Pointer(rb) if covariant(lb.as_ref(), rb.as_ref()) => Ok(Value::new(
-                val.value(ctx).map(|v| ctx.builder.build_bitcast(v, ctx.null_type.ptr_type(Default::default()), "")),
+                val.value(ctx).map(|v| {
+                    ctx.builder
+                        .build_bitcast(v, ctx.null_type.ptr_type(Default::default()), "")
+                }),
                 None,
-                Type::Pointer(rb)
+                Type::Pointer(rb),
             )),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         Type::Tuple(v) => {
             if target == Type::TypeData {
                 if let Some(InterData::Array(a)) = val.inter_val {
                     let mut vec = Vec::with_capacity(v.len());
                     for (iv, dt) in a.into_iter().zip(v) {
-                        vec.push(impl_convert(unreachable_span(), (Value::metaval(iv, dt), None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).ok_or(err.clone())?);
+                        vec.push(
+                            impl_convert(
+                                unreachable_span(),
+                                (Value::metaval(iv, dt), None),
+                                (Type::TypeData, None),
+                                ctx,
+                            )
+                            .ok()
+                            .and_then(Value::into_type)
+                            .ok_or(err.clone())?,
+                        );
                     }
                     Ok(Value::make_type(Type::Tuple(vec)))
+                } else {
+                    Err(err)
                 }
-                else {Err(err)}
+            } else {
+                Err(err)
             }
-            else {Err(err)}
         }
-        Type::Null => if target == Type::TypeData {Ok(Value::make_type(Type::Null))} else {Err(err)},
+        Type::Null => {
+            if target == Type::TypeData {
+                Ok(Value::make_type(Type::Null))
+            } else {
+                Err(err)
+            }
+        }
         Type::Error => Ok(Value::error()),
-        _ => Err(err)
+        _ => Err(err),
     }
 }
-pub fn expl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option<SourceSpan>), (target, tloc): (Type, Option<SourceSpan>), ctx: &CompCtx<'ctx>) -> Result<Value<'ctx>, CobaltError> {
+pub fn expl_convert<'ctx>(
+    loc: SourceSpan,
+    (mut val, vloc): (Value<'ctx>, Option<SourceSpan>),
+    (target, tloc): (Type, Option<SourceSpan>),
+    ctx: &CompCtx<'ctx>,
+) -> Result<Value<'ctx>, CobaltError> {
     let err = CobaltError::InvalidConversion {
         is_expl: true,
         val: val.data_type.to_string(),
         ty: target.to_string(),
-        vloc, tloc,
-        oloc: loc
+        vloc,
+        tloc,
+        oloc: loc,
     };
-    if val.data_type == target {return Ok(val)}
-    else if target == Type::Null {return Ok(Value::null())}
-    else if target == Type::Error {return Ok(Value::error())}
-    else if let Type::Reference(ref b) = target {
+    if val.data_type == target {
+        return Ok(val);
+    } else if target == Type::Null {
+        return Ok(Value::null());
+    } else if target == Type::Error {
+        return Ok(Value::error());
+    } else if let Type::Reference(ref b) = target {
         if **b == val.data_type {
             mark_use(&val, cfg::Location::current(ctx).unwrap(), ctx, loc);
-            if val.name.is_none() {ctx.to_drop.borrow_mut().last_mut().unwrap().push(val.clone());}
-            return Ok(Value::new(if matches!(val.data_type, Type::Mut(_)) {val.value(ctx)} else {val.addr(ctx).map(From::from)}, None, target))
+            if val.name.is_none() {
+                ctx.to_drop
+                    .borrow_mut()
+                    .last_mut()
+                    .unwrap()
+                    .push(val.clone());
+            }
+            return Ok(Value::new(
+                if matches!(val.data_type, Type::Mut(_)) {
+                    val.value(ctx)
+                } else {
+                    val.addr(ctx).map(From::from)
+                },
+                None,
+                target,
+            ));
         }
         if let Type::Mut(b) = b.as_ref() {
             if **b == val.data_type {
-                return if let Some(floc) = val.frozen {Err(CobaltError::CantMutateImmut {
-                    vloc: vloc.unwrap_or(loc),
-                    ty: val.data_type.to_string(),
-                    oloc: None,
-                    op: "".to_string(),
-                    floc
-                })}
-                else {
+                return if let Some(floc) = val.frozen {
+                    Err(CobaltError::CantMutateImmut {
+                        vloc: vloc.unwrap_or(loc),
+                        ty: val.data_type.to_string(),
+                        oloc: None,
+                        op: "".to_string(),
+                        floc,
+                    })
+                } else {
                     mark_use(&val, cfg::Location::current(ctx).unwrap(), ctx, loc);
-                    if val.name.is_none() {ctx.to_drop.borrow_mut().last_mut().unwrap().push(val.clone());}
+                    if val.name.is_none() {
+                        ctx.to_drop
+                            .borrow_mut()
+                            .last_mut()
+                            .unwrap()
+                            .push(val.clone());
+                    }
                     Ok(Value::new(val.addr(ctx).map(From::from), None, target))
-                }
+                };
             }
         }
     }
@@ -2101,40 +3929,82 @@ pub fn expl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
             match *b {
                 Type::Mut(b) => match *b {
                     Type::Array(b, Some(l)) => match target {
-                        Type::Pointer(b2) if covariant(&b, &b2) => Ok(Value::new(val.comp_val, val.inter_val, Type::Pointer(b))),
-                        Type::Reference(b2) => match *b2 {
-                            Type::Mut(b2) => if b == b2 {
-                                let at = Type::Reference(Box::new(Type::Mut(Box::new(Type::Array(b2, None)))));
-                                Ok(Value::new(
-                                    if let Some(PointerValue(v)) = val.comp_val {
-                                        let llt = at.llvm_type(ctx).unwrap().into_struct_type();
-                                        let v1 = ctx.builder.build_insert_value(llt.const_zero(), v, 0, "").unwrap();
-                                        let v2 = ctx.builder.build_insert_value(v1, ctx.context.i64_type().const_int(l as u64, false), 1, "").unwrap();
-                                        Some(v2.into_struct_value().into())
-                                    } else {None},
-                                    val.inter_val,
-                                    at
-                                ))
-                            }
-                            else {Err(err)}
-                            Type::Array(b2, None) => if b == b2 {
-                                let at = Type::Reference(Box::new(Type::Mut(Box::new(Type::Array(b2, None)))));
-                                Ok(Value::new(
-                                    if let Some(PointerValue(v)) = val.comp_val {
-                                        let llt = at.llvm_type(ctx).unwrap().into_struct_type();
-                                        let v1 = ctx.builder.build_insert_value(llt.const_zero(), v, 0, "").unwrap();
-                                        let v2 = ctx.builder.build_insert_value(v1, ctx.context.i64_type().const_int(l as u64, false), 1, "").unwrap();
-                                        Some(v2.into_struct_value().into())
-                                    } else {None},
-                                    val.inter_val,
-                                    at
-                                ))
-                            }
-                            else {Err(err)}
-                            _ => Err(err)
+                        Type::Pointer(b2) if covariant(&b, &b2) => {
+                            Ok(Value::new(val.comp_val, val.inter_val, Type::Pointer(b)))
                         }
-                        _ => Err(err)
-                    }
+                        Type::Reference(b2) => match *b2 {
+                            Type::Mut(b2) => {
+                                if b == b2 {
+                                    let at = Type::Reference(Box::new(Type::Mut(Box::new(
+                                        Type::Array(b2, None),
+                                    ))));
+                                    Ok(Value::new(
+                                        if let Some(PointerValue(v)) = val.comp_val {
+                                            let llt = at.llvm_type(ctx).unwrap().into_struct_type();
+                                            let v1 = ctx
+                                                .builder
+                                                .build_insert_value(llt.const_zero(), v, 0, "")
+                                                .unwrap();
+                                            let v2 = ctx
+                                                .builder
+                                                .build_insert_value(
+                                                    v1,
+                                                    ctx.context
+                                                        .i64_type()
+                                                        .const_int(l as u64, false),
+                                                    1,
+                                                    "",
+                                                )
+                                                .unwrap();
+                                            Some(v2.into_struct_value().into())
+                                        } else {
+                                            None
+                                        },
+                                        val.inter_val,
+                                        at,
+                                    ))
+                                } else {
+                                    Err(err)
+                                }
+                            }
+                            Type::Array(b2, None) => {
+                                if b == b2 {
+                                    let at = Type::Reference(Box::new(Type::Mut(Box::new(
+                                        Type::Array(b2, None),
+                                    ))));
+                                    Ok(Value::new(
+                                        if let Some(PointerValue(v)) = val.comp_val {
+                                            let llt = at.llvm_type(ctx).unwrap().into_struct_type();
+                                            let v1 = ctx
+                                                .builder
+                                                .build_insert_value(llt.const_zero(), v, 0, "")
+                                                .unwrap();
+                                            let v2 = ctx
+                                                .builder
+                                                .build_insert_value(
+                                                    v1,
+                                                    ctx.context
+                                                        .i64_type()
+                                                        .const_int(l as u64, false),
+                                                    1,
+                                                    "",
+                                                )
+                                                .unwrap();
+                                            Some(v2.into_struct_value().into())
+                                        } else {
+                                            None
+                                        },
+                                        val.inter_val,
+                                        at,
+                                    ))
+                                } else {
+                                    Err(err)
+                                }
+                            }
+                            _ => Err(err),
+                        },
+                        _ => Err(err),
+                    },
                     Type::Array(b, None) => match target {
                         Type::Pointer(b2) if covariant(&b, &b2) => {
                             val.data_type = Type::Reference(Box::new(Type::Array(b, None)));
@@ -2143,41 +4013,69 @@ pub fn expl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
                             }
                             Ok(Value::new(val.comp_val, val.inter_val, Type::Pointer(b2)))
                         }
-                        _ => Err(err)
-                    }
+                        _ => Err(err),
+                    },
                     b => {
-                        if b.has_dtor(ctx) {Err(CobaltError::CantMoveFromReference {loc, ty: b.to_string()})}
-                        else {
+                        if b.has_dtor(ctx) {
+                            Err(CobaltError::CantMoveFromReference {
+                                loc,
+                                ty: b.to_string(),
+                            })
+                        } else {
                             if !(ctx.is_const.get() && matches!(b, Type::Mut(_))) {
                                 if let Some(PointerValue(v)) = val.comp_val {
-                                    val.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
+                                    val.comp_val = Some(ctx.builder.build_load(
+                                        b.llvm_type(ctx).unwrap(),
+                                        v,
+                                        "",
+                                    ));
                                 }
                             }
                             val.data_type = b;
                             expl_convert(loc, (val, vloc), (target, tloc), ctx)
                         }
                     }
-                }
+                },
                 Type::Array(b, Some(l)) => match target {
-                    Type::Pointer(b2) if covariant(&b, &b2) => Ok(Value::new(val.comp_val, val.inter_val, Type::Pointer(b2))),
-                    Type::Reference(b2) => if let Type::Array(b2, None) = *b2 {
-                        if b == b2 {
-                            let at = Type::Reference(Box::new(Type::Array(b2, None)));
-                            Ok(Value::new(
-                                if let Some(PointerValue(v)) = val.comp_val {
-                                    let llt = at.llvm_type(ctx).unwrap().into_struct_type();
-                                    let v1 = ctx.builder.build_insert_value(llt.const_zero(), v, 0, "").unwrap();
-                                    let v2 = ctx.builder.build_insert_value(v1, ctx.context.i64_type().const_int(l as u64, false), 1, "").unwrap();
-                                    Some(v2.into_struct_value().into())
-                                } else {None},
-                                val.inter_val,
-                                at
-                            ))
+                    Type::Pointer(b2) if covariant(&b, &b2) => {
+                        Ok(Value::new(val.comp_val, val.inter_val, Type::Pointer(b2)))
+                    }
+                    Type::Reference(b2) => {
+                        if let Type::Array(b2, None) = *b2 {
+                            if b == b2 {
+                                let at = Type::Reference(Box::new(Type::Array(b2, None)));
+                                Ok(Value::new(
+                                    if let Some(PointerValue(v)) = val.comp_val {
+                                        let llt = at.llvm_type(ctx).unwrap().into_struct_type();
+                                        let v1 = ctx
+                                            .builder
+                                            .build_insert_value(llt.const_zero(), v, 0, "")
+                                            .unwrap();
+                                        let v2 = ctx
+                                            .builder
+                                            .build_insert_value(
+                                                v1,
+                                                ctx.context.i64_type().const_int(l as u64, false),
+                                                1,
+                                                "",
+                                            )
+                                            .unwrap();
+                                        Some(v2.into_struct_value().into())
+                                    } else {
+                                        None
+                                    },
+                                    val.inter_val,
+                                    at,
+                                ))
+                            } else {
+                                Err(err)
+                            }
+                        } else {
+                            Err(err)
                         }
-                        else {Err(err)}
-                    } else {Err(err)}
-                    _ => Err(err)
-                }
+                    }
+                    _ => Err(err),
+                },
                 Type::Array(b, None) => match target {
                     Type::Pointer(b2) if covariant(&b, &b2) => {
                         val.data_type = Type::Reference(Box::new(Type::Array(b.clone(), None)));
@@ -2186,14 +4084,19 @@ pub fn expl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
                         }
                         Ok(Value::new(val.comp_val, val.inter_val, Type::Pointer(b)))
                     }
-                    _ => Err(err)
-                }
+                    _ => Err(err),
+                },
                 b => {
-                    if b.has_dtor(ctx) {Err(CobaltError::CantMoveFromReference {loc, ty: b.to_string()})}
-                    else {
+                    if b.has_dtor(ctx) {
+                        Err(CobaltError::CantMoveFromReference {
+                            loc,
+                            ty: b.to_string(),
+                        })
+                    } else {
                         if !(ctx.is_const.get() && matches!(b, Type::Mut(_))) {
                             if let Some(PointerValue(v)) = val.comp_val {
-                                val.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
+                                val.comp_val =
+                                    Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
                             }
                         }
                         val.data_type = b;
@@ -2213,177 +4116,468 @@ pub fn expl_convert<'ctx>(loc: SourceSpan, (mut val, vloc): (Value<'ctx>, Option
         }
         Type::IntLiteral => match target {
             x @ Type::Int(..) => Ok(Value::new(
-                if let Some(InterData::Int(v)) = val.inter_val {Some(IntValue(x.llvm_type(ctx).unwrap().into_int_type().const_int(v as u64, true)))}
-                          else if let Some(IntValue(v)) = val.comp_val {Some(IntValue(ctx.builder.build_int_z_extend(v, x.llvm_type(ctx).unwrap().into_int_type(), "")))}
-                          else {None},
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(IntValue(
+                        x.llvm_type(ctx)
+                            .unwrap()
+                            .into_int_type()
+                            .const_int(v as u64, true),
+                    ))
+                } else if let Some(IntValue(v)) = val.comp_val {
+                    Some(IntValue(ctx.builder.build_int_z_extend(
+                        v,
+                        x.llvm_type(ctx).unwrap().into_int_type(),
+                        "",
+                    )))
+                } else {
+                    None
+                },
                 val.inter_val,
-                x
+                x,
             )),
             x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Ok(Value::new(
-                if let Some(InterData::Int(v)) = val.inter_val {Some(FloatValue(x.llvm_type(ctx).unwrap().into_float_type().const_float(v as f64)))}
-                          else if let Some(IntValue(v)) = val.comp_val {Some(FloatValue(ctx.builder.build_signed_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "")))}
-                          else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
-                x
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(FloatValue(
+                        x.llvm_type(ctx)
+                            .unwrap()
+                            .into_float_type()
+                            .const_float(v as f64),
+                    ))
+                } else if let Some(IntValue(v)) = val.comp_val {
+                    Some(FloatValue(ctx.builder.build_signed_int_to_float(
+                        v,
+                        x.llvm_type(ctx).unwrap().into_float_type(),
+                        "",
+                    )))
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Float(v as f64))
+                } else {
+                    None
+                },
+                x,
             )),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         Type::Int(ls, true) => match target {
-            Type::Int(rs, ru) if ls == rs => Ok(Value::new(val.comp_val, val.inter_val, Type::Int(rs, ru))),
+            Type::Int(rs, ru) if ls == rs => {
+                Ok(Value::new(val.comp_val, val.inter_val, Type::Int(rs, ru)))
+            }
             Type::Int(1, false) => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_compare(NE, v, ctx.context.custom_width_int_type(ls as u32).const_zero(), "").into())} else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
-                Type::Int(1, false)
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_int_compare(
+                                NE,
+                                v,
+                                ctx.context.custom_width_int_type(ls as u32).const_zero(),
+                                "",
+                            )
+                            .into(),
+                    )
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Int(if v == 0 { 0 } else { 1 }))
+                } else {
+                    None
+                },
+                Type::Int(1, false),
             )),
             Type::Int(rs, true) if ls < rs => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_z_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_int_z_extend(v, ctx.context.custom_width_int_type(rs as u32), "")
+                            .into(),
+                    )
+                } else {
+                    None
+                },
                 val.inter_val,
-                Type::Int(rs, true)
+                Type::Int(rs, true),
             )),
             Type::Int(rs, false) if ls < rs => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "")
+                            .into(),
+                    )
+                } else {
+                    None
+                },
                 val.inter_val,
-                Type::Int(rs, false)
+                Type::Int(rs, false),
             )),
             Type::Int(rs, ru) if ls > rs => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_truncate(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_int_truncate(v, ctx.context.custom_width_int_type(rs as u32), "")
+                            .into(),
+                    )
+                } else {
+                    None
+                },
                 val.inter_val,
-                Type::Int(rs, ru)
+                Type::Int(rs, ru),
             )),
             x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_unsigned_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
-                x
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_unsigned_int_to_float(
+                                v,
+                                x.llvm_type(ctx).unwrap().into_float_type(),
+                                "",
+                            )
+                            .into(),
+                    )
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Float(v as f64))
+                } else {
+                    None
+                },
+                x,
             )),
             Type::Pointer(b) => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_to_ptr(v, Type::Pointer(b.clone()).llvm_type(ctx).unwrap().into_pointer_type(), "").into())} else {None},
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_int_to_ptr(
+                                v,
+                                Type::Pointer(b.clone())
+                                    .llvm_type(ctx)
+                                    .unwrap()
+                                    .into_pointer_type(),
+                                "",
+                            )
+                            .into(),
+                    )
+                } else {
+                    None
+                },
                 None,
-                Type::Pointer(b)
+                Type::Pointer(b),
             )),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         Type::Int(ls, false) => match target {
-            Type::Int(rs, ru) if ls == rs => Ok(Value::new(val.comp_val, val.inter_val, Type::Int(rs, ru))),
+            Type::Int(rs, ru) if ls == rs => {
+                Ok(Value::new(val.comp_val, val.inter_val, Type::Int(rs, ru)))
+            }
             Type::Int(1, false) => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_compare(NE, v, ctx.context.custom_width_int_type(ls as u32).const_zero(), "").into())} else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
-                Type::Int(1, false)
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_int_compare(
+                                NE,
+                                v,
+                                ctx.context.custom_width_int_type(ls as u32).const_zero(),
+                                "",
+                            )
+                            .into(),
+                    )
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Int(if v == 0 { 0 } else { 1 }))
+                } else {
+                    None
+                },
+                Type::Int(1, false),
             )),
             Type::Int(rs, ru) if ls < rs => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_int_s_extend(v, ctx.context.custom_width_int_type(rs as u32), "")
+                            .into(),
+                    )
+                } else {
+                    None
+                },
                 val.inter_val,
-                Type::Int(rs, ru)
+                Type::Int(rs, ru),
             )),
             Type::Int(rs, ru) if ls > rs => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_truncate(v, ctx.context.custom_width_int_type(rs as u32), "").into())} else {None},
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_int_truncate(v, ctx.context.custom_width_int_type(rs as u32), "")
+                            .into(),
+                    )
+                } else {
+                    None
+                },
                 val.inter_val,
-                Type::Int(rs, ru)
+                Type::Int(rs, ru),
             )),
             x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_signed_int_to_float(v, x.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Float(v as f64))} else {None},
-                x
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_signed_int_to_float(
+                                v,
+                                x.llvm_type(ctx).unwrap().into_float_type(),
+                                "",
+                            )
+                            .into(),
+                    )
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Float(v as f64))
+                } else {
+                    None
+                },
+                x,
             )),
             Type::Pointer(b) => Ok(Value::new(
-                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_int_to_ptr(v, Type::Pointer(b.clone()).llvm_type(ctx).unwrap().into_pointer_type(), "").into())} else {None},
+                if let (Some(IntValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_int_to_ptr(
+                                v,
+                                Type::Pointer(b.clone())
+                                    .llvm_type(ctx)
+                                    .unwrap()
+                                    .into_pointer_type(),
+                                "",
+                            )
+                            .into(),
+                    )
+                } else {
+                    None
+                },
                 None,
-                Type::Pointer(b)
+                Type::Pointer(b),
             )),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         ref x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => match target {
             Type::Int(1, false) => Ok(Value::new(
-                if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_float_compare(ONE, v, x.llvm_type(ctx).unwrap().into_float_type().const_zero(), "").into())} else {None},
-                if let Some(InterData::Int(v)) = val.inter_val {Some(InterData::Int(if v == 0 {0} else {1}))} else {None},
-                Type::Int(1, false)
+                if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_float_compare(
+                                ONE,
+                                v,
+                                x.llvm_type(ctx).unwrap().into_float_type().const_zero(),
+                                "",
+                            )
+                            .into(),
+                    )
+                } else {
+                    None
+                },
+                if let Some(InterData::Int(v)) = val.inter_val {
+                    Some(InterData::Int(if v == 0 { 0 } else { 1 }))
+                } else {
+                    None
+                },
+                Type::Int(1, false),
             )),
             Type::Int(s, false) => Ok(Value::new(
-                if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_float_to_signed_int(v, ctx.context.custom_width_int_type(s as u32), "").into())} else {None},
-                if let Some(InterData::Float(v)) = val.inter_val {Some(InterData::Int(v as i128))} else {None},
-                Type::Int(s, false)
+                if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_float_to_signed_int(
+                                v,
+                                ctx.context.custom_width_int_type(s as u32),
+                                "",
+                            )
+                            .into(),
+                    )
+                } else {
+                    None
+                },
+                if let Some(InterData::Float(v)) = val.inter_val {
+                    Some(InterData::Int(v as i128))
+                } else {
+                    None
+                },
+                Type::Int(s, false),
             )),
             Type::Int(s, true) => Ok(Value::new(
-                if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_float_to_unsigned_int(v, ctx.context.custom_width_int_type(s as u32), "").into())} else {None},
-                if let Some(InterData::Float(v)) = val.inter_val {Some(InterData::Int(v as i128))} else {None},
-                Type::Int(s, false)
+                if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_float_to_unsigned_int(
+                                v,
+                                ctx.context.custom_width_int_type(s as u32),
+                                "",
+                            )
+                            .into(),
+                    )
+                } else {
+                    None
+                },
+                if let Some(InterData::Float(v)) = val.inter_val {
+                    Some(InterData::Int(v as i128))
+                } else {
+                    None
+                },
+                Type::Int(s, false),
             )),
             r @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Ok(Value::new(
-                if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {Some(ctx.builder.build_float_cast(v, r.llvm_type(ctx).unwrap().into_float_type(), "").into())} else {None},
+                if let (Some(FloatValue(v)), false) = (val.value(ctx), ctx.is_const.get()) {
+                    Some(
+                        ctx.builder
+                            .build_float_cast(v, r.llvm_type(ctx).unwrap().into_float_type(), "")
+                            .into(),
+                    )
+                } else {
+                    None
+                },
                 val.inter_val,
-                x.clone()
+                x.clone(),
             )),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         Type::Pointer(ref lb) => match target {
             Type::Pointer(rb) if covariant(lb.as_ref(), rb.as_ref()) => Ok(Value::new(
-                val.value(ctx).map(|v| ctx.builder.build_bitcast(v, ctx.null_type.ptr_type(Default::default()), "")),
+                val.value(ctx).map(|v| {
+                    ctx.builder
+                        .build_bitcast(v, ctx.null_type.ptr_type(Default::default()), "")
+                }),
                 None,
-                Type::Pointer(Box::new(Type::Null))
+                Type::Pointer(Box::new(Type::Null)),
             )),
             Type::Pointer(rb) if **lb == Type::Null && !matches!(*rb, Type::Array(_, None)) => {
                 let pt = Type::Pointer(rb);
                 Ok(Value::new(
-                    val.value(ctx).and_then(|v| Some(ctx.builder.build_bitcast(v, pt.llvm_type(ctx)?, ""))),
+                    val.value(ctx)
+                        .and_then(|v| Some(ctx.builder.build_bitcast(v, pt.llvm_type(ctx)?, ""))),
                     None,
-                    pt
+                    pt,
                 ))
             }
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         Type::Tuple(v) => {
             if target == Type::TypeData {
                 if let Some(InterData::Array(a)) = val.inter_val {
                     let mut vec = Vec::with_capacity(v.len());
                     for (iv, dt) in a.into_iter().zip(v) {
-                        vec.push(impl_convert(unreachable_span(), (Value::metaval(iv, dt), None), (Type::TypeData, None), ctx).ok().and_then(Value::into_type).ok_or(err.clone())?);
+                        vec.push(
+                            impl_convert(
+                                unreachable_span(),
+                                (Value::metaval(iv, dt), None),
+                                (Type::TypeData, None),
+                                ctx,
+                            )
+                            .ok()
+                            .and_then(Value::into_type)
+                            .ok_or(err.clone())?,
+                        );
                     }
                     Ok(Value::make_type(Type::Tuple(vec)))
+                } else {
+                    Err(err)
                 }
-                else {Err(err)}
+            } else {
+                Err(err)
             }
-            else {Err(err)}
         }
         Type::Null => match target {
             Type::TypeData => Ok(Value::make_type(Type::Null)),
-            x @ (Type::IntLiteral | Type::Int(..)) => Ok(Value::interpreted(x.llvm_type(ctx).unwrap().into_int_type().const_int(0, false).into(), InterData::Int(0), x)),
-            x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => Ok(Value::interpreted(x.llvm_type(ctx).unwrap().into_float_type().const_float(0.0).into(), InterData::Float(0.0), x)),
+            x @ (Type::IntLiteral | Type::Int(..)) => Ok(Value::interpreted(
+                x.llvm_type(ctx)
+                    .unwrap()
+                    .into_int_type()
+                    .const_int(0, false)
+                    .into(),
+                InterData::Int(0),
+                x,
+            )),
+            x @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128) => {
+                Ok(Value::interpreted(
+                    x.llvm_type(ctx)
+                        .unwrap()
+                        .into_float_type()
+                        .const_float(0.0)
+                        .into(),
+                    InterData::Float(0.0),
+                    x,
+                ))
+            }
             x @ Type::Pointer(..) => Ok(Value::compiled(x.llvm_type(ctx).unwrap().const_zero(), x)),
-            _ => Err(err)
-        }
+            _ => Err(err),
+        },
         Type::Error => Ok(Value::error()),
-        _ => Err(err)
+        _ => Err(err),
     }
 }
-pub fn attr<'ctx>((mut val, vloc): (Value<'ctx>, SourceSpan), (id, iloc): (&str, SourceSpan), ctx: &CompCtx<'ctx>) -> Result<Value<'ctx>, CobaltError> {
+pub fn attr<'ctx>(
+    (mut val, vloc): (Value<'ctx>, SourceSpan),
+    (id, iloc): (&str, SourceSpan),
+    ctx: &CompCtx<'ctx>,
+) -> Result<Value<'ctx>, CobaltError> {
     let err = CobaltError::AttrNotDefined {
         val: val.data_type.to_string(),
         attr: id.to_string(),
-        vloc, aloc: iloc
+        vloc,
+        aloc: iloc,
     };
     match val.data_type.clone() {
-        Type::Reference(b) => {
-            match *b {
-                Type::Mut(b) => if let Type::Nominal(n) = *b {
+        Type::Reference(b) => match *b {
+            Type::Mut(b) => {
+                if let Type::Nominal(n) = *b {
                     if id == "__base" {
-                        val.data_type = Type::Reference(Box::new(Type::Mut(Box::new(ctx.nominals.borrow()[&n].0.clone()))));
+                        val.data_type = Type::Reference(Box::new(Type::Mut(Box::new(
+                            ctx.nominals.borrow()[&n].0.clone(),
+                        ))));
                         Ok(val)
-                    }
-                    else {
+                    } else {
                         let noms = ctx.nominals.borrow();
                         let v = noms[&n].2.get(id).ok_or(err.clone())?;
-                        if let Value {data_type: Type::Reference(r), inter_val: Some(iv @ InterData::Function(FnData {mt, ..})), comp_val, ..} = v {
+                        if let Value {
+                            data_type: Type::Reference(r),
+                            inter_val: Some(iv @ InterData::Function(FnData { mt, .. })),
+                            comp_val,
+                            ..
+                        } = v
+                        {
                             if let Type::Function(ret, args) = r.as_ref() {
                                 match mt {
                                     MethodType::Normal => {
-                                        mark_use(&val, cfg::Location::current(ctx).unwrap(), ctx, vloc);
+                                        mark_use(
+                                            &val,
+                                            cfg::Location::current(ctx).unwrap(),
+                                            ctx,
+                                            vloc,
+                                        );
                                         let name = val.name.clone();
-                                        let this = impl_convert(vloc, (val, None), (args[0].0.clone(), Some(iloc)), ctx)?;
+                                        let this = impl_convert(
+                                            vloc,
+                                            (val, None),
+                                            (args[0].0.clone(), Some(iloc)),
+                                            ctx,
+                                        )?;
                                         let bm = Type::BoundMethod(ret.clone(), args.clone());
                                         let mut v = Value::metaval(iv.clone(), bm);
-                                        if let (Some(vv), Some(f), Some(StructType(llt))) = (this.comp_val, comp_val, v.data_type.llvm_type(ctx)) {
+                                        if let (Some(vv), Some(f), Some(StructType(llt))) =
+                                            (this.comp_val, comp_val, v.data_type.llvm_type(ctx))
+                                        {
                                             let v0 = llt.get_undef();
-                                            let v1 = ctx.builder.build_insert_value(v0, vv, 0, "").unwrap();
-                                            let v2 = ctx.builder.build_insert_value(v1, *f, 1, "").unwrap();
+                                            let v1 = ctx
+                                                .builder
+                                                .build_insert_value(v0, vv, 0, "")
+                                                .unwrap();
+                                            let v2 = ctx
+                                                .builder
+                                                .build_insert_value(v1, *f, 1, "")
+                                                .unwrap();
                                             v.comp_val = Some(v2.as_basic_value_enum());
                                         }
                                         v.name = name;
@@ -2392,111 +4586,215 @@ pub fn attr<'ctx>((mut val, vloc): (Value<'ctx>, SourceSpan), (id, iloc): (&str,
                                     MethodType::Static => Err(err),
                                     MethodType::Getter => {
                                         val.comp_val = val.addr(ctx).map(From::from);
-                                        val.data_type = Type::Reference(Box::new(val.data_type.clone()));
-                                        mark_use(&val, cfg::Location::current(ctx).unwrap(), ctx, vloc);
-                                        ops::call(Value::new(*comp_val, Some(iv.clone()), Type::Function(ret.clone(), args.clone())), iloc, None, vec![(val.clone(), vloc)], ctx)
+                                        val.data_type =
+                                            Type::Reference(Box::new(val.data_type.clone()));
+                                        mark_use(
+                                            &val,
+                                            cfg::Location::current(ctx).unwrap(),
+                                            ctx,
+                                            vloc,
+                                        );
+                                        ops::call(
+                                            Value::new(
+                                                *comp_val,
+                                                Some(iv.clone()),
+                                                Type::Function(ret.clone(), args.clone()),
+                                            ),
+                                            iloc,
+                                            None,
+                                            vec![(val.clone(), vloc)],
+                                            ctx,
+                                        )
                                     }
                                 }
-                            } else {Err(err)}
-                        } else {Err(err)}
+                            } else {
+                                Err(err)
+                            }
+                        } else {
+                            Err(err)
+                        }
                     }
-                } else {Err(err)}
-                Type::Nominal(n) =>
-                    if id == "__base" {
-                        val.data_type = Type::Reference(Box::new(ctx.nominals.borrow()[&n].0.clone()));
-                        Ok(val)
-                    }
-                    else {
-                        let noms = ctx.nominals.borrow();
-                        let v = noms[&n].2.get(id).ok_or(err.clone())?;
-                        if let Value {data_type: Type::Reference(r), inter_val: Some(iv @ InterData::Function(FnData {mt, ..})), comp_val, ..} = v {
-                            if let Type::Function(ret, args) = r.as_ref() {
-                                match mt {
-                                    MethodType::Normal => {
-                                        mark_use(&val, cfg::Location::current(ctx).unwrap(), ctx, vloc);
-                                        let name = val.name.clone();
-                                        let this = impl_convert(vloc, (val, None), (args[0].0.clone(), Some(iloc)), ctx)?;
-                                        let bm = Type::BoundMethod(ret.clone(), args.clone());
-                                        let mut v = Value::metaval(iv.clone(), bm);
-                                        if let (Some(vv), Some(f), Some(StructType(llt))) = (this.comp_val, comp_val, v.data_type.llvm_type(ctx)) {
-                                            let v0 = llt.get_undef();
-                                            let v1 = ctx.builder.build_insert_value(v0, vv, 0, "").unwrap();
-                                            let v2 = ctx.builder.build_insert_value(v1, *f, 1, "").unwrap();
-                                            v.comp_val = Some(v2.as_basic_value_enum());
-                                        }
-                                        v.name = name;
-                                        Ok(v)
+                } else {
+                    Err(err)
+                }
+            }
+            Type::Nominal(n) => {
+                if id == "__base" {
+                    val.data_type = Type::Reference(Box::new(ctx.nominals.borrow()[&n].0.clone()));
+                    Ok(val)
+                } else {
+                    let noms = ctx.nominals.borrow();
+                    let v = noms[&n].2.get(id).ok_or(err.clone())?;
+                    if let Value {
+                        data_type: Type::Reference(r),
+                        inter_val: Some(iv @ InterData::Function(FnData { mt, .. })),
+                        comp_val,
+                        ..
+                    } = v
+                    {
+                        if let Type::Function(ret, args) = r.as_ref() {
+                            match mt {
+                                MethodType::Normal => {
+                                    mark_use(&val, cfg::Location::current(ctx).unwrap(), ctx, vloc);
+                                    let name = val.name.clone();
+                                    let this = impl_convert(
+                                        vloc,
+                                        (val, None),
+                                        (args[0].0.clone(), Some(iloc)),
+                                        ctx,
+                                    )?;
+                                    let bm = Type::BoundMethod(ret.clone(), args.clone());
+                                    let mut v = Value::metaval(iv.clone(), bm);
+                                    if let (Some(vv), Some(f), Some(StructType(llt))) =
+                                        (this.comp_val, comp_val, v.data_type.llvm_type(ctx))
+                                    {
+                                        let v0 = llt.get_undef();
+                                        let v1 =
+                                            ctx.builder.build_insert_value(v0, vv, 0, "").unwrap();
+                                        let v2 =
+                                            ctx.builder.build_insert_value(v1, *f, 1, "").unwrap();
+                                        v.comp_val = Some(v2.as_basic_value_enum());
                                     }
-                                    MethodType::Static => Err(err),
-                                    MethodType::Getter => {
-                                        val.comp_val = val.addr(ctx).map(From::from);
-                                        val.data_type = Type::Reference(Box::new(val.data_type.clone()));
-                                        mark_use(&val, cfg::Location::current(ctx).unwrap(), ctx, vloc);
-                                        ops::call(Value::new(*comp_val, Some(iv.clone()), Type::Function(ret.clone(), args.clone())), iloc, None, vec![(val.clone(), vloc)], ctx)
-                                    }
+                                    v.name = name;
+                                    Ok(v)
                                 }
-                            } else {Err(err)}
-                        } else {Err(err)}
+                                MethodType::Static => Err(err),
+                                MethodType::Getter => {
+                                    val.comp_val = val.addr(ctx).map(From::from);
+                                    val.data_type =
+                                        Type::Reference(Box::new(val.data_type.clone()));
+                                    mark_use(&val, cfg::Location::current(ctx).unwrap(), ctx, vloc);
+                                    ops::call(
+                                        Value::new(
+                                            *comp_val,
+                                            Some(iv.clone()),
+                                            Type::Function(ret.clone(), args.clone()),
+                                        ),
+                                        iloc,
+                                        None,
+                                        vec![(val.clone(), vloc)],
+                                        ctx,
+                                    )
+                                }
+                            }
+                        } else {
+                            Err(err)
+                        }
+                    } else {
+                        Err(err)
                     }
-                _ => Err(err)
+                }
+            }
+            _ => Err(err),
+        },
+        Type::Mut(b) => {
+            if let Type::Nominal(n) = *b {
+                if id == "__base" {
+                    val.data_type = Type::Reference(Box::new(Type::Mut(Box::new(
+                        ctx.nominals.borrow()[&n].0.clone(),
+                    ))));
+                    Ok(val)
+                } else {
+                    let noms = ctx.nominals.borrow();
+                    let v = noms[&n].2.get(id).ok_or(err.clone())?;
+                    if let Value {
+                        data_type: Type::Reference(r),
+                        inter_val: Some(iv @ InterData::Function(FnData { mt, .. })),
+                        comp_val,
+                        ..
+                    } = v
+                    {
+                        if let Type::Function(ret, args) = r.as_ref() {
+                            match mt {
+                                MethodType::Normal => {
+                                    mark_use(&val, cfg::Location::current(ctx).unwrap(), ctx, vloc);
+                                    let name = val.name.clone();
+                                    let this = impl_convert(
+                                        vloc,
+                                        (val, None),
+                                        (args[0].0.clone(), Some(iloc)),
+                                        ctx,
+                                    )?;
+                                    let bm = Type::BoundMethod(ret.clone(), args.clone());
+                                    let mut v = Value::metaval(iv.clone(), bm);
+                                    if let (Some(vv), Some(f), Some(StructType(llt))) =
+                                        (this.comp_val, comp_val, v.data_type.llvm_type(ctx))
+                                    {
+                                        let v0 = llt.get_undef();
+                                        let v1 =
+                                            ctx.builder.build_insert_value(v0, vv, 0, "").unwrap();
+                                        let v2 =
+                                            ctx.builder.build_insert_value(v1, *f, 1, "").unwrap();
+                                        v.comp_val = Some(v2.as_basic_value_enum());
+                                    }
+                                    v.name = name;
+                                    Ok(v)
+                                }
+                                MethodType::Static => Err(err),
+                                MethodType::Getter => {
+                                    val.comp_val = val.addr(ctx).map(From::from);
+                                    val.data_type =
+                                        Type::Reference(Box::new(val.data_type.clone()));
+                                    mark_move(
+                                        &val,
+                                        cfg::Location::current(ctx).unwrap(),
+                                        ctx,
+                                        vloc,
+                                    );
+                                    ops::call(
+                                        Value::new(
+                                            *comp_val,
+                                            Some(iv.clone()),
+                                            Type::Function(ret.clone(), args.clone()),
+                                        ),
+                                        iloc,
+                                        None,
+                                        vec![(val.clone(), vloc)],
+                                        ctx,
+                                    )
+                                }
+                            }
+                        } else {
+                            Err(err)
+                        }
+                    } else {
+                        Err(err)
+                    }
+                }
+            } else {
+                Err(err)
             }
         }
-        Type::Mut(b) => if let Type::Nominal(n) = *b {
-            if id == "__base" {
-                val.data_type = Type::Reference(Box::new(Type::Mut(Box::new(ctx.nominals.borrow()[&n].0.clone()))));
-                Ok(val)
-            }
-            else {
-                let noms = ctx.nominals.borrow();
-                let v = noms[&n].2.get(id).ok_or(err.clone())?;
-                if let Value {data_type: Type::Reference(r), inter_val: Some(iv @ InterData::Function(FnData {mt, ..})), comp_val, ..} = v {
-                    if let Type::Function(ret, args) = r.as_ref() {
-                        match mt {
-                            MethodType::Normal => {
-                                mark_use(&val, cfg::Location::current(ctx).unwrap(), ctx, vloc);
-                                let name = val.name.clone();
-                                let this = impl_convert(vloc, (val, None), (args[0].0.clone(), Some(iloc)), ctx)?;
-                                let bm = Type::BoundMethod(ret.clone(), args.clone());
-                                let mut v = Value::metaval(iv.clone(), bm);
-                                if let (Some(vv), Some(f), Some(StructType(llt))) = (this.comp_val, comp_val, v.data_type.llvm_type(ctx)) {
-                                    let v0 = llt.get_undef();
-                                    let v1 = ctx.builder.build_insert_value(v0, vv, 0, "").unwrap();
-                                    let v2 = ctx.builder.build_insert_value(v1, *f, 1, "").unwrap();
-                                    v.comp_val = Some(v2.as_basic_value_enum());
-                                }
-                                v.name = name;
-                                Ok(v)
-                            }
-                            MethodType::Static => Err(err),
-                            MethodType::Getter => {
-                                val.comp_val = val.addr(ctx).map(From::from);
-                                val.data_type = Type::Reference(Box::new(val.data_type.clone()));
-                                mark_move(&val, cfg::Location::current(ctx).unwrap(), ctx, vloc);
-                                ops::call(Value::new(*comp_val, Some(iv.clone()), Type::Function(ret.clone(), args.clone())), iloc, None, vec![(val.clone(), vloc)], ctx)
-                            }
-                        }
-                    } else {Err(err)}
-                } else {Err(err)}
-            }
-        } else {Err(err)}
-        Type::Nominal(n) =>
+        Type::Nominal(n) => {
             if id == "__base" {
                 val.data_type = ctx.nominals.borrow()[&n].0.clone();
                 Ok(val)
-            }
-            else {
+            } else {
                 let noms = ctx.nominals.borrow();
                 let v = noms[&n].2.get(id).ok_or(err.clone())?;
-                if let Value {data_type: Type::Reference(r), inter_val: Some(iv @ InterData::Function(FnData {mt, ..})), comp_val, ..} = v {
+                if let Value {
+                    data_type: Type::Reference(r),
+                    inter_val: Some(iv @ InterData::Function(FnData { mt, .. })),
+                    comp_val,
+                    ..
+                } = v
+                {
                     if let Type::Function(ret, args) = r.as_ref() {
                         match mt {
                             MethodType::Normal => {
                                 mark_use(&val, cfg::Location::current(ctx).unwrap(), ctx, vloc);
                                 let name = val.name.clone();
-                                let this = impl_convert(vloc, (val, None), (args[0].0.clone(), Some(iloc)), ctx)?;
+                                let this = impl_convert(
+                                    vloc,
+                                    (val, None),
+                                    (args[0].0.clone(), Some(iloc)),
+                                    ctx,
+                                )?;
                                 let bm = Type::BoundMethod(ret.clone(), args.clone());
                                 let mut v = Value::metaval(iv.clone(), bm);
-                                if let (Some(vv), Some(f), Some(StructType(llt))) = (this.comp_val, comp_val, v.data_type.llvm_type(ctx)) {
+                                if let (Some(vv), Some(f), Some(StructType(llt))) =
+                                    (this.comp_val, comp_val, v.data_type.llvm_type(ctx))
+                                {
                                     let v0 = llt.get_undef();
                                     let v1 = ctx.builder.build_insert_value(v0, vv, 0, "").unwrap();
                                     let v2 = ctx.builder.build_insert_value(v1, *f, 1, "").unwrap();
@@ -2510,16 +4808,34 @@ pub fn attr<'ctx>((mut val, vloc): (Value<'ctx>, SourceSpan), (id, iloc): (&str,
                                 val.comp_val = val.addr(ctx).map(From::from);
                                 val.data_type = Type::Reference(Box::new(val.data_type.clone()));
                                 mark_move(&val, cfg::Location::current(ctx).unwrap(), ctx, vloc);
-                                ops::call(Value::new(*comp_val, Some(iv.clone()), Type::Function(ret.clone(), args.clone())), iloc, None, vec![(val.clone(), vloc)], ctx)
+                                ops::call(
+                                    Value::new(
+                                        *comp_val,
+                                        Some(iv.clone()),
+                                        Type::Function(ret.clone(), args.clone()),
+                                    ),
+                                    iloc,
+                                    None,
+                                    vec![(val.clone(), vloc)],
+                                    ctx,
+                                )
                             }
                         }
-                    } else {Err(err)}
-                } else {Err(err)}
+                    } else {
+                        Err(err)
+                    }
+                } else {
+                    Err(err)
+                }
             }
-        _ => Err(err)
+        }
+        _ => Err(err),
     }
 }
-fn prep_asm<'ctx>(mut arg: Value<'ctx>, ctx: &CompCtx<'ctx>) -> Option<(BasicMetadataTypeEnum<'ctx>, BasicMetadataValueEnum<'ctx>)> {
+fn prep_asm<'ctx>(
+    mut arg: Value<'ctx>,
+    ctx: &CompCtx<'ctx>,
+) -> Option<(BasicMetadataTypeEnum<'ctx>, BasicMetadataValueEnum<'ctx>)> {
     let i64_ty = ctx.context.i64_type();
     let i32_ty = ctx.context.i32_type();
     let i16_ty = ctx.context.i16_type();
@@ -2529,7 +4845,11 @@ fn prep_asm<'ctx>(mut arg: Value<'ctx>, ctx: &CompCtx<'ctx>) -> Option<(BasicMet
             arg.data_type = *b;
             if !matches!(arg.data_type, Type::Mut(_)) {
                 if let Some(PointerValue(val)) = arg.value(ctx) {
-                    arg.comp_val = Some(ctx.builder.build_load(arg.data_type.llvm_type(ctx).unwrap(), val, ""));
+                    arg.comp_val = Some(ctx.builder.build_load(
+                        arg.data_type.llvm_type(ctx).unwrap(),
+                        val,
+                        "",
+                    ));
                 }
             }
             prep_asm(arg, ctx)
@@ -2537,175 +4857,363 @@ fn prep_asm<'ctx>(mut arg: Value<'ctx>, ctx: &CompCtx<'ctx>) -> Option<(BasicMet
         Type::Mut(b) => {
             arg.data_type = *b;
             if let Some(PointerValue(val)) = arg.value(ctx) {
-                arg.comp_val = Some(ctx.builder.build_load(arg.data_type.llvm_type(ctx).unwrap(), val, ""));
+                arg.comp_val = Some(ctx.builder.build_load(
+                    arg.data_type.llvm_type(ctx).unwrap(),
+                    val,
+                    "",
+                ));
             }
             prep_asm(arg, ctx)
         }
         Type::IntLiteral => Some((i64_ty.into(), arg.value(ctx)?.into())),
         Type::Int(64, _) => Some((i64_ty.into(), arg.value(ctx)?.into())),
-        Type::Int(33..=63, true) => Some((i64_ty.into(), ctx.builder.build_int_z_extend(arg.value(ctx)?.into_int_value(), i64_ty, "").into())),
-        Type::Int(33..=63, false) => Some((i64_ty.into(), ctx.builder.build_int_s_extend(arg.value(ctx)?.into_int_value(), i64_ty, "").into())),
+        Type::Int(33..=63, true) => Some((
+            i64_ty.into(),
+            ctx.builder
+                .build_int_z_extend(arg.value(ctx)?.into_int_value(), i64_ty, "")
+                .into(),
+        )),
+        Type::Int(33..=63, false) => Some((
+            i64_ty.into(),
+            ctx.builder
+                .build_int_s_extend(arg.value(ctx)?.into_int_value(), i64_ty, "")
+                .into(),
+        )),
         Type::Int(32, _) => Some((i32_ty.into(), arg.value(ctx)?.into())),
-        Type::Int(17..=31, true) => Some((i32_ty.into(), ctx.builder.build_int_z_extend(arg.value(ctx)?.into_int_value(), i32_ty, "").into())),
-        Type::Int(17..=31, false) => Some((i32_ty.into(), ctx.builder.build_int_s_extend(arg.value(ctx)?.into_int_value(), i32_ty, "").into())),
+        Type::Int(17..=31, true) => Some((
+            i32_ty.into(),
+            ctx.builder
+                .build_int_z_extend(arg.value(ctx)?.into_int_value(), i32_ty, "")
+                .into(),
+        )),
+        Type::Int(17..=31, false) => Some((
+            i32_ty.into(),
+            ctx.builder
+                .build_int_s_extend(arg.value(ctx)?.into_int_value(), i32_ty, "")
+                .into(),
+        )),
         Type::Int(16, _) => Some((i64_ty.into(), arg.value(ctx)?.into())),
-        Type::Int(9..=15, true) => Some((i16_ty.into(), ctx.builder.build_int_z_extend(arg.value(ctx)?.into_int_value(), i16_ty, "").into())),
-        Type::Int(9..=15, false) => Some((i16_ty.into(), ctx.builder.build_int_s_extend(arg.value(ctx)?.into_int_value(), i16_ty, "").into())),
+        Type::Int(9..=15, true) => Some((
+            i16_ty.into(),
+            ctx.builder
+                .build_int_z_extend(arg.value(ctx)?.into_int_value(), i16_ty, "")
+                .into(),
+        )),
+        Type::Int(9..=15, false) => Some((
+            i16_ty.into(),
+            ctx.builder
+                .build_int_s_extend(arg.value(ctx)?.into_int_value(), i16_ty, "")
+                .into(),
+        )),
         Type::Int(8, _) => Some((i64_ty.into(), arg.value(ctx)?.into())),
-        Type::Int(1..=7, true) => Some((i8_ty.into(), ctx.builder.build_int_z_extend(arg.value(ctx)?.into_int_value(), i8_ty, "").into())),
-        Type::Int(1..=7, false) => Some((i8_ty.into(), ctx.builder.build_int_s_extend(arg.value(ctx)?.into_int_value(), i8_ty, "").into())),
-        t @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128 | Type::Pointer(..)) => Some((t.llvm_type(ctx).unwrap().into(), arg.comp_val.or_else(|| arg.inter_val.and_then(|x| t.into_compiled(&x, ctx)))?.into())),
-        _ => None
+        Type::Int(1..=7, true) => Some((
+            i8_ty.into(),
+            ctx.builder
+                .build_int_z_extend(arg.value(ctx)?.into_int_value(), i8_ty, "")
+                .into(),
+        )),
+        Type::Int(1..=7, false) => Some((
+            i8_ty.into(),
+            ctx.builder
+                .build_int_s_extend(arg.value(ctx)?.into_int_value(), i8_ty, "")
+                .into(),
+        )),
+        t
+        @ (Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128 | Type::Pointer(..)) => {
+            Some((
+                t.llvm_type(ctx).unwrap().into(),
+                arg.comp_val
+                    .or_else(|| arg.inter_val.and_then(|x| t.into_compiled(&x, ctx)))?
+                    .into(),
+            ))
+        }
+        _ => None,
     }
 }
-pub fn call<'ctx>(mut target: Value<'ctx>, loc: SourceSpan, cparen: Option<SourceSpan>, mut args: Vec<(Value<'ctx>, SourceSpan)>, ctx: &CompCtx<'ctx>) -> Result<Value<'ctx>, CobaltError> {
+pub fn call<'ctx>(
+    mut target: Value<'ctx>,
+    loc: SourceSpan,
+    cparen: Option<SourceSpan>,
+    mut args: Vec<(Value<'ctx>, SourceSpan)>,
+    ctx: &CompCtx<'ctx>,
+) -> Result<Value<'ctx>, CobaltError> {
     match target.data_type {
         Type::Error => Ok(Value::error()),
-        Type::Reference(b) => {
-            match *b {
-                Type::Mut(b) => match *b {
-                    Type::Tuple(v) => {
-                        let err = CobaltError::CannotCallWithArgs {
-                            val: format!("&({})", v.iter().map(Type::to_string).collect::<Vec<_>>().join(", ")),
-                            loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
-                            args: args.iter().map(|(v, _)| v.data_type.to_string()).collect(),
-                            aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
-                            nargs: vec![]
-                        };
-                        match args.as_slice() {
-                            [(Value {data_type: Type::IntLiteral | Type::Int(..), inter_val, ..}, aloc)] => {
-                                if let Some(InterData::Int(idx)) = inter_val {
-                                    let idx = *idx as usize;
-                                    if let Some(t) = v.get(idx) {
-                                        Ok(Value::new(
-                                            target.comp_val.and_then(|llv| ctx.builder.build_struct_gep(types::tuple_type(&v, ctx)?, llv.into_pointer_value(), idx as u32, "").ok().map(From::from)),
-                                            if let Some(InterData::Array(v)) = target.inter_val {v.get(idx).cloned()} else {None},
-                                            Type::Reference(Box::new(Type::Mut(Box::new(t.clone()))))
-                                        ))
-                                    }
-                                    else {Err(CobaltError::TupleIdxOutOfBounds {
-                                        idx, len: v.len(),
-                                        tloc: loc, iloc: *aloc
-                                    })}
-                                }
-                                else {Err(CobaltError::NotCompileTime {loc: *aloc})}
-                            },
-                            _ => Err(err)
-                        }
-                    }
-                    b => {
-                        if !ctx.is_const.get() {
-                            if let Some(PointerValue(v)) = target.comp_val {
-                                target.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
-                            }
-                        }
-                        target.data_type = b;
-                        call(target, loc, cparen, args, ctx)
-                    }
-                }
+        Type::Reference(b) => match *b {
+            Type::Mut(b) => match *b {
                 Type::Tuple(v) => {
                     let err = CobaltError::CannotCallWithArgs {
-                        val: format!("&({})", v.iter().map(Type::to_string).collect::<Vec<_>>().join(", ")),
+                        val: format!(
+                            "&({})",
+                            v.iter().map(Type::to_string).collect::<Vec<_>>().join(", ")
+                        ),
                         loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
                         args: args.iter().map(|(v, _)| v.data_type.to_string()).collect(),
                         aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
-                        nargs: vec![]
+                        nargs: vec![],
                     };
                     match args.as_slice() {
-                        [(Value {data_type: Type::IntLiteral | Type::Int(..), inter_val, ..}, aloc)] => {
+                        [(
+                            Value {
+                                data_type: Type::IntLiteral | Type::Int(..),
+                                inter_val,
+                                ..
+                            },
+                            aloc,
+                        )] => {
                             if let Some(InterData::Int(idx)) = inter_val {
                                 let idx = *idx as usize;
                                 if let Some(t) = v.get(idx) {
                                     Ok(Value::new(
-                                        target.comp_val.and_then(|llv| ctx.builder.build_struct_gep(types::tuple_type(&v, ctx)?, llv.into_pointer_value(), idx as u32, "").ok().map(From::from)),
-                                        if let Some(InterData::Array(v)) = target.inter_val {v.get(idx).cloned()} else {None},
-                                        Type::Reference(Box::new(t.clone()))
+                                        target.comp_val.and_then(|llv| {
+                                            ctx.builder
+                                                .build_struct_gep(
+                                                    types::tuple_type(&v, ctx)?,
+                                                    llv.into_pointer_value(),
+                                                    idx as u32,
+                                                    "",
+                                                )
+                                                .ok()
+                                                .map(From::from)
+                                        }),
+                                        if let Some(InterData::Array(v)) = target.inter_val {
+                                            v.get(idx).cloned()
+                                        } else {
+                                            None
+                                        },
+                                        Type::Reference(Box::new(Type::Mut(Box::new(t.clone())))),
                                     ))
+                                } else {
+                                    Err(CobaltError::TupleIdxOutOfBounds {
+                                        idx,
+                                        len: v.len(),
+                                        tloc: loc,
+                                        iloc: *aloc,
+                                    })
                                 }
-                                else {Err(CobaltError::TupleIdxOutOfBounds {
-                                    idx, len: v.len(),
-                                    tloc: loc, iloc: *aloc
-                                })}
+                            } else {
+                                Err(CobaltError::NotCompileTime { loc: *aloc })
                             }
-                            else {Err(CobaltError::NotCompileTime {loc: *aloc})}
-                        },
-                        _ => Err(err)
+                        }
+                        _ => Err(err),
                     }
-                }
-                b @ Type::Function(..) => {
-                    target.data_type = b;
-                    call(target, loc, cparen, args, ctx)
                 }
                 b => {
                     if !ctx.is_const.get() {
                         if let Some(PointerValue(v)) = target.comp_val {
-                            target.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
+                            target.comp_val =
+                                Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
                         }
                     }
                     target.data_type = b;
                     call(target, loc, cparen, args, ctx)
                 }
+            },
+            Type::Tuple(v) => {
+                let err = CobaltError::CannotCallWithArgs {
+                    val: format!(
+                        "&({})",
+                        v.iter().map(Type::to_string).collect::<Vec<_>>().join(", ")
+                    ),
+                    loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
+                    args: args.iter().map(|(v, _)| v.data_type.to_string()).collect(),
+                    aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
+                    nargs: vec![],
+                };
+                match args.as_slice() {
+                    [(
+                        Value {
+                            data_type: Type::IntLiteral | Type::Int(..),
+                            inter_val,
+                            ..
+                        },
+                        aloc,
+                    )] => {
+                        if let Some(InterData::Int(idx)) = inter_val {
+                            let idx = *idx as usize;
+                            if let Some(t) = v.get(idx) {
+                                Ok(Value::new(
+                                    target.comp_val.and_then(|llv| {
+                                        ctx.builder
+                                            .build_struct_gep(
+                                                types::tuple_type(&v, ctx)?,
+                                                llv.into_pointer_value(),
+                                                idx as u32,
+                                                "",
+                                            )
+                                            .ok()
+                                            .map(From::from)
+                                    }),
+                                    if let Some(InterData::Array(v)) = target.inter_val {
+                                        v.get(idx).cloned()
+                                    } else {
+                                        None
+                                    },
+                                    Type::Reference(Box::new(t.clone())),
+                                ))
+                            } else {
+                                Err(CobaltError::TupleIdxOutOfBounds {
+                                    idx,
+                                    len: v.len(),
+                                    tloc: loc,
+                                    iloc: *aloc,
+                                })
+                            }
+                        } else {
+                            Err(CobaltError::NotCompileTime { loc: *aloc })
+                        }
+                    }
+                    _ => Err(err),
+                }
             }
-        }
+            b @ Type::Function(..) => {
+                target.data_type = b;
+                call(target, loc, cparen, args, ctx)
+            }
+            b => {
+                if !ctx.is_const.get() {
+                    if let Some(PointerValue(v)) = target.comp_val {
+                        target.comp_val =
+                            Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
+                    }
+                }
+                target.data_type = b;
+                call(target, loc, cparen, args, ctx)
+            }
+        },
         Type::Function(ret, params) => {
             let mut err = CobaltError::CannotCallWithArgs {
-                val: format!("fn ({}): {ret}", params.iter().map(|(t, _)| t.to_string()).collect::<Vec<_>>().join(", ")),
+                val: format!(
+                    "fn ({}): {ret}",
+                    params
+                        .iter()
+                        .map(|(t, _)| t.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
                 loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
                 args: args.iter().map(|(v, _)| v.data_type.to_string()).collect(),
                 aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
-                nargs: vec![]
+                nargs: vec![],
             };
-            let mut push_arg = |arg: ArgError| {if let CobaltError::CannotCallWithArgs {nargs, ..} = &mut err {nargs.push(arg)}};
+            let mut push_arg = |arg: ArgError| {
+                if let CobaltError::CannotCallWithArgs { nargs, .. } = &mut err {
+                    nargs.push(arg)
+                }
+            };
             let mut good = true;
             let p = params.len();
             let mut a = args.len();
-            let defaults = if let Some(InterData::Function(FnData {defaults, ..})) = target.inter_val {defaults} else {vec![]};
+            let defaults =
+                if let Some(InterData::Function(FnData { defaults, .. })) = target.inter_val {
+                    defaults
+                } else {
+                    vec![]
+                };
             if a > p {
-                push_arg(ArgError::WrongNumArgs {found: a, expected: p, loc: args[p].1});
+                push_arg(ArgError::WrongNumArgs {
+                    found: a,
+                    expected: p,
+                    loc: args[p].1,
+                });
                 a = p;
             }
             if a < p {
                 let d = defaults.len();
-                args.extend(&mut defaults.into_iter().enumerate().skip(p - a).map(|(n, v)| {
-                    let (pty, pc) = &params[p - d + n];
-                    (Value::new(pc.then(|| pty.into_compiled(&v, ctx)).flatten(), Some(v), pty.clone()), cparen.unwrap_or(loc))
-                }));
+                args.extend(
+                    &mut defaults.into_iter().enumerate().skip(p - a).map(|(n, v)| {
+                        let (pty, pc) = &params[p - d + n];
+                        (
+                            Value::new(
+                                pc.then(|| pty.into_compiled(&v, ctx)).flatten(),
+                                Some(v),
+                                pty.clone(),
+                            ),
+                            cparen.unwrap_or(loc),
+                        )
+                    }),
+                );
                 a = args.len();
             }
             if a < p {
-                push_arg(ArgError::WrongNumArgs {found: a, expected: p, loc: cparen.unwrap_or(loc)});
+                push_arg(ArgError::WrongNumArgs {
+                    found: a,
+                    expected: p,
+                    loc: cparen.unwrap_or(loc),
+                });
                 args.resize_with(p, || (Value::error(), cparen.unwrap_or(loc)));
             }
-            let (c, r) = args.iter().zip(params.iter()).enumerate().map(|(n, ((v, l), (t, c)))| {
-                (if let Ok(val) = impl_convert(unreachable_span(), (v.clone(), None), (t.clone(), None), ctx) {
-                    if *c && val.inter_val.is_none() {
-                        good = false;
-                        push_arg(ArgError::ArgMustBeConst {n, loc: *l})
-                    }
-                    val
-                }
-                else {
-                    good = false;
-                    push_arg(ArgError::InvalidArg {n, val: v.data_type.to_string(), ty: t.to_string(), loc: *l});
-                    Value::error()
-                }, c)
-            }).partition::<Vec<_>, _>(|(_, c)| **c);
-            if !good {return Err(err)}
-            if !c.is_empty() {return Err(CobaltError::ConstFnsArentSupported {loc})}
+            let (c, r) = args
+                .iter()
+                .zip(params.iter())
+                .enumerate()
+                .map(|(n, ((v, l), (t, c)))| {
+                    (
+                        if let Ok(val) = impl_convert(
+                            unreachable_span(),
+                            (v.clone(), None),
+                            (t.clone(), None),
+                            ctx,
+                        ) {
+                            if *c && val.inter_val.is_none() {
+                                good = false;
+                                push_arg(ArgError::ArgMustBeConst { n, loc: *l })
+                            }
+                            val
+                        } else {
+                            good = false;
+                            push_arg(ArgError::InvalidArg {
+                                n,
+                                val: v.data_type.to_string(),
+                                ty: t.to_string(),
+                                loc: *l,
+                            });
+                            Value::error()
+                        },
+                        c,
+                    )
+                })
+                .partition::<Vec<_>, _>(|(_, c)| **c);
+            if !good {
+                return Err(err);
+            }
+            if !c.is_empty() {
+                return Err(CobaltError::ConstFnsArentSupported { loc });
+            }
             good = true;
-            let val: Option<inkwell::values::PointerValue> = target.comp_val.and_then(|v| v.try_into().ok());
-            let args_v: Vec<BasicMetadataValueEnum> = r.iter().filter_map(|(Value {comp_val, ..}, _)| comp_val.map(|v| v.into()).or_else(|| {good = false; None})).collect();
-            let aty: Vec<BasicMetadataTypeEnum> = args_v.iter().map(|v| BasicValueEnum::try_from(*v).unwrap().get_type().into()).collect();
-            let fty = if ret.size(ctx) == SizeType::Static(0) {Some(ctx.context.void_type().fn_type(&aty, false))} else {ret.llvm_type(ctx).map(|t| t.fn_type(&aty, false))};
+            let val: Option<inkwell::values::PointerValue> =
+                target.comp_val.and_then(|v| v.try_into().ok());
+            let args_v: Vec<BasicMetadataValueEnum> = r
+                .iter()
+                .filter_map(|(Value { comp_val, .. }, _)| {
+                    comp_val.map(|v| v.into()).or_else(|| {
+                        good = false;
+                        None
+                    })
+                })
+                .collect();
+            let aty: Vec<BasicMetadataTypeEnum> = args_v
+                .iter()
+                .map(|v| BasicValueEnum::try_from(*v).unwrap().get_type().into())
+                .collect();
+            let fty = if ret.size(ctx) == SizeType::Static(0) {
+                Some(ctx.context.void_type().fn_type(&aty, false))
+            } else {
+                ret.llvm_type(ctx).map(|t| t.fn_type(&aty, false))
+            };
             Ok(Value::new(
                 val.and_then(|v| {
                     let call = ctx.builder.build_indirect_call(fty?, v, &args_v, "");
-                    let inst = call.try_as_basic_value().right_or_else(|v| v.as_instruction_value().unwrap());
-                    for (n, (val, loc)) in args.iter().enumerate() {mark_move(val, cfg::Location::Inst(inst, n), ctx, *loc)}
+                    let inst = call
+                        .try_as_basic_value()
+                        .right_or_else(|v| v.as_instruction_value().unwrap());
+                    for (n, (val, loc)) in args.iter().enumerate() {
+                        mark_move(val, cfg::Location::Inst(inst, n), ctx, *loc)
+                    }
                     call.try_as_basic_value().left()
                 }),
                 None,
-                *ret
+                *ret,
             ))
         }
         Type::BoundMethod(ret, params) => {
@@ -2726,68 +5234,102 @@ pub fn call<'ctx>(mut target: Value<'ctx>, loc: SourceSpan, cparen: Option<Sourc
             mark_move(&this, cfg::Location::current(ctx).unwrap(), ctx, loc);
             v
         }
-        Type::InlineAsm(r) => if let (Some(InterData::InlineAsm(c, b)), false) = (target.inter_val, ctx.is_const.get()) {
-            let mut params = Vec::with_capacity(args.len());
-            let mut comp_args = Vec::with_capacity(args.len());
-            let mut err = CobaltError::InvalidInlineAsmCall {loc, args: vec![]};
-            let mut push_arg = |arg: InvalidAsmArg| if let CobaltError::InvalidInlineAsmCall {args, ..} = &mut err {args.push(arg)};
-            let mut good = true;
-            for (arg, l) in args {
-                let n = arg.data_type.to_string();
-                if let Some((ty, val)) = prep_asm(arg, ctx) {
-                    params.push(ty);
-                    comp_args.push(val);
+        Type::InlineAsm(r) => {
+            if let (Some(InterData::InlineAsm(c, b)), false) =
+                (target.inter_val, ctx.is_const.get())
+            {
+                let mut params = Vec::with_capacity(args.len());
+                let mut comp_args = Vec::with_capacity(args.len());
+                let mut err = CobaltError::InvalidInlineAsmCall { loc, args: vec![] };
+                let mut push_arg = |arg: InvalidAsmArg| {
+                    if let CobaltError::InvalidInlineAsmCall { args, .. } = &mut err {
+                        args.push(arg)
+                    }
+                };
+                let mut good = true;
+                for (arg, l) in args {
+                    let n = arg.data_type.to_string();
+                    if let Some((ty, val)) = prep_asm(arg, ctx) {
+                        params.push(ty);
+                        comp_args.push(val);
+                    } else {
+                        good = false;
+                        push_arg(InvalidAsmArg(n, l));
+                    }
                 }
-                else {
-                    good = false;
-                    push_arg(InvalidAsmArg(n, l));
+                if !good {
+                    return Err(err);
                 }
+                if let Some(llt) = r.llvm_type(ctx) {
+                    let fty = llt.fn_type(&params, false);
+                    let asm = ctx
+                        .context
+                        .create_inline_asm(fty, b, c, true, true, None, false);
+                    let ret = ctx.builder.build_indirect_call(fty, asm, &comp_args, "");
+                    Ok(Value::new(ret.try_as_basic_value().left(), None, *r))
+                } else {
+                    let fty = ctx.context.void_type().fn_type(&params, false);
+                    let asm = ctx
+                        .context
+                        .create_inline_asm(fty, b, c, true, true, None, false);
+                    ctx.builder.build_indirect_call(fty, asm, &comp_args, "");
+                    Ok(Value::null())
+                }
+            } else {
+                Ok(Value::error())
             }
-            if !good {return Err(err)}
-            if let Some(llt) = r.llvm_type(ctx) {
-                let fty = llt.fn_type(&params, false);
-                let asm = ctx.context.create_inline_asm(fty, b, c, true, true, None, false);
-                let ret = ctx.builder.build_indirect_call(fty, asm, &comp_args, "");
-                Ok(Value::new(
-                    ret.try_as_basic_value().left(),
-                    None,
-                    *r
-                ))
-            }
-            else {
-                let fty = ctx.context.void_type().fn_type(&params, false);
-                let asm = ctx.context.create_inline_asm(fty, b, c, true, true, None, false);
-                ctx.builder.build_indirect_call(fty, asm, &comp_args, "");
-                Ok(Value::null())
-            }
-        } else {Ok(Value::error())}
+        }
         Type::Tuple(v) => {
             let err = CobaltError::CannotCallWithArgs {
-                val: format!("({})", v.iter().map(Type::to_string).collect::<Vec<_>>().join(", ")),
+                val: format!(
+                    "({})",
+                    v.iter().map(Type::to_string).collect::<Vec<_>>().join(", ")
+                ),
                 loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
                 args: args.iter().map(|(v, _)| v.data_type.to_string()).collect(),
                 aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
-                nargs: vec![]
+                nargs: vec![],
             };
             match args.as_slice() {
-                [(Value {data_type: Type::IntLiteral | Type::Int(..), inter_val, ..}, aloc)] => {
+                [(
+                    Value {
+                        data_type: Type::IntLiteral | Type::Int(..),
+                        inter_val,
+                        ..
+                    },
+                    aloc,
+                )] => {
                     if let Some(InterData::Int(idx)) = inter_val {
                         let idx = *idx as usize;
                         if let Some(t) = v.get(idx) {
                             Ok(Value::new(
-                                target.comp_val.and_then(|v| ctx.builder.build_extract_value(v.into_struct_value(), idx as u32, "")),
-                                if let Some(InterData::Array(v)) = target.inter_val {v.get(idx).cloned()} else {None},
-                                t.clone()
+                                target.comp_val.and_then(|v| {
+                                    ctx.builder.build_extract_value(
+                                        v.into_struct_value(),
+                                        idx as u32,
+                                        "",
+                                    )
+                                }),
+                                if let Some(InterData::Array(v)) = target.inter_val {
+                                    v.get(idx).cloned()
+                                } else {
+                                    None
+                                },
+                                t.clone(),
                             ))
+                        } else {
+                            Err(CobaltError::TupleIdxOutOfBounds {
+                                idx,
+                                len: v.len(),
+                                tloc: loc,
+                                iloc: *aloc,
+                            })
                         }
-                        else {Err(CobaltError::TupleIdxOutOfBounds {
-                            idx, len: v.len(),
-                            tloc: loc, iloc: *aloc
-                        })}
+                    } else {
+                        Err(CobaltError::NotCompileTime { loc: *aloc })
                     }
-                    else {Err(CobaltError::NotCompileTime {loc: *aloc})}
                 }
-                _ => Err(err)
+                _ => Err(err),
             }
         }
         Type::Intrinsic(name) => match name.as_str() {
@@ -2800,131 +5342,223 @@ pub fn call<'ctx>(mut target: Value<'ctx>, loc: SourceSpan, cparen: Option<Sourc
                         if is_str(&a0.data_type) && is_str(&a1.data_type) {
                             match (a0, a1) {
                                 (
-                                    Value {inter_val: Some(InterData::Array(c)), ..},
-                                    Value {inter_val: Some(InterData::Array(b)), ..}
+                                    Value {
+                                        inter_val: Some(InterData::Array(c)),
+                                        ..
+                                    },
+                                    Value {
+                                        inter_val: Some(InterData::Array(b)),
+                                        ..
+                                    },
                                 ) => {
                                     let mut errs = vec![];
-                                    let c = String::from_utf8(c.into_iter().map(|x| if let InterData::Int(v) = x {v as u8} else {unreachable!()}).collect::<Vec<_>>()).unwrap_or_else(|e| {
+                                    let c = String::from_utf8(
+                                        c.into_iter()
+                                            .map(|x| {
+                                                if let InterData::Int(v) = x {
+                                                    v as u8
+                                                } else {
+                                                    unreachable!()
+                                                }
+                                            })
+                                            .collect::<Vec<_>>(),
+                                    )
+                                    .unwrap_or_else(|e| {
                                         errs.push(CobaltError::NonUtf8String {
                                             pos: e.utf8_error().valid_up_to(),
-                                            loc: loc0
+                                            loc: loc0,
                                         });
                                         String::new()
                                     });
-                                    let b = String::from_utf8(b.into_iter().map(|x| if let InterData::Int(v) = x {v as u8} else {unreachable!()}).collect::<Vec<_>>()).unwrap_or_else(|e| {
+                                    let b = String::from_utf8(
+                                        b.into_iter()
+                                            .map(|x| {
+                                                if let InterData::Int(v) = x {
+                                                    v as u8
+                                                } else {
+                                                    unreachable!()
+                                                }
+                                            })
+                                            .collect::<Vec<_>>(),
+                                    )
+                                    .unwrap_or_else(|e| {
                                         errs.push(CobaltError::NonUtf8String {
                                             pos: e.utf8_error().valid_up_to(),
-                                            loc: loc1
+                                            loc: loc1,
                                         });
                                         String::new()
                                     });
                                     if !errs.is_empty() {
                                         return Err(CobaltError::InvalidIntrinsicCall {
                                             name: "asm",
-                                            loc, errs
+                                            loc,
+                                            errs,
                                         });
                                     }
-                                    Ok(Value::metaval(InterData::InlineAsm(c, b), Type::InlineAsm(Box::new(Type::Null))))
-                                },
+                                    Ok(Value::metaval(
+                                        InterData::InlineAsm(c, b),
+                                        Type::InlineAsm(Box::new(Type::Null)),
+                                    ))
+                                }
                                 (a0, a1) => Err(CobaltError::InvalidInlineAsm2 {
-                                    loc1: loc0, type1: a0.data_type.to_string(), const1: a0.inter_val.is_some(),
-                                    loc2: loc1, type2: a1.data_type.to_string(), const2: a1.inter_val.is_some()
-                                })
+                                    loc1: loc0,
+                                    type1: a0.data_type.to_string(),
+                                    const1: a0.inter_val.is_some(),
+                                    loc2: loc1,
+                                    type2: a1.data_type.to_string(),
+                                    const2: a1.inter_val.is_some(),
+                                }),
                             }
-                        }
-                        else {
+                        } else {
                             Err(CobaltError::InvalidInlineAsm2 {
-                                loc1: loc0, type1: a0.data_type.to_string(), const1: a0.inter_val.is_some(),
-                                loc2: loc1, type2: a1.data_type.to_string(), const2: a1.inter_val.is_some()
+                                loc1: loc0,
+                                type1: a0.data_type.to_string(),
+                                const1: a0.inter_val.is_some(),
+                                loc2: loc1,
+                                type2: a1.data_type.to_string(),
+                                const2: a1.inter_val.is_some(),
                             })
                         }
-                    },
+                    }
                     3 => {
                         let (a0, loc0) = args.pop_front().unwrap();
                         let (a1, loc1) = args.pop_front().unwrap();
                         let (a2, loc2) = args.pop_front().unwrap();
-                        if let Value {data_type: Type::TypeData, inter_val: Some(InterData::Type(r)), ..} = a0 {
+                        if let Value {
+                            data_type: Type::TypeData,
+                            inter_val: Some(InterData::Type(r)),
+                            ..
+                        } = a0
+                        {
                             if is_str(&a1.data_type) && is_str(&a2.data_type) {
                                 match (a1, a2) {
                                     (
-                                        Value {inter_val: Some(InterData::Array(c)), ..},
-                                        Value {inter_val: Some(InterData::Array(b)), ..}
+                                        Value {
+                                            inter_val: Some(InterData::Array(c)),
+                                            ..
+                                        },
+                                        Value {
+                                            inter_val: Some(InterData::Array(b)),
+                                            ..
+                                        },
                                     ) => {
                                         let mut errs = vec![];
-                                        let c = String::from_utf8(c.into_iter().map(|x| if let InterData::Int(v) = x {v as u8} else {unreachable!()}).collect::<Vec<_>>()).unwrap_or_else(|e| {
+                                        let c = String::from_utf8(
+                                            c.into_iter()
+                                                .map(|x| {
+                                                    if let InterData::Int(v) = x {
+                                                        v as u8
+                                                    } else {
+                                                        unreachable!()
+                                                    }
+                                                })
+                                                .collect::<Vec<_>>(),
+                                        )
+                                        .unwrap_or_else(|e| {
                                             errs.push(CobaltError::NonUtf8String {
                                                 pos: e.utf8_error().valid_up_to(),
-                                                loc: loc1
+                                                loc: loc1,
                                             });
                                             String::new()
                                         });
-                                        let b = String::from_utf8(b.into_iter().map(|x| if let InterData::Int(v) = x {v as u8} else {unreachable!()}).collect::<Vec<_>>()).unwrap_or_else(|e| {
+                                        let b = String::from_utf8(
+                                            b.into_iter()
+                                                .map(|x| {
+                                                    if let InterData::Int(v) = x {
+                                                        v as u8
+                                                    } else {
+                                                        unreachable!()
+                                                    }
+                                                })
+                                                .collect::<Vec<_>>(),
+                                        )
+                                        .unwrap_or_else(|e| {
                                             errs.push(CobaltError::NonUtf8String {
                                                 pos: e.utf8_error().valid_up_to(),
-                                                loc: loc2
+                                                loc: loc2,
                                             });
                                             String::new()
                                         });
                                         if !errs.is_empty() {
                                             return Err(CobaltError::InvalidIntrinsicCall {
                                                 name: "asm",
-                                                loc, errs
+                                                loc,
+                                                errs,
                                             });
                                         }
-                                        Ok(Value::metaval(InterData::InlineAsm(c, b), Type::InlineAsm(r)))
-                                    },
+                                        Ok(Value::metaval(
+                                            InterData::InlineAsm(c, b),
+                                            Type::InlineAsm(r),
+                                        ))
+                                    }
                                     (a1, a2) => Err(CobaltError::InvalidInlineAsm3 {
-                                        loc1: loc0, type1: "type".to_string(), const1: true,
-                                        loc2: loc1, type2: a1.data_type.to_string(), const2: a1.inter_val.is_some(),
-                                        loc3: loc2, type3: a2.data_type.to_string(), const3: a2.inter_val.is_some()
-                                    })
+                                        loc1: loc0,
+                                        type1: "type".to_string(),
+                                        const1: true,
+                                        loc2: loc1,
+                                        type2: a1.data_type.to_string(),
+                                        const2: a1.inter_val.is_some(),
+                                        loc3: loc2,
+                                        type3: a2.data_type.to_string(),
+                                        const3: a2.inter_val.is_some(),
+                                    }),
                                 }
-                            }
-                            else {
+                            } else {
                                 Err(CobaltError::InvalidInlineAsm3 {
-                                    loc1: loc0, type1: "type".to_string(), const1: true,
-                                    loc2: loc1, type2: a1.data_type.to_string(), const2: a1.inter_val.is_some(),
-                                    loc3: loc2, type3: a2.data_type.to_string(), const3: a2.inter_val.is_some()
+                                    loc1: loc0,
+                                    type1: "type".to_string(),
+                                    const1: true,
+                                    loc2: loc1,
+                                    type2: a1.data_type.to_string(),
+                                    const2: a1.inter_val.is_some(),
+                                    loc3: loc2,
+                                    type3: a2.data_type.to_string(),
+                                    const3: a2.inter_val.is_some(),
                                 })
                             }
-                        }
-                        else {
+                        } else {
                             Err(CobaltError::InvalidInlineAsm3 {
-                                loc1: loc0, type1: a0.data_type.to_string(), const1: a0.inter_val.is_some(),
-                                loc2: loc1, type2: a1.data_type.to_string(), const2: a1.inter_val.is_some(),
-                                loc3: loc2, type3: a2.data_type.to_string(), const3: a2.inter_val.is_some()
+                                loc1: loc0,
+                                type1: a0.data_type.to_string(),
+                                const1: a0.inter_val.is_some(),
+                                loc2: loc1,
+                                type2: a1.data_type.to_string(),
+                                const2: a1.inter_val.is_some(),
+                                loc3: loc2,
+                                type3: a2.data_type.to_string(),
+                                const3: a2.inter_val.is_some(),
                             })
                         }
-                    },
-                    x => {
-                        Err(CobaltError::InvalidInlineAsm {
-                            nargs: x,
-                            loc
-                        })
                     }
+                    x => Err(CobaltError::InvalidInlineAsm { nargs: x, loc }),
                 }
             }
             "alloca" => {
                 let mut args = args.into_iter().collect::<VecDeque<_>>();
                 if args.is_empty() {
-                    return Err(CobaltError::AllocaNeedsArgs {loc})
+                    return Err(CobaltError::AllocaNeedsArgs { loc });
                 }
                 let loc0 = args.front().unwrap().1;
-                let ty = (args.front().unwrap().0.data_type == Type::TypeData).then(|| args.pop_front().unwrap().0.into_type()).flatten();
+                let ty = (args.front().unwrap().0.data_type == Type::TypeData)
+                    .then(|| args.pop_front().unwrap().0.into_type())
+                    .flatten();
                 if args.is_empty() {
                     if let Some(ty) = ty {
                         if let Some(llt) = ty.llvm_type(ctx) {
-                            Ok(Value::compiled(ctx.builder.build_alloca(llt, "").into(), Type::Pointer(Box::new(Type::Mut(Box::new(ty))))))
+                            Ok(Value::compiled(
+                                ctx.builder.build_alloca(llt, "").into(),
+                                Type::Pointer(Box::new(Type::Mut(Box::new(ty)))),
+                            ))
+                        } else {
+                            Err(CobaltError::NonRuntimeAllocaType {
+                                ty: ty.to_string(),
+                                loc: loc0,
+                            })
                         }
-                        else {
-                            Err(CobaltError::NonRuntimeAllocaType {ty: ty.to_string(), loc: loc0})
-                        }
-                    }
-                    else {
+                    } else {
                         unreachable!()
                     }
-                }
-                else {
+                } else {
                     let mut val = None;
                     let mut errs = vec![];
                     for (mut arg, loc) in args {
@@ -2933,27 +5567,33 @@ pub fn call<'ctx>(mut target: Value<'ctx>, loc: SourceSpan, cparen: Option<Sourc
                                 Type::Reference(b) | Type::Mut(b) => {
                                     if !(ctx.is_const.get() || matches!(*b, Type::Mut(_))) {
                                         if let Some(PointerValue(v)) = arg.comp_val {
-                                            arg.comp_val = Some(ctx.builder.build_load(b.llvm_type(ctx).unwrap(), v, ""));
+                                            arg.comp_val = Some(ctx.builder.build_load(
+                                                b.llvm_type(ctx).unwrap(),
+                                                v,
+                                                "",
+                                            ));
                                         }
                                     }
                                     arg.data_type = *b;
-                                },
+                                }
                                 x @ (Type::Int(..) | Type::IntLiteral) => {
                                     arg.data_type = x;
                                     if !ctx.is_const.get() {
                                         if let Some(IntValue(v)) = arg.value(ctx) {
                                             if let Some(v2) = val {
                                                 val = Some(ctx.builder.build_int_mul(v, v2, ""));
-                                            }
-                                            else {
+                                            } else {
                                                 val = Some(v);
                                             }
                                         }
                                     }
                                     break;
-                                },
+                                }
                                 x => {
-                                    errs.push(CobaltError::NonIntegralAllocaArg {ty: x.to_string(), loc});
+                                    errs.push(CobaltError::NonIntegralAllocaArg {
+                                        ty: x.to_string(),
+                                        loc,
+                                    });
                                     break;
                                 }
                             }
@@ -2964,75 +5604,159 @@ pub fn call<'ctx>(mut target: Value<'ctx>, loc: SourceSpan, cparen: Option<Sourc
                             if !errs.is_empty() {
                                 return Err(CobaltError::InvalidIntrinsicCall {
                                     name: "alloca",
-                                    loc, errs
-                                })
+                                    loc,
+                                    errs,
+                                });
                             }
-                            Ok(Value::compiled(ctx.builder.build_array_alloca(llt, val.unwrap(), "").into(), Type::Pointer(Box::new(Type::Mut(Box::new(ty))))))
-                        }
-                        else {
-                            errs.push(CobaltError::NonRuntimeAllocaType {ty: ty.to_string(), loc: loc0});
+                            Ok(Value::compiled(
+                                ctx.builder.build_array_alloca(llt, val.unwrap(), "").into(),
+                                Type::Pointer(Box::new(Type::Mut(Box::new(ty)))),
+                            ))
+                        } else {
+                            errs.push(CobaltError::NonRuntimeAllocaType {
+                                ty: ty.to_string(),
+                                loc: loc0,
+                            });
                             Err(CobaltError::InvalidIntrinsicCall {
                                 name: "alloca",
-                                loc, errs
+                                loc,
+                                errs,
                             })
                         }
-                    }
-                    else {
+                    } else {
                         if !errs.is_empty() {
                             return Err(CobaltError::InvalidIntrinsicCall {
                                 name: "alloca",
-                                loc, errs
-                            })
+                                loc,
+                                errs,
+                            });
                         }
-                        Ok(Value::compiled(ctx.builder.build_array_alloca(ctx.context.i8_type(), val.unwrap(), "").into(), Type::Pointer(Box::new(Type::Mut(Box::new(Type::Null))))))
+                        Ok(Value::compiled(
+                            ctx.builder
+                                .build_array_alloca(ctx.context.i8_type(), val.unwrap(), "")
+                                .into(),
+                            Type::Pointer(Box::new(Type::Mut(Box::new(Type::Null)))),
+                        ))
                     }
                 }
             }
-            "sizeof" => Ok(Value::metaval(InterData::Int(Type::Tuple(args.into_iter().map(|(v, aloc)| v.clone().into_type().ok_or_else(|| CobaltError::ExpectedType {loc, aloc, ty: v.data_type.to_string()})).collect::<Result<_, _>>()?).size(ctx).as_static().unwrap_or(0) as _), Type::IntLiteral)),
+            "sizeof" => Ok(Value::metaval(
+                InterData::Int(
+                    Type::Tuple(
+                        args.into_iter()
+                            .map(|(v, aloc)| {
+                                v.clone()
+                                    .into_type()
+                                    .ok_or_else(|| CobaltError::ExpectedType {
+                                        loc,
+                                        aloc,
+                                        ty: v.data_type.to_string(),
+                                    })
+                            })
+                            .collect::<Result<_, _>>()?,
+                    )
+                    .size(ctx)
+                    .as_static()
+                    .unwrap_or(0) as _,
+                ),
+                Type::IntLiteral,
+            )),
             "typename" => {
                 let name = match args.len() {
                     0 => "null".into(),
-                    1 => args[0].0.clone().into_type().ok_or_else(|| CobaltError::ExpectedType {loc, aloc: args[0].1, ty: args[0].0.data_type.to_string()})?.to_string(),
-                    _ => Type::Tuple(args.into_iter().map(|(v, aloc)| v.clone().into_type().ok_or_else(|| CobaltError::ExpectedType {loc, aloc, ty: v.data_type.to_string()})).collect::<Result<_, _>>()?).to_string(),
+                    1 => args[0]
+                        .0
+                        .clone()
+                        .into_type()
+                        .ok_or_else(|| CobaltError::ExpectedType {
+                            loc,
+                            aloc: args[0].1,
+                            ty: args[0].0.data_type.to_string(),
+                        })?
+                        .to_string(),
+                    _ => Type::Tuple(
+                        args.into_iter()
+                            .map(|(v, aloc)| {
+                                v.clone()
+                                    .into_type()
+                                    .ok_or_else(|| CobaltError::ExpectedType {
+                                        loc,
+                                        aloc,
+                                        ty: v.data_type.to_string(),
+                                    })
+                            })
+                            .collect::<Result<_, _>>()?,
+                    )
+                    .to_string(),
                 };
-                Ok(Value::interpreted(ctx.builder.build_global_string_ptr(&name, "cobalt.str").as_pointer_value().into(), InterData::Array(name.bytes().map(|v| InterData::Int(v as _)).collect()), Type::Reference(Box::new(Type::Array(Box::new(Type::Int(8, true)), Some(name.len() as _))))))
+                Ok(Value::interpreted(
+                    ctx.builder
+                        .build_global_string_ptr(&name, "cobalt.str")
+                        .as_pointer_value()
+                        .into(),
+                    InterData::Array(name.bytes().map(|v| InterData::Int(v as _)).collect()),
+                    Type::Reference(Box::new(Type::Array(
+                        Box::new(Type::Int(8, true)),
+                        Some(name.len() as _),
+                    ))),
+                ))
             }
             "typeof" => Ok(match args.len() {
                 0 => Value::null(),
                 1 => Value::make_type(args.into_iter().next().unwrap().0.data_type),
-                _ => Value::make_type(Type::Tuple(args.into_iter().map(|x| x.0.data_type).collect())),
+                _ => Value::make_type(Type::Tuple(
+                    args.into_iter().map(|x| x.0.data_type).collect(),
+                )),
             }),
-            x => Err(CobaltError::UnknownIntrinsic {loc, name: x.to_string()})
-        }
+            x => Err(CobaltError::UnknownIntrinsic {
+                loc,
+                name: x.to_string(),
+            }),
+        },
         t => Err(CobaltError::CannotCallWithArgs {
             val: t.to_string(),
             loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
             args: args.iter().map(|(v, _)| v.data_type.to_string()).collect(),
             aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
-            nargs: vec![]
-        })
+            nargs: vec![],
+        }),
     }
 }
 pub fn common(lhs: &Type, rhs: &Type, ctx: &CompCtx) -> Option<Type> {
-    if lhs == rhs {Some(lhs.clone())}
-    else if impl_convertible(lhs, rhs, ctx) {Some(rhs.clone())}
-    else if impl_convertible(rhs, lhs, ctx) {Some(lhs.clone())}
-    else {None}
+    if lhs == rhs {
+        Some(lhs.clone())
+    } else if impl_convertible(lhs, rhs, ctx) {
+        Some(rhs.clone())
+    } else if impl_convertible(rhs, lhs, ctx) {
+        Some(lhs.clone())
+    } else {
+        None
+    }
 }
 fn is_str(ty: &Type) -> bool {
     let uint8_t = Type::Int(8, true);
     match ty {
-        Type::Pointer(b) => **b == uint8_t || if let Type::Mut(b) = b.as_ref() {**b == uint8_t} else {false},
+        Type::Pointer(b) => {
+            **b == uint8_t
+                || if let Type::Mut(b) = b.as_ref() {
+                    **b == uint8_t
+                } else {
+                    false
+                }
+        }
         Type::Array(b, _) => **b == uint8_t,
         Type::Reference(b) | Type::Mut(b) => is_str(b.as_ref()),
-        _ => false
+        _ => false,
     }
 }
 /// Type::Reference unwraps, all mutable stuff is handled by Type::Mut
 /// This adds back the reference if necessary
 fn add_ref(ty: Type) -> Type {
-    if matches!(ty, Type::Mut(_)) {Type::Reference(Box::new(ty))}
-    else {ty}
+    if matches!(ty, Type::Mut(_)) {
+        Type::Reference(Box::new(ty))
+    } else {
+        ty
+    }
 }
 /// determine the "decayed" type of a variable
 /// This removes references and mutability
@@ -3041,7 +5765,7 @@ pub fn decay(mut ty: Type) -> Type {
         match ty {
             Type::Reference(b) | Type::Mut(b) => ty = decay(*b),
             Type::IntLiteral => break Type::Int(64, false),
-            t => break t
+            t => break t,
         }
     }
 }
@@ -3051,12 +5775,12 @@ pub fn decay_boxed(mut ty: Box<Type>) -> Box<Type> {
         match *ty {
             Type::Reference(b) | Type::Mut(b) => {
                 ty = decay_boxed(b);
-                continue
+                continue;
             }
             Type::IntLiteral => break Box::new(Type::Int(64, false)),
             _ => {}
         }
-        break ty
+        break ty;
     }
 }
 /// determine the "decayed" type of a variable
@@ -3066,7 +5790,7 @@ pub fn weak_decay(mut ty: Type) -> Type {
         match ty {
             Type::Reference(b) => ty = decay(*b),
             Type::IntLiteral => break Type::Int(64, false),
-            t => break t
+            t => break t,
         }
     }
 }
@@ -3076,22 +5800,31 @@ pub fn weak_decay_boxed(mut ty: Box<Type>) -> Box<Type> {
         match *ty {
             Type::Reference(b) => {
                 ty = decay_boxed(b);
-                continue
+                continue;
             }
             Type::IntLiteral => break Box::new(Type::Int(64, false)),
             _ => {}
         }
-        break ty
+        break ty;
     }
 }
 /// convenience function to maybe add a Type::Mut
 #[inline(always)]
 pub fn maybe_mut(ty: Box<Type>, is_mut: bool) -> Box<Type> {
-    if is_mut {Box::new(Type::Mut(ty))}
-    else {ty}
+    if is_mut {
+        Box::new(Type::Mut(ty))
+    } else {
+        ty
+    }
 }
 pub fn covariant(derived: &Type, base: &Type) -> bool {
-    base == derived ||
-    if let Type::Mut(d) = derived {covariant(d, base)}
-    else {matches!((base, derived), (Type::Array(_, Some(0)), Type::Array(_, Some(0))) | (_, Type::Null))}
+    base == derived
+        || if let Type::Mut(d) = derived {
+            covariant(d, base)
+        } else {
+            matches!(
+                (base, derived),
+                (Type::Array(_, Some(0)), Type::Array(_, Some(0))) | (_, Type::Null)
+            )
+        }
 }

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -1,31 +1,52 @@
 use crate::*;
 use cobalt_llvm::inkwell::values::FunctionValue;
-use inkwell::types::{BasicType, BasicTypeEnum::{self, *}, BasicMetadataTypeEnum};
+use inkwell::types::{
+    BasicMetadataTypeEnum, BasicType,
+    BasicTypeEnum::{self, *},
+};
 use inkwell::values::BasicValueEnum;
-use Type::{*, Error};
-use SizeType::*;
-use std::fmt::*;
 use std::borrow::Cow;
-use std::io::{self, Write, Read, BufRead};
+use std::fmt::*;
+use std::io::{self, BufRead, Read, Write};
+use SizeType::*;
+use Type::{Error, *};
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy)]
 pub enum SizeType {
     Static(u32),
     Dynamic,
-    Meta
+    Meta,
 }
 impl SizeType {
-    pub fn is_static(self) -> bool {matches!(self, Static(_))}
-    pub fn is_dynamic(self) -> bool {self == Dynamic}
-    pub fn is_meta(self) -> bool {self == Meta}
-    pub fn as_static(self) -> Option<u32> {if let Static(x) = self {Some(x)} else {None}}
-    pub fn map_static<F: FnOnce(u32) -> u32>(self, f: F) -> SizeType {if let Static(x) = self {Static(f(x))} else {self}}
+    pub fn is_static(self) -> bool {
+        matches!(self, Static(_))
+    }
+    pub fn is_dynamic(self) -> bool {
+        self == Dynamic
+    }
+    pub fn is_meta(self) -> bool {
+        self == Meta
+    }
+    pub fn as_static(self) -> Option<u32> {
+        if let Static(x) = self {
+            Some(x)
+        } else {
+            None
+        }
+    }
+    pub fn map_static<F: FnOnce(u32) -> u32>(self, f: F) -> SizeType {
+        if let Static(x) = self {
+            Static(f(x))
+        } else {
+            self
+        }
+    }
 }
 impl Display for SizeType {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
             SizeType::Static(size) => write!(f, "{size}"),
             SizeType::Dynamic => write!(f, "dynamic"),
-            SizeType::Meta => write!(f, "meta")
+            SizeType::Meta => write!(f, "meta"),
         }
     }
 }
@@ -35,20 +56,32 @@ impl std::ops::Add for SizeType {
         match (self, rhs) {
             (SizeType::Meta, _) | (_, SizeType::Meta) => SizeType::Meta,
             (SizeType::Dynamic, _) | (_, SizeType::Dynamic) => SizeType::Dynamic,
-            (SizeType::Static(l), SizeType::Static(r)) => SizeType::Static(l + r)
+            (SizeType::Static(l), SizeType::Static(r)) => SizeType::Static(l + r),
         }
     }
 }
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum Type {
-    IntLiteral, Intrinsic(String),
+    IntLiteral,
+    Intrinsic(String),
     Int(u16, bool),
-    Float16, Float32, Float64, Float128,
-    Pointer(Box<Type>), Reference(Box<Type>), Mut(Box<Type>),
-    Null, Module, TypeData, InlineAsm(Box<Type>), Array(Box<Type>, Option<u32>),
-    Function(Box<Type>, Vec<(Type, bool)>), BoundMethod(Box<Type>, Vec<(Type, bool)>), Nominal(String),
+    Float16,
+    Float32,
+    Float64,
+    Float128,
+    Pointer(Box<Type>),
+    Reference(Box<Type>),
+    Mut(Box<Type>),
+    Null,
+    Module,
+    TypeData,
+    InlineAsm(Box<Type>),
+    Array(Box<Type>, Option<u32>),
+    Function(Box<Type>, Vec<(Type, bool)>),
+    BoundMethod(Box<Type>, Vec<(Type, bool)>),
+    Nominal(String),
     Tuple(Vec<Type>),
-    Error
+    Error,
 }
 impl Display for Type {
     fn fmt(&self, f: &mut Formatter) -> Result {
@@ -75,24 +108,43 @@ impl Display for Type {
                 write!(f, "fn (")?;
                 let mut len = args.len();
                 for (arg, ty) in args.iter() {
-                    write!(f, "{}{}", match ty {
-                        true => "const ",
-                        false => ""
-                    }, arg)?;
-                    if len > 1 {write!(f, ", ")?}
+                    write!(
+                        f,
+                        "{}{}",
+                        match ty {
+                            true => "const ",
+                            false => "",
+                        },
+                        arg
+                    )?;
+                    if len > 1 {
+                        write!(f, ", ")?
+                    }
                     len -= 1;
                 }
                 write!(f, "): {}", *ret)
             }
             BoundMethod(ret, args) => {
-                write!(f, "{}{}.fn (", if args[0].1 {"const "} else {""}, args[0].0)?;
+                write!(
+                    f,
+                    "{}{}.fn (",
+                    if args[0].1 { "const " } else { "" },
+                    args[0].0
+                )?;
                 let mut len = args.len();
                 for (arg, ty) in args[1..].iter() {
-                    write!(f, "{}{}", match ty {
-                        true => "const ",
-                        false => ""
-                    }, arg)?;
-                    if len > 1 {write!(f, ", ")?}
+                    write!(
+                        f,
+                        "{}{}",
+                        match ty {
+                            true => "const ",
+                            false => "",
+                        },
+                        arg
+                    )?;
+                    if len > 1 {
+                        write!(f, ", ")?
+                    }
                     len -= 1;
                 }
                 write!(f, "): {}", *ret)
@@ -103,11 +155,13 @@ impl Display for Type {
                 let mut it = v.iter().peekable();
                 while let Some(v) = it.next() {
                     write!(f, "{v}")?;
-                    if it.peek().is_some() {write!(f, ", ")?;}
+                    if it.peek().is_some() {
+                        write!(f, ", ")?;
+                    }
                 }
                 write!(f, ")")
             }
-            Error => write!(f, "<error>")
+            Error => write!(f, "<error>"),
         }
     }
 }
@@ -127,18 +181,27 @@ impl Type {
             BoundMethod(..) => Static(ctx.flags.word_size as u32 * 2),
             Pointer(b) | Reference(b) => match **b {
                 Type::Array(_, None) => Static(ctx.flags.word_size as u32 * 2),
-                _ => Static(ctx.flags.word_size as u32)
-            }
+                _ => Static(ctx.flags.word_size as u32),
+            },
             Mut(b) => b.size(ctx),
-            Tuple(v) => v.iter().fold(Static(0), |v, t| if let Static(bs) = v {
-                let n = t.size(ctx);
-                if let Static(ns) = n {
-                    let a = t.align(ctx) as u32;
-                    if a == 0 || a == 1 {Static(bs + ns)}
-                    else {Static(((bs + a - 1) / a) * a + ns)}
-                } else {n}
-            } else {v}),
-            Nominal(n) => ctx.nominals.borrow()[n].0.size(ctx)
+            Tuple(v) => v.iter().fold(Static(0), |v, t| {
+                if let Static(bs) = v {
+                    let n = t.size(ctx);
+                    if let Static(ns) = n {
+                        let a = t.align(ctx) as u32;
+                        if a == 0 || a == 1 {
+                            Static(bs + ns)
+                        } else {
+                            Static(((bs + a - 1) / a) * a + ns)
+                        }
+                    } else {
+                        n
+                    }
+                } else {
+                    v
+                }
+            }),
+            Nominal(n) => ctx.nominals.borrow()[n].0.size(ctx),
         }
     }
     pub fn align(&self, ctx: &CompCtx) -> u16 {
@@ -148,7 +211,7 @@ impl Type {
                 0..=8 => 1,
                 9..=16 => 2,
                 17..=32 => 4,
-                33.. => 8
+                33.. => 8,
             },
             Float16 => 2,
             Float32 => 4,
@@ -159,7 +222,7 @@ impl Type {
             Pointer(_) | Reference(_) | BoundMethod(..) => ctx.flags.word_size,
             Mut(b) => b.align(ctx),
             Tuple(v) => v.iter().map(|x| x.align(ctx)).max().unwrap_or(1),
-            Nominal(n) => ctx.nominals.borrow()[n].0.align(ctx)
+            Nominal(n) => ctx.nominals.borrow()[n].0.align(ctx),
         }
     }
     pub fn llvm_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Option<BasicTypeEnum<'ctx>> {
@@ -171,27 +234,74 @@ impl Type {
             Float64 => Some(FloatType(ctx.context.f64_type())),
             Float128 => Some(FloatType(ctx.context.f128_type())),
             Null | Function(..) | Module | TypeData | InlineAsm(_) | Intrinsic(_) | Error => None,
-            BoundMethod(ret, params) => Some(ctx.context.struct_type(&[params[0].0.llvm_type(ctx)?, Type::Pointer(Box::new(Type::Function(ret.clone(), params.clone()))).llvm_type(ctx)?], false).into()),
+            BoundMethod(ret, params) => Some(
+                ctx.context
+                    .struct_type(
+                        &[
+                            params[0].0.llvm_type(ctx)?,
+                            Type::Pointer(Box::new(Type::Function(ret.clone(), params.clone())))
+                                .llvm_type(ctx)?,
+                        ],
+                        false,
+                    )
+                    .into(),
+            ),
             Array(b, Some(n)) => Some(b.llvm_type(ctx)?.array_type(*n).into()),
             Array(_, None) => None,
             Pointer(b) | Reference(b) => match &**b {
-                Type::Array(b, None) => Some(ctx.context.struct_type(&[b.llvm_type(ctx)?.ptr_type(Default::default()).into(), ctx.context.i64_type().into()], false).into()),
-                Type::Array(b, Some(_)) => Some(b.llvm_type(ctx)?.ptr_type(Default::default()).into()),
+                Type::Array(b, None) => Some(
+                    ctx.context
+                        .struct_type(
+                            &[
+                                b.llvm_type(ctx)?.ptr_type(Default::default()).into(),
+                                ctx.context.i64_type().into(),
+                            ],
+                            false,
+                        )
+                        .into(),
+                ),
+                Type::Array(b, Some(_)) => {
+                    Some(b.llvm_type(ctx)?.ptr_type(Default::default()).into())
+                }
                 Type::Function(r, p) => {
                     let mut args = Vec::<BasicMetadataTypeEnum>::with_capacity(p.len());
-                    for (p, c) in p {if !c {args.push(p.llvm_type(ctx)?.into());}}
-                    Some(if r.size(ctx) == Static(0) {ctx.context.void_type().fn_type(&args, false)} else {r.llvm_type(ctx)?.fn_type(&args, false)}.ptr_type(Default::default()).into())
+                    for (p, c) in p {
+                        if !c {
+                            args.push(p.llvm_type(ctx)?.into());
+                        }
+                    }
+                    Some(
+                        if r.size(ctx) == Static(0) {
+                            ctx.context.void_type().fn_type(&args, false)
+                        } else {
+                            r.llvm_type(ctx)?.fn_type(&args, false)
+                        }
+                        .ptr_type(Default::default())
+                        .into(),
+                    )
                 }
-                Type::Mut(b) => b.llvm_type(ctx).map(|t| t.ptr_type(Default::default()).into()),
-                b => if b.size(ctx) == Static(0) {Some(PointerType(ctx.null_type.ptr_type(Default::default())))} else {Some(PointerType(b.llvm_type(ctx)?.ptr_type(Default::default())))}
-            }
-            Mut(b) => b.llvm_type(ctx).map(|t| t.ptr_type(Default::default()).into()),
+                Type::Mut(b) => b
+                    .llvm_type(ctx)
+                    .map(|t| t.ptr_type(Default::default()).into()),
+                b => {
+                    if b.size(ctx) == Static(0) {
+                        Some(PointerType(ctx.null_type.ptr_type(Default::default())))
+                    } else {
+                        Some(PointerType(b.llvm_type(ctx)?.ptr_type(Default::default())))
+                    }
+                }
+            },
+            Mut(b) => b
+                .llvm_type(ctx)
+                .map(|t| t.ptr_type(Default::default()).into()),
             Tuple(v) => {
                 let mut vec = Vec::with_capacity(v.len());
-                for t in v {vec.push(t.llvm_type(ctx)?);}
+                for t in v {
+                    vec.push(t.llvm_type(ctx)?);
+                }
                 Some(ctx.context.struct_type(&vec, false).into())
             }
-            Nominal(n) => ctx.nominals.borrow()[n].0.llvm_type(ctx)
+            Nominal(n) => ctx.nominals.borrow()[n].0.llvm_type(ctx),
         }
     }
     pub fn has_dtor(&self, ctx: &CompCtx) -> bool {
@@ -204,103 +314,221 @@ impl Type {
             Type::Array(b, _) | Type::Mut(b) => b.has_dtor(ctx),
             Type::Tuple(v) => v.iter().any(|t| t.has_dtor(ctx)),
             Type::BoundMethod(_, a) => a.get(0).map_or(false, |t| t.0.has_dtor(ctx)),
-            _ => false
+            _ => false,
         }
     }
     fn can_be_compiled<'ctx>(&self, v: &InterData<'ctx>, ctx: &CompCtx<'ctx>) -> bool {
         match self {
             Type::IntLiteral | Type::Int(..) => matches!(v, InterData::Int(..)),
-            Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128 => matches!(v, InterData::Float(..)),
-            Type::Array(b, Some(n)) => if let InterData::Array(v) = v {v.len() == *n as _ && v.iter().all(|v| b.can_be_compiled(v, ctx))} else {false} 
-            Type::Tuple(vs) => if let InterData::Array(is) = v {vs.len() == is.len() && vs.iter().zip(is).all(|(t, v)| t.can_be_compiled(v, ctx))} else {false},
+            Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128 => {
+                matches!(v, InterData::Float(..))
+            }
+            Type::Array(b, Some(n)) => {
+                if let InterData::Array(v) = v {
+                    v.len() == *n as _ && v.iter().all(|v| b.can_be_compiled(v, ctx))
+                } else {
+                    false
+                }
+            }
+            Type::Tuple(vs) => {
+                if let InterData::Array(is) = v {
+                    vs.len() == is.len()
+                        && vs.iter().zip(is).all(|(t, v)| t.can_be_compiled(v, ctx))
+                } else {
+                    false
+                }
+            }
             Type::Nominal(n) => ctx.nominals.borrow()[n].0.can_be_compiled(v, ctx),
             Type::Mut(b) => b.can_be_compiled(v, ctx),
-            _ => false
+            _ => false,
         }
     }
-    pub fn into_compiled<'ctx>(&self, v: &InterData<'ctx>, ctx: &CompCtx<'ctx>) -> Option<BasicValueEnum<'ctx>> {
-        if ctx.is_const.get() {return None}
+    pub fn into_compiled<'ctx>(
+        &self,
+        v: &InterData<'ctx>,
+        ctx: &CompCtx<'ctx>,
+    ) -> Option<BasicValueEnum<'ctx>> {
+        if ctx.is_const.get() {
+            return None;
+        }
         match self {
-            Type::IntLiteral => if let InterData::Int(v) = v {Some(ctx.context.i64_type().const_int(*v as u64, true).into())} else {None},
-            Type::Int(s, u) => if let InterData::Int(v) = v {Some(ctx.context.custom_width_int_type(*s as u32).const_int(*v as u64, *u).into())} else {None},
-            Type::Float16 => if let InterData::Float(v) = v {Some(ctx.context.f16_type().const_float(*v).into())} else {None},
-            Type::Float32 => if let InterData::Float(v) = v {Some(ctx.context.f32_type().const_float(*v).into())} else {None},
-            Type::Float64 => if let InterData::Float(v) = v {Some(ctx.context.f64_type().const_float(*v).into())} else {None},
-            Type::Float128 => if let InterData::Float(v) = v {Some(ctx.context.f128_type().const_float(*v).into())} else {None},
+            Type::IntLiteral => {
+                if let InterData::Int(v) = v {
+                    Some(ctx.context.i64_type().const_int(*v as u64, true).into())
+                } else {
+                    None
+                }
+            }
+            Type::Int(s, u) => {
+                if let InterData::Int(v) = v {
+                    Some(
+                        ctx.context
+                            .custom_width_int_type(*s as u32)
+                            .const_int(*v as u64, *u)
+                            .into(),
+                    )
+                } else {
+                    None
+                }
+            }
+            Type::Float16 => {
+                if let InterData::Float(v) = v {
+                    Some(ctx.context.f16_type().const_float(*v).into())
+                } else {
+                    None
+                }
+            }
+            Type::Float32 => {
+                if let InterData::Float(v) = v {
+                    Some(ctx.context.f32_type().const_float(*v).into())
+                } else {
+                    None
+                }
+            }
+            Type::Float64 => {
+                if let InterData::Float(v) = v {
+                    Some(ctx.context.f64_type().const_float(*v).into())
+                } else {
+                    None
+                }
+            }
+            Type::Float128 => {
+                if let InterData::Float(v) = v {
+                    Some(ctx.context.f128_type().const_float(*v).into())
+                } else {
+                    None
+                }
+            }
             Type::Array(b, Some(n)) => {
                 if let InterData::Array(v) = v {
                     (v.len() == *n as _).then_some(())?;
                     let ty = b.llvm_type(ctx)?;
                     let arr = ty.array_type(*n);
                     let val = arr.get_undef();
-                    v.iter().enumerate()
-                        .try_fold(val, |val, (n, v)| b
-                            .into_compiled(v, ctx)
-                            .and_then(|v| ctx.builder.build_insert_value(val, v, n as _, ""))
-                            .map(|v| v.into_array_value()))
+                    v.iter()
+                        .enumerate()
+                        .try_fold(val, |val, (n, v)| {
+                            b.into_compiled(v, ctx)
+                                .and_then(|v| ctx.builder.build_insert_value(val, v, n as _, ""))
+                                .map(|v| v.into_array_value())
+                        })
                         .map(From::from)
+                } else {
+                    None
                 }
-                else {None}
             }
             Type::Tuple(vs) => {
                 self.can_be_compiled(v, ctx).then_some(())?;
                 if let InterData::Array(is) = v {
-                    let (vals, types): (Vec<_>, Vec<_>) = vs.iter().zip(is).map(|(t, v)| {
-                        let llv = t.into_compiled(v, ctx).unwrap();
-                        (llv, llv.get_type())
-                    }).unzip();
+                    let (vals, types): (Vec<_>, Vec<_>) = vs
+                        .iter()
+                        .zip(is)
+                        .map(|(t, v)| {
+                            let llv = t.into_compiled(v, ctx).unwrap();
+                            (llv, llv.get_type())
+                        })
+                        .unzip();
                     let ty = ctx.context.struct_type(&types, false);
-                    vals.into_iter().enumerate().try_fold(ty.get_undef(), |v, (n, val)| ctx.builder.build_insert_value(v, val, n as u32, "").map(|v| v.into_struct_value())).map(From::from)
+                    vals.into_iter()
+                        .enumerate()
+                        .try_fold(ty.get_undef(), |v, (n, val)| {
+                            ctx.builder
+                                .build_insert_value(v, val, n as u32, "")
+                                .map(|v| v.into_struct_value())
+                        })
+                        .map(From::from)
+                } else {
+                    unreachable!()
                 }
-                else {unreachable!()}
-            },
+            }
             Type::Nominal(n) => ctx.nominals.borrow()[n].0.into_compiled(v, ctx),
             Type::Mut(b) => b.into_compiled(v, ctx),
-            _ => None
+            _ => None,
         }
     }
     pub fn contains_nominal(&self) -> bool {
         match self {
             Type::Nominal(_) => true,
-            Type::Reference(b) | Type::Pointer(b) | Type::Mut(b) | Type::Array(b, _) | Type::InlineAsm(b) => b.contains_nominal(),
+            Type::Reference(b)
+            | Type::Pointer(b)
+            | Type::Mut(b)
+            | Type::Array(b, _)
+            | Type::InlineAsm(b) => b.contains_nominal(),
             Type::Tuple(v) => v.iter().any(|t| t.contains_nominal()),
-            Type::Function(r, a) => r.contains_nominal() || a.iter().any(|t| t.0.contains_nominal()),
-            Type::BoundMethod(r, a) => r.contains_nominal() || a.iter().any(|t| t.0.contains_nominal()),
-            _ => false
+            Type::Function(r, a) => {
+                r.contains_nominal() || a.iter().any(|t| t.0.contains_nominal())
+            }
+            Type::BoundMethod(r, a) => {
+                r.contains_nominal() || a.iter().any(|t| t.0.contains_nominal())
+            }
+            _ => false,
         }
     }
     pub fn unwrapped(&self, ctx: &CompCtx) -> Cow<Self> {
         match self {
             Type::Nominal(n) => Cow::Owned(ctx.nominals.borrow()[n].0.clone()),
-            Type::Reference(b) =>
-                if b.contains_nominal() {Cow::Owned(Type::Reference(Box::new(b.unwrapped(ctx).into_owned())))}
-                else {Cow::Borrowed(self)},
-            Type::Pointer(b) =>
-                if b.contains_nominal() {Cow::Owned(Type::Pointer(Box::new(b.unwrapped(ctx).into_owned())))}
-                else {Cow::Borrowed(self)},
-            Type::Array(b, s) =>
-                if b.contains_nominal() {Cow::Owned(Type::Array(Box::new(b.unwrapped(ctx).into_owned()), *s))}
-                else {Cow::Borrowed(self)},
-            Type::InlineAsm(b) =>
-                if b.contains_nominal() {Cow::Owned(Type::InlineAsm(Box::new(b.unwrapped(ctx).into_owned())))}
-                else {Cow::Borrowed(self)},
-            Type::Tuple(v) =>
-                if v.iter().any(|t| t.contains_nominal()) {Cow::Owned(Type::Tuple(v.iter().map(|t| t.unwrapped(ctx).into_owned()).collect()))}
-                else {Cow::Borrowed(self)},
-            Type::Function(r, a) =>
-                if r.contains_nominal() || a.iter().any(|t| t.0.contains_nominal()) {Cow::Owned(Type::Function(
-                    Box::new(r.unwrapped(ctx).into_owned()),
-                    a.iter().map(|(t, c)| (t.unwrapped(ctx).into_owned(), *c)).collect()
-                ))}
-                else {Cow::Borrowed(self)},
-            Type::BoundMethod(r, a) =>
-                if r.contains_nominal() || a.iter().any(|t| t.0.contains_nominal())
-                {Cow::Owned(Type::BoundMethod(
-                    Box::new(r.unwrapped(ctx).into_owned()),
-                    a.iter().map(|(t, c)| (t.unwrapped(ctx).into_owned(), *c)).collect()
-                ))}
-                else {Cow::Borrowed(self)},
-            _ => Cow::Borrowed(self)
+            Type::Reference(b) => {
+                if b.contains_nominal() {
+                    Cow::Owned(Type::Reference(Box::new(b.unwrapped(ctx).into_owned())))
+                } else {
+                    Cow::Borrowed(self)
+                }
+            }
+            Type::Pointer(b) => {
+                if b.contains_nominal() {
+                    Cow::Owned(Type::Pointer(Box::new(b.unwrapped(ctx).into_owned())))
+                } else {
+                    Cow::Borrowed(self)
+                }
+            }
+            Type::Array(b, s) => {
+                if b.contains_nominal() {
+                    Cow::Owned(Type::Array(Box::new(b.unwrapped(ctx).into_owned()), *s))
+                } else {
+                    Cow::Borrowed(self)
+                }
+            }
+            Type::InlineAsm(b) => {
+                if b.contains_nominal() {
+                    Cow::Owned(Type::InlineAsm(Box::new(b.unwrapped(ctx).into_owned())))
+                } else {
+                    Cow::Borrowed(self)
+                }
+            }
+            Type::Tuple(v) => {
+                if v.iter().any(|t| t.contains_nominal()) {
+                    Cow::Owned(Type::Tuple(
+                        v.iter().map(|t| t.unwrapped(ctx).into_owned()).collect(),
+                    ))
+                } else {
+                    Cow::Borrowed(self)
+                }
+            }
+            Type::Function(r, a) => {
+                if r.contains_nominal() || a.iter().any(|t| t.0.contains_nominal()) {
+                    Cow::Owned(Type::Function(
+                        Box::new(r.unwrapped(ctx).into_owned()),
+                        a.iter()
+                            .map(|(t, c)| (t.unwrapped(ctx).into_owned(), *c))
+                            .collect(),
+                    ))
+                } else {
+                    Cow::Borrowed(self)
+                }
+            }
+            Type::BoundMethod(r, a) => {
+                if r.contains_nominal() || a.iter().any(|t| t.0.contains_nominal()) {
+                    Cow::Owned(Type::BoundMethod(
+                        Box::new(r.unwrapped(ctx).into_owned()),
+                        a.iter()
+                            .map(|(t, c)| (t.unwrapped(ctx).into_owned(), *c))
+                            .collect(),
+                    ))
+                } else {
+                    Cow::Borrowed(self)
+                }
+            }
+            _ => Cow::Borrowed(self),
         }
     }
     pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {
@@ -309,7 +537,9 @@ impl Type {
             Int(s, u) => {
                 out.write_all(&[1])?;
                 let mut v = *s as i16;
-                if *u {v = -v;}
+                if *u {
+                    v = -v;
+                }
                 out.write_all(&v.to_be_bytes())
             }
             Intrinsic(s) => {
@@ -343,35 +573,35 @@ impl Type {
                     out.write_all(&[u8::from(*c)])?; // param is const
                 }
                 Ok(())
-            },
+            }
             InlineAsm(b) => {
                 out.write_all(&[14])?;
                 b.save(out)
-            },
+            }
             Error => panic!("error values shouldn't be serialized!"),
             Array(b, None) => {
                 out.write_all(&[15])?;
                 b.save(out)
-            },
+            }
             Array(b, Some(s)) => {
                 let mut data = [16u8, 0, 0, 0, 0];
                 data[1..].copy_from_slice(&s.to_be_bytes());
                 out.write_all(&data)?;
                 b.save(out)
-            },
+            }
             TypeData => out.write_all(&[17]),
             Nominal(n) => {
                 out.write_all(&[18])?;
                 out.write_all(n.as_bytes())?;
                 out.write_all(&[0])
-            },
+            }
             Module => out.write_all(&[19]),
             Tuple(v) => {
                 let mut buf = [20u8, 0, 0, 0, 0];
                 buf[1..].copy_from_slice(&(v.len() as u32).to_be_bytes());
                 out.write_all(&buf)?;
                 v.iter().try_for_each(|t| t.save(out))
-            },
+            }
             BoundMethod(r, p) => {
                 out.write_all(&[21])?;
                 out.write_all(&(p.len() as u16).to_be_bytes())?; // # of params
@@ -381,7 +611,7 @@ impl Type {
                     out.write_all(&[u8::from(*c)])?; // param is const
                 }
                 Ok(())
-            },
+            }
         }
     }
     pub fn load<R: Read + BufRead>(buf: &mut R) -> io::Result<Self> {
@@ -393,13 +623,17 @@ impl Type {
                 buf.read_exact(&mut bytes)?;
                 let v = i16::from_be_bytes(bytes);
                 Type::Int(v.unsigned_abs(), v < 0)
-            },
+            }
             2 => {
                 let mut vec = vec![];
                 buf.read_until(0, &mut vec)?;
-                if vec.last() == Some(&0) {vec.pop();}
-                Type::Intrinsic(String::from_utf8(vec).expect("intrinsic name should be valid UTF-8"))
-            },
+                if vec.last() == Some(&0) {
+                    vec.pop();
+                }
+                Type::Intrinsic(
+                    String::from_utf8(vec).expect("intrinsic name should be valid UTF-8"),
+                )
+            }
             3 => Type::Float16,
             4 => Type::Float32,
             5 => Type::Float64,
@@ -427,14 +661,16 @@ impl Type {
                 let mut bytes = [0; 4];
                 buf.read_exact(&mut bytes)?;
                 Type::Array(Box::new(Type::load(buf)?), Some(u32::from_be_bytes(bytes)))
-            },
+            }
             17 => Type::TypeData,
             18 => {
                 let mut vec = Vec::<u8>::new();
                 buf.read_until(0, &mut vec)?;
-                if vec.last() == Some(&0) {vec.pop();}
+                if vec.last() == Some(&0) {
+                    vec.pop();
+                }
                 Type::Nominal(String::from_utf8(vec).expect("Type names should be valid UTF-8!"))
-            },
+            }
             19 => Type::Module,
             20 => {
                 let mut bytes = [0; 4];
@@ -446,7 +682,7 @@ impl Type {
                     count -= 1;
                 }
                 Type::Tuple(vec)
-            },
+            }
             21 => {
                 let mut bytes = [0; 2];
                 buf.read_exact(&mut bytes)?;
@@ -461,36 +697,42 @@ impl Type {
                 }
                 Type::BoundMethod(Box::new(ret), vec)
             }
-            x => panic!("read type value expecting value in 1..=21, got {x}")
+            x => panic!("read type value expecting value in 1..=21, got {x}"),
         })
     }
     /// Ensure that any symbols reachable from this type are exported
     pub fn export(&self, ctx: &CompCtx) {
         match self {
             Type::Nominal(n) => ctx.nominals.borrow_mut().get_mut(n).unwrap().1 = true,
-            Type::Reference(b) | Type::Pointer(b) | Type::Mut(b) | Type::Array(b, _) | Type::InlineAsm(b) => b.export(ctx),
+            Type::Reference(b)
+            | Type::Pointer(b)
+            | Type::Mut(b)
+            | Type::Array(b, _)
+            | Type::InlineAsm(b) => b.export(ctx),
             Type::Tuple(v) => v.iter().for_each(|t| t.export(ctx)),
             Type::Function(r, a) => {
                 r.export(ctx);
                 a.iter().for_each(|t| t.0.export(ctx));
-            },
+            }
             Type::BoundMethod(r, a) => {
                 r.export(ctx);
                 a.iter().for_each(|t| t.0.export(ctx));
-            },
+            }
             _ => {}
         }
     }
 }
 pub fn tuple_type<'ctx>(v: &[Type], ctx: &CompCtx<'ctx>) -> Option<BasicTypeEnum<'ctx>> {
     let mut vec = Vec::with_capacity(v.len());
-    for t in v {vec.push(t.llvm_type(ctx)?);}
+    for t in v {
+        vec.push(t.llvm_type(ctx)?);
+    }
     Some(ctx.context.struct_type(&vec, false).into())
 }
 #[derive(Debug, Clone, Default)]
 pub struct NominalInfo<'ctx> {
     pub dtor: Option<FunctionValue<'ctx>>,
-    pub no_auto_drop: bool
+    pub no_auto_drop: bool,
 }
 impl<'ctx> NominalInfo<'ctx> {
     pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {
@@ -503,16 +745,27 @@ impl<'ctx> NominalInfo<'ctx> {
     pub fn load<R: Read + BufRead>(buf: &mut R, ctx: &CompCtx<'ctx>) -> io::Result<Self> {
         let mut vec = vec![];
         buf.read_until(0, &mut vec)?;
-        if vec.last() == Some(&0) {vec.pop();}
-        let dtor = if vec.is_empty() {None}
-        else {
+        if vec.last() == Some(&0) {
+            vec.pop();
+        }
+        let dtor = if vec.is_empty() {
+            None
+        } else {
             let name = String::from_utf8(vec).expect("value should be valid UTF-8!");
             let fv = ctx.module.get_function(&name);
-            Some(fv.unwrap_or_else(|| ctx.module.add_function(&name, ctx.context.void_type().fn_type(&[ctx.null_type.ptr_type(Default::default()).into()], false), None)))
+            Some(fv.unwrap_or_else(|| {
+                ctx.module.add_function(
+                    &name,
+                    ctx.context
+                        .void_type()
+                        .fn_type(&[ctx.null_type.ptr_type(Default::default()).into()], false),
+                    None,
+                )
+            }))
         };
         let mut c = 0u8;
         buf.read_exact(std::slice::from_mut(&mut c))?;
         let no_auto_drop = c != 0;
-        Ok(Self {dtor, no_auto_drop})
+        Ok(Self { dtor, no_auto_drop })
     }
 }

--- a/cobalt-ast/src/value.rs
+++ b/cobalt-ast/src/value.rs
@@ -1,17 +1,21 @@
 use crate::*;
-use inkwell::types::{BasicTypeEnum::*, BasicMetadataTypeEnum, BasicType};
+use inkwell::types::{BasicMetadataTypeEnum, BasicType, BasicTypeEnum::*};
 use inkwell::values::{BasicValueEnum, PointerValue};
-use std::collections::HashMap;
-use std::io::{self, Write, Read, BufRead};
-use std::rc::Rc;
 use std::cell::Cell;
+use std::collections::HashMap;
+use std::io::{self, BufRead, Read, Write};
+use std::rc::Rc;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MethodType {Normal, Static, Getter}
+pub enum MethodType {
+    Normal,
+    Static,
+    Getter,
+}
 #[derive(Debug, Clone)]
 pub struct FnData<'ctx> {
     pub defaults: Vec<InterData<'ctx>>,
     pub cconv: u32,
-    pub mt: MethodType
+    pub mt: MethodType,
 }
 #[derive(Debug, Clone)]
 pub enum InterData<'ctx> {
@@ -22,42 +26,55 @@ pub enum InterData<'ctx> {
     Function(FnData<'ctx>),
     InlineAsm(String, String),
     Type(Box<Type>),
-    Module(HashMap<String, Symbol<'ctx>>, Vec<(CompoundDottedName, bool)>, String)
+    Module(
+        HashMap<String, Symbol<'ctx>>,
+        Vec<(CompoundDottedName, bool)>,
+        String,
+    ),
 }
 impl<'ctx> InterData<'ctx> {
     pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {
         match self {
             InterData::Null => out.write_all(&[1]),
-            InterData::Int(v) => out.write_all(&[2]).and_then(|_| out.write_all(&v.to_be_bytes())),
-            InterData::Float(v) => out.write_all(&[3]).and_then(|_| out.write_all(&v.to_be_bytes())),
+            InterData::Int(v) => out
+                .write_all(&[2])
+                .and_then(|_| out.write_all(&v.to_be_bytes())),
+            InterData::Float(v) => out
+                .write_all(&[3])
+                .and_then(|_| out.write_all(&v.to_be_bytes())),
             InterData::Array(v) => {
                 out.write_all(&[5])?;
                 out.write_all(&(v.len() as u32).to_be_bytes())?; // length
-                for val in v.iter() {val.save(out)?;} // InterData is self-puncatuating
+                for val in v.iter() {
+                    val.save(out)?;
+                } // InterData is self-puncatuating
                 Ok(())
-            },
-            InterData::Function(v) => { // serialized the same as InterData::Array
+            }
+            InterData::Function(v) => {
+                // serialized the same as InterData::Array
                 out.write_all(&[6])?;
                 out.write_all(&(v.defaults.len() as u32).to_be_bytes())?;
-                for val in v.defaults.iter() {val.save(out)?;}
+                for val in v.defaults.iter() {
+                    val.save(out)?;
+                }
                 out.write_all(&v.cconv.to_be_bytes())?;
                 out.write_all(std::slice::from_ref(&match v.mt {
                     MethodType::Normal => 1,
                     MethodType::Static => 2,
-                    MethodType::Getter => 3
+                    MethodType::Getter => 3,
                 }))
-            },
+            }
             InterData::InlineAsm(c, b) => {
                 out.write_all(&[7])?;
                 out.write_all(c.as_bytes())?;
                 out.write_all(&[0])?;
                 out.write_all(b.as_bytes())?;
                 out.write_all(&[0])
-            },
+            }
             InterData::Type(t) => {
                 out.write_all(&[8])?;
                 t.save(out)
-            },
+            }
             InterData::Module(v, i, n) => {
                 out.write_all(&[9])?;
                 out.write_all(n.as_bytes())?;
@@ -70,7 +87,10 @@ impl<'ctx> InterData<'ctx> {
                     }
                 }
                 out.write_all(&[0])?; // null terminator for symbol list
-                for import in i.iter().filter_map(|(s, b)| if *b {Some(s)} else {None}) {
+                for import in i
+                    .iter()
+                    .filter_map(|(s, b)| if *b { Some(s) } else { None })
+                {
                     import.save(out)?;
                 }
                 out.write_all(&[0])
@@ -87,26 +107,36 @@ impl<'ctx> InterData<'ctx> {
                 let mut bytes = [0; 16];
                 buf.read_exact(&mut bytes)?;
                 Some(InterData::Int(i128::from_be_bytes(bytes)))
-            },
+            }
             3 => {
                 let mut bytes = [0; 8];
                 buf.read_exact(&mut bytes)?;
                 Some(InterData::Float(f64::from_be_bytes(bytes)))
-            },
+            }
             5 => {
                 let mut bytes = [0; 4];
                 buf.read_exact(&mut bytes)?;
                 let len = u32::from_be_bytes(bytes);
                 let mut vec = Vec::with_capacity(len as usize);
-                for _ in 0..len {vec.push(Self::load(buf, ctx)?.expect("# of unwrapped array elements doesn't match the prefixed count"))}
+                for _ in 0..len {
+                    vec.push(
+                        Self::load(buf, ctx)?.expect(
+                            "# of unwrapped array elements doesn't match the prefixed count",
+                        ),
+                    )
+                }
                 Some(InterData::Array(vec))
-            },
+            }
             6 => {
                 let mut bytes = [0; 4];
                 buf.read_exact(&mut bytes)?;
                 let len = u32::from_be_bytes(bytes);
                 let mut vec = Vec::with_capacity(len as usize);
-                for _ in 0..len {vec.push(Self::load(buf, ctx)?.expect("# of unwrapped default parameters doesn't match the prefixed count"))}
+                for _ in 0..len {
+                    vec.push(Self::load(buf, ctx)?.expect(
+                        "# of unwrapped default parameters doesn't match the prefixed count",
+                    ))
+                }
                 buf.read_exact(&mut bytes)?;
                 let mut c = 0u8;
                 buf.read_exact(std::slice::from_mut(&mut c))?;
@@ -114,35 +144,58 @@ impl<'ctx> InterData<'ctx> {
                     1 => MethodType::Normal,
                     2 => MethodType::Static,
                     3 => MethodType::Getter,
-                    x => panic!("Expected 1, 2, or 3 for method type, got {x}")
+                    x => panic!("Expected 1, 2, or 3 for method type, got {x}"),
                 };
-                Some(InterData::Function(FnData{defaults: vec, cconv: u32::from_be_bytes(bytes), mt}))
-            },
+                Some(InterData::Function(FnData {
+                    defaults: vec,
+                    cconv: u32::from_be_bytes(bytes),
+                    mt,
+                }))
+            }
             7 => {
                 let mut constraint = Vec::new();
                 let mut body = Vec::new();
                 buf.read_until(0, &mut constraint)?;
                 buf.read_until(0, &mut body)?;
-                Some(InterData::InlineAsm(String::from_utf8(constraint).expect("Inline assmebly constraint should be valid UTF-8"), String::from_utf8(body).expect("Inline assembly should be valid UTF-8")))
-            },
+                Some(InterData::InlineAsm(
+                    String::from_utf8(constraint)
+                        .expect("Inline assmebly constraint should be valid UTF-8"),
+                    String::from_utf8(body).expect("Inline assembly should be valid UTF-8"),
+                ))
+            }
             8 => Some(InterData::Type(Box::new(Type::load(buf)?))),
             9 => {
                 let mut out = HashMap::new();
                 let mut imports = vec![];
                 let mut vec = Vec::new();
                 buf.read_until(0, &mut vec)?;
-                if vec.last() == Some(&0) {vec.pop();}
+                if vec.last() == Some(&0) {
+                    vec.pop();
+                }
                 loop {
                     let mut name = vec![];
                     buf.read_until(0, &mut name)?;
-                    if name.last() == Some(&0) {name.pop();}
-                    if name.is_empty() {break}
-                    out.insert(String::from_utf8(name).expect("Cobalt symbols should be valid UTF-8"), Symbol::load(buf, ctx)?);
+                    if name.last() == Some(&0) {
+                        name.pop();
+                    }
+                    if name.is_empty() {
+                        break;
+                    }
+                    out.insert(
+                        String::from_utf8(name).expect("Cobalt symbols should be valid UTF-8"),
+                        Symbol::load(buf, ctx)?,
+                    );
                 }
-                while let Some(val) = CompoundDottedName::load(buf)? {imports.push((val, false));}
-                Some(InterData::Module(out, imports, String::from_utf8(vec).expect("Module names should be valid UTF-8")))
-            },
-            x => panic!("read interpreted data type expecting number in 1..=9, got {x}")
+                while let Some(val) = CompoundDottedName::load(buf)? {
+                    imports.push((val, false));
+                }
+                Some(InterData::Module(
+                    out,
+                    imports,
+                    String::from_utf8(vec).expect("Module names should be valid UTF-8"),
+                ))
+            }
+            x => panic!("read interpreted data type expecting number in 1..=9, got {x}"),
         })
     }
 }
@@ -153,20 +206,127 @@ pub struct Value<'ctx> {
     pub data_type: Type,
     pub address: Rc<Cell<Option<PointerValue<'ctx>>>>,
     pub name: Option<(String, usize)>,
-    pub frozen: Option<SourceSpan>
+    pub frozen: Option<SourceSpan>,
 }
 impl<'ctx> Value<'ctx> {
-    pub fn error() -> Self {Value {comp_val: None, inter_val: None, data_type: Type::Error, address: Rc::default(), name: None, frozen: None}}
-    pub fn null() -> Self {Value {comp_val: None, inter_val: None, data_type: Type::Null, address: Rc::default(), name: None, frozen: None}}
-    pub fn new(comp_val: Option<BasicValueEnum<'ctx>>, inter_val: Option<InterData<'ctx>>, data_type: Type) -> Self {Value {comp_val, inter_val, data_type, address: Rc::default(), name: None, frozen: None}}
-    pub fn with_addr(comp_val: Option<BasicValueEnum<'ctx>>, inter_val: Option<InterData<'ctx>>, data_type: Type, addr: PointerValue<'ctx>) -> Self {Value {comp_val, inter_val, data_type, address: Rc::new(Cell::new(Some(addr))), name: None, frozen: None}}
-    pub fn compiled(comp_val: BasicValueEnum<'ctx>, data_type: Type) -> Self {Value {comp_val: Some(comp_val), inter_val: None, data_type, address: Rc::default(), name: None, frozen: None}}
-    pub fn interpreted(comp_val: BasicValueEnum<'ctx>, inter_val: InterData<'ctx>, data_type: Type) -> Self {Value {comp_val: Some(comp_val), inter_val: Some(inter_val), data_type, address: Rc::default(), name: None, frozen: None}}
-    pub fn metaval(inter_val: InterData<'ctx>, data_type: Type) -> Self {Value {comp_val: None, inter_val: Some(inter_val), data_type, address: Rc::default(), name: None, frozen: None}}
-    pub fn make_type(type_: Type) -> Self {Value {comp_val: None, inter_val: Some(InterData::Type(Box::new(type_))), data_type: Type::TypeData, address: Rc::default(), name: None, frozen: None}}
-    pub fn empty_mod(name: String) -> Self {Value {comp_val: None, inter_val: Some(InterData::Module(HashMap::new(), vec![], name)), data_type: Type::Module, address: Rc::default(), name: None, frozen: None}}
-    pub fn make_mod(syms: HashMap<String, Symbol<'ctx>>, imps: Vec<(CompoundDottedName, bool)>, name: String) -> Self {Value {comp_val: None, inter_val: Some(InterData::Module(syms, imps, name)), data_type: Type::Module, address: Rc::default(), name: None, frozen: None}}
-    
+    pub fn error() -> Self {
+        Value {
+            comp_val: None,
+            inter_val: None,
+            data_type: Type::Error,
+            address: Rc::default(),
+            name: None,
+            frozen: None,
+        }
+    }
+    pub fn null() -> Self {
+        Value {
+            comp_val: None,
+            inter_val: None,
+            data_type: Type::Null,
+            address: Rc::default(),
+            name: None,
+            frozen: None,
+        }
+    }
+    pub fn new(
+        comp_val: Option<BasicValueEnum<'ctx>>,
+        inter_val: Option<InterData<'ctx>>,
+        data_type: Type,
+    ) -> Self {
+        Value {
+            comp_val,
+            inter_val,
+            data_type,
+            address: Rc::default(),
+            name: None,
+            frozen: None,
+        }
+    }
+    pub fn with_addr(
+        comp_val: Option<BasicValueEnum<'ctx>>,
+        inter_val: Option<InterData<'ctx>>,
+        data_type: Type,
+        addr: PointerValue<'ctx>,
+    ) -> Self {
+        Value {
+            comp_val,
+            inter_val,
+            data_type,
+            address: Rc::new(Cell::new(Some(addr))),
+            name: None,
+            frozen: None,
+        }
+    }
+    pub fn compiled(comp_val: BasicValueEnum<'ctx>, data_type: Type) -> Self {
+        Value {
+            comp_val: Some(comp_val),
+            inter_val: None,
+            data_type,
+            address: Rc::default(),
+            name: None,
+            frozen: None,
+        }
+    }
+    pub fn interpreted(
+        comp_val: BasicValueEnum<'ctx>,
+        inter_val: InterData<'ctx>,
+        data_type: Type,
+    ) -> Self {
+        Value {
+            comp_val: Some(comp_val),
+            inter_val: Some(inter_val),
+            data_type,
+            address: Rc::default(),
+            name: None,
+            frozen: None,
+        }
+    }
+    pub fn metaval(inter_val: InterData<'ctx>, data_type: Type) -> Self {
+        Value {
+            comp_val: None,
+            inter_val: Some(inter_val),
+            data_type,
+            address: Rc::default(),
+            name: None,
+            frozen: None,
+        }
+    }
+    pub fn make_type(type_: Type) -> Self {
+        Value {
+            comp_val: None,
+            inter_val: Some(InterData::Type(Box::new(type_))),
+            data_type: Type::TypeData,
+            address: Rc::default(),
+            name: None,
+            frozen: None,
+        }
+    }
+    pub fn empty_mod(name: String) -> Self {
+        Value {
+            comp_val: None,
+            inter_val: Some(InterData::Module(HashMap::new(), vec![], name)),
+            data_type: Type::Module,
+            address: Rc::default(),
+            name: None,
+            frozen: None,
+        }
+    }
+    pub fn make_mod(
+        syms: HashMap<String, Symbol<'ctx>>,
+        imps: Vec<(CompoundDottedName, bool)>,
+        name: String,
+    ) -> Self {
+        Value {
+            comp_val: None,
+            inter_val: Some(InterData::Module(syms, imps, name)),
+            data_type: Type::Module,
+            address: Rc::default(),
+            name: None,
+            frozen: None,
+        }
+    }
+
     pub fn addr(&self, ctx: &CompCtx<'ctx>) -> Option<PointerValue<'ctx>> {
         self.address.get().or_else(|| {
             let ctv = self.value(ctx)?;
@@ -183,83 +343,207 @@ impl<'ctx> Value<'ctx> {
         }
     }
 
-    pub fn value(&self, ctx: &CompCtx<'ctx>) -> Option<BasicValueEnum<'ctx>> {self.comp_val.or_else(|| self.inter_val.as_ref().and_then(|v| self.data_type.into_compiled(v, ctx)))}
-    pub fn into_value(self, ctx: &CompCtx<'ctx>) -> Option<BasicValueEnum<'ctx>> {self.comp_val.or_else(|| self.inter_val.as_ref().and_then(|v| self.data_type.into_compiled(v, ctx)))}
+    pub fn value(&self, ctx: &CompCtx<'ctx>) -> Option<BasicValueEnum<'ctx>> {
+        self.comp_val.or_else(|| {
+            self.inter_val
+                .as_ref()
+                .and_then(|v| self.data_type.into_compiled(v, ctx))
+        })
+    }
+    pub fn into_value(self, ctx: &CompCtx<'ctx>) -> Option<BasicValueEnum<'ctx>> {
+        self.comp_val.or_else(|| {
+            self.inter_val
+                .as_ref()
+                .and_then(|v| self.data_type.into_compiled(v, ctx))
+        })
+    }
 
     pub fn ins_dtor(&self, ctx: &CompCtx<'ctx>) {
         match &self.data_type {
-            Type::Nominal(n) => if let Some(addr) = self.addr(ctx) {
-                let b = ctx.nominals.borrow();
-                let info = &b[n];
-                if let Some(fv) = info.3.dtor {
-                    ctx.builder.build_call(fv, &[addr.into()], "");
-                }
-                else if !info.3.no_auto_drop {
-                    let mut this = self.clone();
-                    this.data_type = info.0.clone();
-                    this.ins_dtor(ctx)
+            Type::Nominal(n) => {
+                if let Some(addr) = self.addr(ctx) {
+                    let b = ctx.nominals.borrow();
+                    let info = &b[n];
+                    if let Some(fv) = info.3.dtor {
+                        ctx.builder.build_call(fv, &[addr.into()], "");
+                    } else if !info.3.no_auto_drop {
+                        let mut this = self.clone();
+                        this.data_type = info.0.clone();
+                        this.ins_dtor(ctx)
+                    }
                 }
             }
-            Type::Tuple(v) => if let Some(BasicValueEnum::StructValue(comp_val)) = self.comp_val {
-                v.iter().enumerate().for_each(|(n, t)| {
-                    if t.has_dtor(ctx) {
-                        let val = ctx.builder.build_extract_value(comp_val, n as _, "").unwrap();
-                        let mut val = Value::compiled(val, t.clone());
-                        if let Some(pv) = self.address.get() {
-                            val.address = Rc::new(Cell::new(Some(ctx.builder.build_struct_gep(self.data_type.llvm_type(ctx).unwrap(), pv, n as _, "").unwrap())));
+            Type::Tuple(v) => {
+                if let Some(BasicValueEnum::StructValue(comp_val)) = self.comp_val {
+                    v.iter().enumerate().for_each(|(n, t)| {
+                        if t.has_dtor(ctx) {
+                            let val = ctx
+                                .builder
+                                .build_extract_value(comp_val, n as _, "")
+                                .unwrap();
+                            let mut val = Value::compiled(val, t.clone());
+                            if let Some(pv) = self.address.get() {
+                                val.address = Rc::new(Cell::new(Some(
+                                    ctx.builder
+                                        .build_struct_gep(
+                                            self.data_type.llvm_type(ctx).unwrap(),
+                                            pv,
+                                            n as _,
+                                            "",
+                                        )
+                                        .unwrap(),
+                                )));
+                            }
+                            val.ins_dtor(ctx);
                         }
-                        val.ins_dtor(ctx);
-                    }
-                })
+                    })
+                }
             }
-            Type::Array(b, Some(s)) => if let Some(BasicValueEnum::ArrayValue(comp_val)) = self.comp_val {
-                if b.has_dtor(ctx) {
-                    let llt = self.data_type.llvm_type(ctx).unwrap();
-                    for n in 0..*s {
-                        let val = ctx.builder.build_extract_value(comp_val, n, "").unwrap();
-                        let mut val = Value::compiled(val, b.as_ref().clone());
-                        if let Some(pv) = self.address.get() {
-                            val.address = Rc::new(Cell::new(Some(ctx.builder.build_struct_gep(llt, pv, n, "").unwrap())));
+            Type::Array(b, Some(s)) => {
+                if let Some(BasicValueEnum::ArrayValue(comp_val)) = self.comp_val {
+                    if b.has_dtor(ctx) {
+                        let llt = self.data_type.llvm_type(ctx).unwrap();
+                        for n in 0..*s {
+                            let val = ctx.builder.build_extract_value(comp_val, n, "").unwrap();
+                            let mut val = Value::compiled(val, b.as_ref().clone());
+                            if let Some(pv) = self.address.get() {
+                                val.address = Rc::new(Cell::new(Some(
+                                    ctx.builder.build_struct_gep(llt, pv, n, "").unwrap(),
+                                )));
+                            }
+                            val.ins_dtor(ctx);
                         }
-                        val.ins_dtor(ctx);
                     }
                 }
             }
-            Type::Mut(b) => if let Some(BasicValueEnum::PointerValue(comp_val)) = self.comp_val {
-                if b.has_dtor(ctx) {
-                    if let Some(llt) = b.llvm_type(ctx) {
-                        let val = ctx.builder.build_load(llt, comp_val, "");
-                        let mut val = Value::compiled(val, b.as_ref().clone());
-                        val.address = Rc::new(Cell::new(Some(comp_val)));
-                        val.ins_dtor(ctx);
+            Type::Mut(b) => {
+                if let Some(BasicValueEnum::PointerValue(comp_val)) = self.comp_val {
+                    if b.has_dtor(ctx) {
+                        if let Some(llt) = b.llvm_type(ctx) {
+                            let val = ctx.builder.build_load(llt, comp_val, "");
+                            let mut val = Value::compiled(val, b.as_ref().clone());
+                            val.address = Rc::new(Cell::new(Some(comp_val)));
+                            val.ins_dtor(ctx);
+                        }
                     }
                 }
             }
-            Type::BoundMethod(_, a) => if let (Some(BasicValueEnum::StructValue(sv)), Some(ty)) = (self.comp_val, a.get(0)) {
-                Value::compiled(ctx.builder.build_extract_value(sv, 0, "").unwrap(), ty.0.clone()).ins_dtor(ctx)
+            Type::BoundMethod(_, a) => {
+                if let (Some(BasicValueEnum::StructValue(sv)), Some(ty)) = (self.comp_val, a.get(0))
+                {
+                    Value::compiled(
+                        ctx.builder.build_extract_value(sv, 0, "").unwrap(),
+                        ty.0.clone(),
+                    )
+                    .ins_dtor(ctx)
+                }
             }
             _ => {}
         }
     }
-    
-    pub fn into_type(self) -> Option<Type> {if let Value {data_type: Type::TypeData, inter_val: Some(InterData::Type(t)), ..} = self {Some(*t)} else {None}}
-    pub fn as_type(&self) -> Option<&Type> {if let Value {data_type: Type::TypeData, inter_val: Some(InterData::Type(t)), ..} = self {Some(t.as_ref())} else {None}}
-    pub fn into_mod(self) -> Option<(HashMap<String, Symbol<'ctx>>, Vec<(CompoundDottedName, bool)>, String)> {if let Value {data_type: Type::Module, inter_val: Some(InterData::Module(s, m, n)), ..} = self {Some((s, m, n))} else {None}}
-    pub fn as_mod(&self) -> Option<(&HashMap<String, Symbol<'ctx>>, &Vec<(CompoundDottedName, bool)>, &String)> {if let Value {data_type: Type::Module, inter_val: Some(InterData::Module(s, m, n)), ..} = self {Some((s, m, n))} else {None}}
-    pub fn as_mod_mut(&mut self) -> Option<(&mut HashMap<String, Symbol<'ctx>>, &mut Vec<(CompoundDottedName, bool)>, &mut String)> {if let Value {data_type: Type::Module, inter_val: Some(InterData::Module(s, m, n)), ..} = self {Some((s, m, n))} else {None}}
+
+    pub fn into_type(self) -> Option<Type> {
+        if let Value {
+            data_type: Type::TypeData,
+            inter_val: Some(InterData::Type(t)),
+            ..
+        } = self
+        {
+            Some(*t)
+        } else {
+            None
+        }
+    }
+    pub fn as_type(&self) -> Option<&Type> {
+        if let Value {
+            data_type: Type::TypeData,
+            inter_val: Some(InterData::Type(t)),
+            ..
+        } = self
+        {
+            Some(t.as_ref())
+        } else {
+            None
+        }
+    }
+    pub fn into_mod(
+        self,
+    ) -> Option<(
+        HashMap<String, Symbol<'ctx>>,
+        Vec<(CompoundDottedName, bool)>,
+        String,
+    )> {
+        if let Value {
+            data_type: Type::Module,
+            inter_val: Some(InterData::Module(s, m, n)),
+            ..
+        } = self
+        {
+            Some((s, m, n))
+        } else {
+            None
+        }
+    }
+    pub fn as_mod(
+        &self,
+    ) -> Option<(
+        &HashMap<String, Symbol<'ctx>>,
+        &Vec<(CompoundDottedName, bool)>,
+        &String,
+    )> {
+        if let Value {
+            data_type: Type::Module,
+            inter_val: Some(InterData::Module(s, m, n)),
+            ..
+        } = self
+        {
+            Some((s, m, n))
+        } else {
+            None
+        }
+    }
+    pub fn as_mod_mut(
+        &mut self,
+    ) -> Option<(
+        &mut HashMap<String, Symbol<'ctx>>,
+        &mut Vec<(CompoundDottedName, bool)>,
+        &mut String,
+    )> {
+        if let Value {
+            data_type: Type::Module,
+            inter_val: Some(InterData::Module(s, m, n)),
+            ..
+        } = self
+        {
+            Some((s, m, n))
+        } else {
+            None
+        }
+    }
 
     pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {
-        out.write_all(self.comp_val.as_ref().map(|v| v.into_pointer_value().get_name().to_bytes().to_owned()).unwrap_or_else(Vec::new).as_slice())?; // LLVM symbol name, null-terminated
+        out.write_all(
+            self.comp_val
+                .as_ref()
+                .map(|v| v.into_pointer_value().get_name().to_bytes().to_owned())
+                .unwrap_or_else(Vec::new)
+                .as_slice(),
+        )?; // LLVM symbol name, null-terminated
         out.write_all(&[0])?;
-        if let Some(v) = self.inter_val.as_ref() {v.save(out)?}
-        else {out.write_all(&[0])?} // Interpreted value, self-punctuating
+        if let Some(v) = self.inter_val.as_ref() {
+            v.save(out)?
+        } else {
+            out.write_all(&[0])?
+        } // Interpreted value, self-punctuating
         self.data_type.save(out) // Type
     }
     pub fn load<R: Read + BufRead>(buf: &mut R, ctx: &CompCtx<'ctx>) -> io::Result<Self> {
         let mut var = Value::error();
         let mut name = vec![];
         buf.read_until(0, &mut name)?;
-        if name.last() == Some(&0) {name.pop();}
+        if name.last() == Some(&0) {
+            name.pop();
+        }
         var.inter_val = InterData::load(buf, ctx)?;
         var.data_type = Type::load(buf)?;
         if !name.is_empty() {
@@ -267,31 +551,79 @@ impl<'ctx> Value<'ctx> {
             if let Type::Function(ret, params) = &var.data_type {
                 if let Some(llt) = ret.llvm_type(ctx) {
                     let mut good = true;
-                    let ps = params.iter().filter_map(|(x, c)| if *c {None} else {Some(BasicMetadataTypeEnum::from(x.llvm_type(ctx).unwrap_or_else(|| {good = false; IntType(ctx.context.i8_type())})))}).collect::<Vec<_>>();
+                    let ps = params
+                        .iter()
+                        .filter_map(|(x, c)| {
+                            if *c {
+                                None
+                            } else {
+                                Some(BasicMetadataTypeEnum::from(
+                                    x.llvm_type(ctx).unwrap_or_else(|| {
+                                        good = false;
+                                        IntType(ctx.context.i8_type())
+                                    }),
+                                ))
+                            }
+                        })
+                        .collect::<Vec<_>>();
                     if good {
                         let ft = llt.fn_type(&ps, false);
-                        let fv = ctx.module.add_function(std::str::from_utf8(&name).expect("LLVM function names should be valid UTF-8"), ft, None);
-                        if let Some(InterData::Function(FnData {cconv, ..})) = var.inter_val {fv.set_call_conventions(cconv)}
+                        let fv = ctx.module.add_function(
+                            std::str::from_utf8(&name)
+                                .expect("LLVM function names should be valid UTF-8"),
+                            ft,
+                            None,
+                        );
+                        if let Some(InterData::Function(FnData { cconv, .. })) = var.inter_val {
+                            fv.set_call_conventions(cconv)
+                        }
                         let gv = fv.as_global_value();
                         gv.set_linkage(DLLImport);
                         var.comp_val = Some(BasicValueEnum::PointerValue(gv.as_pointer_value()));
                     }
-                }
-                else if ret.size(ctx) == SizeType::Static(0) {
+                } else if ret.size(ctx) == SizeType::Static(0) {
                     let mut good = true;
-                    let ps = params.iter().filter_map(|(x, c)| if *c {None} else {Some(BasicMetadataTypeEnum::from(x.llvm_type(ctx).unwrap_or_else(|| {good = false; IntType(ctx.context.i8_type())})))}).collect::<Vec<_>>();
+                    let ps = params
+                        .iter()
+                        .filter_map(|(x, c)| {
+                            if *c {
+                                None
+                            } else {
+                                Some(BasicMetadataTypeEnum::from(
+                                    x.llvm_type(ctx).unwrap_or_else(|| {
+                                        good = false;
+                                        IntType(ctx.context.i8_type())
+                                    }),
+                                ))
+                            }
+                        })
+                        .collect::<Vec<_>>();
                     if good {
                         let ft = ctx.context.void_type().fn_type(&ps, false);
-                        let fv = ctx.module.add_function(std::str::from_utf8(&name).expect("LLVM function names should be valid UTF-8"), ft, None);
-                        if let Some(InterData::Function(FnData {cconv, ..})) = var.inter_val {fv.set_call_conventions(cconv)}
+                        let fv = ctx.module.add_function(
+                            std::str::from_utf8(&name)
+                                .expect("LLVM function names should be valid UTF-8"),
+                            ft,
+                            None,
+                        );
+                        if let Some(InterData::Function(FnData { cconv, .. })) = var.inter_val {
+                            fv.set_call_conventions(cconv)
+                        }
                         let gv = fv.as_global_value();
                         gv.set_linkage(DLLImport);
                         var.comp_val = Some(BasicValueEnum::PointerValue(gv.as_pointer_value()));
                     }
                 }
-            }
-            else if let Some(t) = if let Type::Reference(ref b) = var.data_type {b.llvm_type(ctx)} else {None} {
-                let gv = ctx.module.add_global(t, None, std::str::from_utf8(&name).expect("LLVM variable names should be valid UTF-8")); // maybe do something with linkage/call convention?
+            } else if let Some(t) = if let Type::Reference(ref b) = var.data_type {
+                b.llvm_type(ctx)
+            } else {
+                None
+            } {
+                let gv = ctx.module.add_global(
+                    t,
+                    None,
+                    std::str::from_utf8(&name).expect("LLVM variable names should be valid UTF-8"),
+                ); // maybe do something with linkage/call convention?
                 gv.set_linkage(DLLImport);
                 var.comp_val = Some(BasicValueEnum::PointerValue(gv.as_pointer_value()));
             }

--- a/cobalt-ast/src/varmap.rs
+++ b/cobalt-ast/src/varmap.rs
@@ -1,16 +1,19 @@
 use crate::*;
-use std::collections::{LinkedList, hash_map::{HashMap, Entry}};
-use std::io::{self, Write, Read, BufRead};
+use std::collections::{
+    hash_map::{Entry, HashMap},
+    LinkedList,
+};
+use std::io::{self, BufRead, Read, Write};
 use std::num::NonZeroUsize;
 #[derive(Debug, Clone, Copy)]
 pub enum UndefVariable {
     NotAModule(usize),
-    DoesNotExist(usize)
+    DoesNotExist(usize),
 }
 #[derive(Debug, Clone)]
 pub enum RedefVariable<'ctx> {
     NotAModule(usize, Symbol<'ctx>),
-    AlreadyExists(usize, Option<SourceSpan>, Symbol<'ctx>)
+    AlreadyExists(usize, Option<SourceSpan>, Symbol<'ctx>),
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VariableData {
@@ -19,7 +22,7 @@ pub struct VariableData {
     pub init: bool,
     pub fwd: bool,
     pub loc: Option<SourceSpan>,
-    pub scope: Option<NonZeroUsize>
+    pub scope: Option<NonZeroUsize>,
 }
 impl VariableData {
     pub fn new(loc: SourceSpan) -> Self {
@@ -29,7 +32,7 @@ impl VariableData {
             init: true,
             fwd: false,
             loc: Some(loc),
-            scope: None
+            scope: None,
         }
     }
     pub fn with_vis(loc: SourceSpan, export: bool) -> Self {
@@ -39,7 +42,7 @@ impl VariableData {
             init: true,
             fwd: false,
             loc: Some(loc),
-            scope: None
+            scope: None,
         }
     }
     pub fn uninit(loc: SourceSpan) -> Self {
@@ -49,7 +52,7 @@ impl VariableData {
             init: false,
             fwd: false,
             loc: Some(loc),
-            scope: None
+            scope: None,
         }
     }
     pub fn uninit_vis(loc: SourceSpan, export: bool) -> Self {
@@ -59,7 +62,7 @@ impl VariableData {
             init: false,
             fwd: false,
             loc: Some(loc),
-            scope: None
+            scope: None,
         }
     }
 }
@@ -71,7 +74,7 @@ impl Default for VariableData {
             init: true,
             fwd: false,
             loc: None,
-            scope: None
+            scope: None,
         }
     }
 }
@@ -83,24 +86,69 @@ impl<'ctx> From<Value<'ctx>> for Symbol<'ctx> {
 #[derive(Debug, Clone)]
 pub struct Symbol<'ctx>(pub Value<'ctx>, pub VariableData);
 impl<'ctx> Symbol<'ctx> {
-    pub fn into_mod(self) -> Option<(HashMap<String, Symbol<'ctx>>, Vec<(CompoundDottedName, bool)>, String)> {self.0.into_mod()}
-    pub fn as_mod(&self) -> Option<(&HashMap<String, Symbol<'ctx>>, &Vec<(CompoundDottedName, bool)>, &String)> {self.0.as_mod()}
-    pub fn as_mod_mut(&mut self) -> Option<(&mut HashMap<String, Symbol<'ctx>>, &mut Vec<(CompoundDottedName, bool)>, &mut String)> {self.0.as_mod_mut()}
-    pub fn empty_mod(name: String) -> Self {Value::empty_mod(name).into()}
-    pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {self.0.save(out)}
-    pub fn load<R: Read + BufRead>(buf: &mut R, ctx: &CompCtx<'ctx>) -> io::Result<Self> {Ok(Symbol(Value::load(buf, ctx)?, VariableData {export: false, ..VariableData::default()}))}
+    pub fn into_mod(
+        self,
+    ) -> Option<(
+        HashMap<String, Symbol<'ctx>>,
+        Vec<(CompoundDottedName, bool)>,
+        String,
+    )> {
+        self.0.into_mod()
+    }
+    pub fn as_mod(
+        &self,
+    ) -> Option<(
+        &HashMap<String, Symbol<'ctx>>,
+        &Vec<(CompoundDottedName, bool)>,
+        &String,
+    )> {
+        self.0.as_mod()
+    }
+    pub fn as_mod_mut(
+        &mut self,
+    ) -> Option<(
+        &mut HashMap<String, Symbol<'ctx>>,
+        &mut Vec<(CompoundDottedName, bool)>,
+        &mut String,
+    )> {
+        self.0.as_mod_mut()
+    }
+    pub fn empty_mod(name: String) -> Self {
+        Value::empty_mod(name).into()
+    }
+    pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {
+        self.0.save(out)
+    }
+    pub fn load<R: Read + BufRead>(buf: &mut R, ctx: &CompCtx<'ctx>) -> io::Result<Self> {
+        Ok(Symbol(
+            Value::load(buf, ctx)?,
+            VariableData {
+                export: false,
+                ..VariableData::default()
+            },
+        ))
+    }
     pub fn dump(&self, depth: usize) {
         match self {
-            Symbol(Value {data_type: Type::Module, inter_val: Some(InterData::Module(s, i, n)), ..}, _) => {
+            Symbol(
+                Value {
+                    data_type: Type::Module,
+                    inter_val: Some(InterData::Module(s, i, n)),
+                    ..
+                },
+                _,
+            ) => {
                 let pre = " ".repeat(depth);
                 eprintln!("module {n:?}");
-                for (i, _) in i {eprintln!("{pre}    import: {i}")}
+                for (i, _) in i {
+                    eprintln!("{pre}    import: {i}")
+                }
                 for (k, s) in s {
                     eprint!("{pre}    {k:?}: ");
                     s.dump(depth + 4)
                 }
-            },
-            Symbol(Value {data_type: dt, ..}, _) => eprintln!("variable of type {dt}")
+            }
+            Symbol(Value { data_type: dt, .. }, _) => eprintln!("variable of type {dt}"),
         }
     }
 }
@@ -108,26 +156,70 @@ impl<'ctx> Symbol<'ctx> {
 pub struct VarMap<'ctx> {
     pub parent: Option<Box<VarMap<'ctx>>>,
     pub symbols: HashMap<String, Symbol<'ctx>>,
-    pub imports: Vec<(CompoundDottedName, bool)>
+    pub imports: Vec<(CompoundDottedName, bool)>,
 }
 impl<'ctx> VarMap<'ctx> {
-    pub fn new(parent: Option<Box<VarMap<'ctx>>>) -> Self {VarMap {parent, ..Self::default()}}
-    pub fn orphan(self) -> Self {VarMap {parent: None, ..self}}
-    pub fn reparent(self, parent: Box<VarMap<'ctx>>) -> Self {VarMap {parent: Some(parent), ..self}}
-    pub fn root(&self) -> &Self {self.parent.as_ref().map(|x| if x.parent.is_some() {x.root()} else {self}).unwrap_or(self)}
-    pub fn root_mut(&mut self) -> &mut Self {
-        if self.parent.is_some() && self.parent.as_ref().unwrap().parent.is_some(){
-            self.parent.as_mut().unwrap().root_mut()
+    pub fn new(parent: Option<Box<VarMap<'ctx>>>) -> Self {
+        VarMap {
+            parent,
+            ..Self::default()
         }
-        else {self}
     }
-    pub fn insert(&mut self, name: &DottedName, sym: Symbol<'ctx>) -> Result<&Symbol<'ctx>, RedefVariable<'ctx>> {
-        let mut this = if name.global {&mut self.root_mut().symbols} else {&mut self.symbols};
+    pub fn orphan(self) -> Self {
+        VarMap {
+            parent: None,
+            ..self
+        }
+    }
+    pub fn reparent(self, parent: Box<VarMap<'ctx>>) -> Self {
+        VarMap {
+            parent: Some(parent),
+            ..self
+        }
+    }
+    pub fn root(&self) -> &Self {
+        self.parent
+            .as_ref()
+            .map(|x| if x.parent.is_some() { x.root() } else { self })
+            .unwrap_or(self)
+    }
+    pub fn root_mut(&mut self) -> &mut Self {
+        if self.parent.is_some() && self.parent.as_ref().unwrap().parent.is_some() {
+            self.parent.as_mut().unwrap().root_mut()
+        } else {
+            self
+        }
+    }
+    pub fn insert(
+        &mut self,
+        name: &DottedName,
+        sym: Symbol<'ctx>,
+    ) -> Result<&Symbol<'ctx>, RedefVariable<'ctx>> {
+        let mut this = if name.global {
+            &mut self.root_mut().symbols
+        } else {
+            &mut self.symbols
+        };
         let mut idx = 0;
-        if name.ids.is_empty() {panic!("mod_insert cannot insert a value at an empty name")}
+        if name.ids.is_empty() {
+            panic!("mod_insert cannot insert a value at an empty name")
+        }
         while idx + 1 < name.ids.len() {
-            if let Symbol(Value {data_type: Type::Module, inter_val: Some(InterData::Module(x, _, _)), ..}, _) = this.entry(name.ids[idx].0.clone()).or_insert_with(|| Symbol::empty_mod(name.start(idx + 1).to_string())) {this = x}
-            else {return Err(RedefVariable::NotAModule(idx, sym))}
+            if let Symbol(
+                Value {
+                    data_type: Type::Module,
+                    inter_val: Some(InterData::Module(x, _, _)),
+                    ..
+                },
+                _,
+            ) = this
+                .entry(name.ids[idx].0.clone())
+                .or_insert_with(|| Symbol::empty_mod(name.start(idx + 1).to_string()))
+            {
+                this = x
+            } else {
+                return Err(RedefVariable::NotAModule(idx, sym));
+            }
             idx += 1;
         }
         match this.entry(name.ids[idx].0.clone()) {
@@ -137,56 +229,147 @@ impl<'ctx> VarMap<'ctx> {
                     let v = x.into_mut();
                     *v = sym;
                     Ok(&*v)
+                } else {
+                    Err(RedefVariable::AlreadyExists(idx, x.get().1.loc, sym))
                 }
-                else {Err(RedefVariable::AlreadyExists(idx, x.get().1.loc, sym))}
-            },
-            Entry::Vacant(x) => Ok(&*x.insert(sym))
+            }
+            Entry::Vacant(x) => Ok(&*x.insert(sym)),
         }
     }
-    pub fn insert_mod(&mut self, name: &DottedName, mut sym: (HashMap<String, Symbol<'ctx>>, Vec<(CompoundDottedName, bool)>), mod_name: String) -> Result<(&HashMap<String, Symbol<'ctx>>, &Vec<(CompoundDottedName, bool)>, &String), RedefVariable<'ctx>> {
-        let mut this = if name.global {&mut self.root_mut().symbols} else {&mut self.symbols};
+    pub fn insert_mod(
+        &mut self,
+        name: &DottedName,
+        mut sym: (
+            HashMap<String, Symbol<'ctx>>,
+            Vec<(CompoundDottedName, bool)>,
+        ),
+        mod_name: String,
+    ) -> Result<
+        (
+            &HashMap<String, Symbol<'ctx>>,
+            &Vec<(CompoundDottedName, bool)>,
+            &String,
+        ),
+        RedefVariable<'ctx>,
+    > {
+        let mut this = if name.global {
+            &mut self.root_mut().symbols
+        } else {
+            &mut self.symbols
+        };
         let mut idx = 0;
-        if name.ids.is_empty() {panic!("mod_insert cannot insert a value at an empty name")}
+        if name.ids.is_empty() {
+            panic!("mod_insert cannot insert a value at an empty name")
+        }
         let mut old = String::new();
         while idx + 1 < name.ids.len() {
-            if let Symbol(Value {data_type: Type::Module, inter_val: Some(InterData::Module(x, _, n)), ..}, _) = this.entry(name.ids[idx].0.clone()).or_insert_with(|| Symbol::empty_mod(old + "." + &name.ids[idx].0)) {
+            if let Symbol(
+                Value {
+                    data_type: Type::Module,
+                    inter_val: Some(InterData::Module(x, _, n)),
+                    ..
+                },
+                _,
+            ) = this
+                .entry(name.ids[idx].0.clone())
+                .or_insert_with(|| Symbol::empty_mod(old + "." + &name.ids[idx].0))
+            {
                 this = x;
                 old = n.clone();
+            } else {
+                return Err(RedefVariable::NotAModule(
+                    idx,
+                    Value::make_mod(sym.0, sym.1, mod_name).into(),
+                ));
             }
-            else {return Err(RedefVariable::NotAModule(idx, Value::make_mod(sym.0, sym.1, mod_name).into()))}
             idx += 1;
         }
         match this.entry(name.ids[idx].0.clone()) {
             Entry::Occupied(mut x) => match x.get_mut() {
-                Symbol(Value {data_type: Type::Module, inter_val: Some(InterData::Module(ref mut m, ref mut i, _)), ..}, _) => {
+                Symbol(
+                    Value {
+                        data_type: Type::Module,
+                        inter_val: Some(InterData::Module(ref mut m, ref mut i, _)),
+                        ..
+                    },
+                    _,
+                ) => {
                     *m = sym.0;
                     i.append(&mut sym.1);
                     Ok(x.into_mut().as_mod().unwrap())
-                },
-                Symbol(_, d) => Err(RedefVariable::AlreadyExists(idx, d.loc, Value::make_mod(sym.0, sym.1, mod_name).into()))
+                }
+                Symbol(_, d) => Err(RedefVariable::AlreadyExists(
+                    idx,
+                    d.loc,
+                    Value::make_mod(sym.0, sym.1, mod_name).into(),
+                )),
             },
-            Entry::Vacant(x) => Ok(x.insert(Value::make_mod(sym.0, sym.1, mod_name).into()).as_mod().unwrap())
+            Entry::Vacant(x) => Ok(x
+                .insert(Value::make_mod(sym.0, sym.1, mod_name).into())
+                .as_mod()
+                .unwrap()),
         }
     }
-    pub fn lookup_mod(&mut self, name: &DottedName) -> Result<(HashMap<String, Symbol<'ctx>>, Vec<(CompoundDottedName, bool)>, String), UndefVariable> {
-        let mut this = if name.global {&mut self.root_mut().symbols} else {&mut self.symbols};
+    pub fn lookup_mod(
+        &mut self,
+        name: &DottedName,
+    ) -> Result<
+        (
+            HashMap<String, Symbol<'ctx>>,
+            Vec<(CompoundDottedName, bool)>,
+            String,
+        ),
+        UndefVariable,
+    > {
+        let mut this = if name.global {
+            &mut self.root_mut().symbols
+        } else {
+            &mut self.symbols
+        };
         let mut idx = 0;
         let mut old = String::new();
-        if name.ids.is_empty() {panic!("mod_lookup_insert cannot find a module at an empty name")}
+        if name.ids.is_empty() {
+            panic!("mod_lookup_insert cannot find a module at an empty name")
+        }
         while idx + 1 < name.ids.len() {
-            if let Some((x, _, n)) = this.entry(name.ids[idx].0.clone()).or_insert_with(|| Symbol::empty_mod(old + "." + &name.ids[idx].0)).as_mod_mut() {
+            if let Some((x, _, n)) = this
+                .entry(name.ids[idx].0.clone())
+                .or_insert_with(|| Symbol::empty_mod(old + "." + &name.ids[idx].0))
+                .as_mod_mut()
+            {
                 this = x;
                 old = n.clone();
+            } else {
+                return Err(UndefVariable::NotAModule(idx));
             }
-            else {return Err(UndefVariable::NotAModule(idx))}
             idx += 1;
         }
         match this.entry(name.ids[idx].0.clone()) {
             Entry::Occupied(mut x) => match x.get_mut() {
-                Symbol(Value {data_type: Type::Module, ..}, _) => if let Symbol(Value {data_type: Type::Module, inter_val: Some(InterData::Module(s, i, n)), ..}, _) = x.remove() {Ok((s, i, n))} else {Err(UndefVariable::NotAModule(idx))},
-                Symbol(..) => Err(UndefVariable::DoesNotExist(idx)) // should be AlreadyExists, but DoesNotExist wouldn't arise here
+                Symbol(
+                    Value {
+                        data_type: Type::Module,
+                        ..
+                    },
+                    _,
+                ) => {
+                    if let Symbol(
+                        Value {
+                            data_type: Type::Module,
+                            inter_val: Some(InterData::Module(s, i, n)),
+                            ..
+                        },
+                        _,
+                    ) = x.remove()
+                    {
+                        Ok((s, i, n))
+                    } else {
+                        Err(UndefVariable::NotAModule(idx))
+                    }
+                }
+                Symbol(..) => Err(UndefVariable::DoesNotExist(idx)), // should be AlreadyExists, but DoesNotExist wouldn't arise here
             },
-            Entry::Vacant(_) => Ok(Default::default())
+            Entry::Vacant(_) => Ok(Default::default()),
         }
     }
     pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {
@@ -198,31 +381,64 @@ impl<'ctx> VarMap<'ctx> {
             }
         }
         out.write_all(&[0])?;
-        for import in self.imports.iter().filter_map(|(s, b)| if *b {Some(s)} else {None}) {
+        for import in self
+            .imports
+            .iter()
+            .filter_map(|(s, b)| if *b { Some(s) } else { None })
+        {
             import.save(out)?;
         }
         out.write_all(&[0])
     }
-    pub fn load<R: Read + BufRead>(&mut self, buf: &mut R, ctx: &CompCtx<'ctx>) -> io::Result<Vec<String>> {
+    pub fn load<R: Read + BufRead>(
+        &mut self,
+        buf: &mut R,
+        ctx: &CompCtx<'ctx>,
+    ) -> io::Result<Vec<String>> {
         let mut out = vec![];
         loop {
             let mut name = vec![];
             buf.read_until(0, &mut name)?;
-            if name.last() == Some(&0) {name.pop();}
-            if name.is_empty() {break}
+            if name.last() == Some(&0) {
+                name.pop();
+            }
+            if name.is_empty() {
+                break;
+            }
             let name = String::from_utf8(name).expect("Cobalt symbols should be valid UTF-8");
             match self.symbols.entry(name) {
                 Entry::Occupied(mut x) => match (x.get_mut(), Symbol::load(buf, ctx)?) {
-                    (Symbol(Value {data_type: Type::Module, inter_val: Some(InterData::Module(bs, bi, _)), ..}, _), Symbol(Value {data_type: Type::Module, inter_val: Some(InterData::Module(ns, mut ni, _)), ..}, _)) => {
+                    (
+                        Symbol(
+                            Value {
+                                data_type: Type::Module,
+                                inter_val: Some(InterData::Module(bs, bi, _)),
+                                ..
+                            },
+                            _,
+                        ),
+                        Symbol(
+                            Value {
+                                data_type: Type::Module,
+                                inter_val: Some(InterData::Module(ns, mut ni, _)),
+                                ..
+                            },
+                            _,
+                        ),
+                    ) => {
                         bi.append(&mut ni);
                         out.append(&mut merge(bs, ns));
-                    },
-                    _ => out.push(x.key().clone())
+                    }
+                    _ => out.push(x.key().clone()),
                 },
-                Entry::Vacant(x) => {x.insert(Symbol::load(buf, ctx)?);}
+                Entry::Vacant(x) => {
+                    x.insert(Symbol::load(buf, ctx)?);
+                }
             }
         }
-        while let Some(val) = CompoundDottedName::load(buf)? {self.imports.push((val, false));}
+        while let Some(val) = CompoundDottedName::load(buf)? {
+            self.imports.push((val, false));
+        }
         Ok(out)
     }
     pub fn load_new<R: Read + BufRead>(buf: &mut R, ctx: &CompCtx<'ctx>) -> io::Result<Self> {
@@ -231,104 +447,235 @@ impl<'ctx> VarMap<'ctx> {
         loop {
             let mut name = vec![];
             buf.read_until(0, &mut name)?;
-            if name.last() == Some(&0) {name.pop();}
-            if name.is_empty() {break}
-            out.insert(String::from_utf8(name).expect("Cobalt symbols should be valid UTF-8"), Symbol::load(buf, ctx)?);
+            if name.last() == Some(&0) {
+                name.pop();
+            }
+            if name.is_empty() {
+                break;
+            }
+            out.insert(
+                String::from_utf8(name).expect("Cobalt symbols should be valid UTF-8"),
+                Symbol::load(buf, ctx)?,
+            );
         }
-        while let Some(val) = CompoundDottedName::load(buf)? {imports.push((val, false));}
-        Ok(VarMap {parent: None, symbols: out, imports})
+        while let Some(val) = CompoundDottedName::load(buf)? {
+            imports.push((val, false));
+        }
+        Ok(VarMap {
+            parent: None,
+            symbols: out,
+            imports,
+        })
     }
     pub fn dump(&self) {
         eprintln!("top level");
-        self.imports.iter().for_each(|(i, _)| eprintln!("    import {i}"));
+        self.imports
+            .iter()
+            .for_each(|(i, _)| eprintln!("    import {i}"));
         self.symbols.iter().for_each(|(k, v)| {
             eprint!("    {k:?}: ");
             v.dump(4);
         })
     }
-    pub fn satisfy<'vm>((symbols, imports): (&'vm HashMap<String, Symbol<'ctx>>, &'vm Vec<(CompoundDottedName, bool)>), name: &str, pattern: &[CompoundDottedNameSegment], root: &'vm VarMap<'ctx>) -> Option<&'vm Symbol<'ctx>> {
+    pub fn satisfy<'vm>(
+        (symbols, imports): (
+            &'vm HashMap<String, Symbol<'ctx>>,
+            &'vm Vec<(CompoundDottedName, bool)>,
+        ),
+        name: &str,
+        pattern: &[CompoundDottedNameSegment],
+        root: &'vm VarMap<'ctx>,
+    ) -> Option<&'vm Symbol<'ctx>> {
         use CompoundDottedNameSegment::*;
         match pattern.first()? {
-            Identifier(x, _) =>
-                if pattern.len() == 1 {if x == name {symbols.get(name).or_else(|| imports.iter().filter_map(|(i, _)| if i.ends_with(name) {Some(i)} else {None}).find_map(|i| {
-                    Self::satisfy(if i.global {(&root.symbols, &root.imports)} else {(symbols, imports)}, name, &i.ids, root)
-                }))} else {None}}
-                else if let Some(Symbol(Value {data_type: Type::Module, inter_val: Some(InterData::Module(s, i, _)), ..}, _)) = symbols.get(x.as_str()) {
+            Identifier(x, _) => {
+                if pattern.len() == 1 {
+                    if x == name {
+                        symbols.get(name).or_else(|| {
+                            imports
+                                .iter()
+                                .filter_map(|(i, _)| if i.ends_with(name) { Some(i) } else { None })
+                                .find_map(|i| {
+                                    Self::satisfy(
+                                        if i.global {
+                                            (&root.symbols, &root.imports)
+                                        } else {
+                                            (symbols, imports)
+                                        },
+                                        name,
+                                        &i.ids,
+                                        root,
+                                    )
+                                })
+                        })
+                    } else {
+                        None
+                    }
+                } else if let Some(Symbol(
+                    Value {
+                        data_type: Type::Module,
+                        inter_val: Some(InterData::Module(s, i, _)),
+                        ..
+                    },
+                    _,
+                )) = symbols.get(x.as_str())
+                {
                     Self::satisfy((s, i), name, &pattern[1..], root)
-                } else {None},
-            Glob(_) =>
-                if pattern.len() == 1 {symbols.get(name).or_else(|| imports.iter().filter_map(|(i, _)| if i.ends_with(name) {Some(i)} else {None}).find_map(|i| {
-                    Self::satisfy(if i.global {(&root.symbols, &root.imports)} else {(symbols, imports)}, name, &i.ids, root)
-                }))}
-                else {
-                    symbols.values().find_map(|v| {
-                        if let Symbol(Value {data_type: Type::Module, inter_val: Some(InterData::Module(s, i, _)), ..}, _) = v {
-                            Self::satisfy((s, i), name, &pattern[1..], root)
-                        } else {None}
+                } else {
+                    None
+                }
+            }
+            Glob(_) => {
+                if pattern.len() == 1 {
+                    symbols.get(name).or_else(|| {
+                        imports
+                            .iter()
+                            .filter_map(|(i, _)| if i.ends_with(name) { Some(i) } else { None })
+                            .find_map(|i| {
+                                Self::satisfy(
+                                    if i.global {
+                                        (&root.symbols, &root.imports)
+                                    } else {
+                                        (symbols, imports)
+                                    },
+                                    name,
+                                    &i.ids,
+                                    root,
+                                )
+                            })
                     })
-                },
+                } else {
+                    symbols.values().find_map(|v| {
+                        if let Symbol(
+                            Value {
+                                data_type: Type::Module,
+                                inter_val: Some(InterData::Module(s, i, _)),
+                                ..
+                            },
+                            _,
+                        ) = v
+                        {
+                            Self::satisfy((s, i), name, &pattern[1..], root)
+                        } else {
+                            None
+                        }
+                    })
+                }
+            }
             Group(x) => x.iter().find_map(|v| {
                 let mut v = v.clone();
                 v.extend_from_slice(&pattern[1..]);
                 Self::satisfy((symbols, imports), name, &v, root)
-            })
+            }),
         }
     }
-    pub fn lookup_in_mod<'vm>((symbols, imports): (&'vm HashMap<String, Symbol<'ctx>>, &'vm Vec<(CompoundDottedName, bool)>), name: &str, root: &'vm VarMap<'ctx>) -> Option<&'vm Symbol<'ctx>> {
-        symbols.get(name).or_else(|| imports.iter().filter_map(|(i, _)| if i.ends_with(name) {Some(i)} else {None}).find_map(|i| {
-            Self::satisfy((symbols, imports), name, &i.ids, root)
-        }))
+    pub fn lookup_in_mod<'vm>(
+        (symbols, imports): (
+            &'vm HashMap<String, Symbol<'ctx>>,
+            &'vm Vec<(CompoundDottedName, bool)>,
+        ),
+        name: &str,
+        root: &'vm VarMap<'ctx>,
+    ) -> Option<&'vm Symbol<'ctx>> {
+        symbols.get(name).or_else(|| {
+            imports
+                .iter()
+                .filter_map(|(i, _)| if i.ends_with(name) { Some(i) } else { None })
+                .find_map(|i| Self::satisfy((symbols, imports), name, &i.ids, root))
+        })
     }
     pub fn lookup(&self, name: &str, global: bool) -> Option<&Symbol<'ctx>> {
         let root = self.root();
-        if global {root.lookup(name, false)}
-        else {
-            self.symbols.get(name).or_else(|| self.imports.iter().filter_map(|(i, _)| if i.ends_with(name) {Some(i)} else {None}).find_map(|i| {
-                let this = if i.global {self.root()} else {self};
-                Self::satisfy((&this.symbols, &this.imports), name, &i.ids, root)
-            })).or_else(|| self.parent.as_ref().and_then(|p| p.lookup(name, global)))
+        if global {
+            root.lookup(name, false)
+        } else {
+            self.symbols
+                .get(name)
+                .or_else(|| {
+                    self.imports
+                        .iter()
+                        .filter_map(|(i, _)| if i.ends_with(name) { Some(i) } else { None })
+                        .find_map(|i| {
+                            let this = if i.global { self.root() } else { self };
+                            Self::satisfy((&this.symbols, &this.imports), name, &i.ids, root)
+                        })
+                })
+                .or_else(|| self.parent.as_ref().and_then(|p| p.lookup(name, global)))
         }
     }
-    pub fn verify_in_mod<'vm>((symbols, imports): (&'vm HashMap<String, Symbol<'ctx>>, &'vm Vec<(CompoundDottedName, bool)>), pattern: &[CompoundDottedNameSegment], root: &'vm VarMap<'ctx>) -> Vec<SourceSpan> {
+    pub fn verify_in_mod<'vm>(
+        (symbols, imports): (
+            &'vm HashMap<String, Symbol<'ctx>>,
+            &'vm Vec<(CompoundDottedName, bool)>,
+        ),
+        pattern: &[CompoundDottedNameSegment],
+        root: &'vm VarMap<'ctx>,
+    ) -> Vec<SourceSpan> {
         use CompoundDottedNameSegment::*;
         match pattern.first() {
             None => vec![],
             Some(Identifier(x, l)) => match Self::lookup_in_mod((symbols, imports), x, root) {
                 Some(_) if pattern.len() == 1 => vec![],
-                Some(Symbol(Value {data_type: Type::Module, inter_val: Some(InterData::Module(s, i, _)), ..}, _)) => Self::verify_in_mod((s, i), &pattern[1..], root),
-                _ => vec![*l]
+                Some(Symbol(
+                    Value {
+                        data_type: Type::Module,
+                        inter_val: Some(InterData::Module(s, i, _)),
+                        ..
+                    },
+                    _,
+                )) => Self::verify_in_mod((s, i), &pattern[1..], root),
+                _ => vec![*l],
             },
-            Some(Glob(l)) =>
+            Some(Glob(l)) => {
                 if pattern.len() == 1 {
-                    if symbols.is_empty() && imports.is_empty() {vec![*l]}
-                    else {vec![]}
-                }
-                else {
-                    let mut ll = symbols.values().filter_map(|x| x.as_mod()).map(|(s, i, _)| {Self::verify_in_mod((s, i), &pattern[1..], root)}).collect::<LinkedList<_>>();
+                    if symbols.is_empty() && imports.is_empty() {
+                        vec![*l]
+                    } else {
+                        vec![]
+                    }
+                } else {
+                    let mut ll = symbols
+                        .values()
+                        .filter_map(|x| x.as_mod())
+                        .map(|(s, i, _)| Self::verify_in_mod((s, i), &pattern[1..], root))
+                        .collect::<LinkedList<_>>();
                     if let Some(mut out) = ll.pop_front() {
                         ll.into_iter().for_each(|v| out.retain(|l| v.contains(l)));
                         out
+                    } else {
+                        vec![]
                     }
-                    else {vec![]}
-                },
+                }
+            }
             Some(Group(x)) => {
-                let mut ll = x.iter().map(|v| {
-                    let mut vec = v.clone();
-                    vec.extend_from_slice(&pattern[1..]);
-                    Self::verify_in_mod((symbols, imports), &vec, root)
-                }).collect::<LinkedList<_>>();
+                let mut ll = x
+                    .iter()
+                    .map(|v| {
+                        let mut vec = v.clone();
+                        vec.extend_from_slice(&pattern[1..]);
+                        Self::verify_in_mod((symbols, imports), &vec, root)
+                    })
+                    .collect::<LinkedList<_>>();
                 if let Some(mut out) = ll.pop_front() {
                     ll.into_iter().for_each(|v| out.retain(|l| v.contains(l)));
                     out
+                } else {
+                    vec![]
                 }
-                else {vec![]}
             }
         }
     }
     pub fn verify(&self, pattern: &CompoundDottedName) -> Vec<SourceSpan> {
         let root = self.root();
-        if pattern.global && self.parent.as_ref().and_then(|p| p.parent.as_ref()).is_some() {root.verify(pattern)}
-        else {
+        if pattern.global
+            && self
+                .parent
+                .as_ref()
+                .and_then(|p| p.parent.as_ref())
+                .is_some()
+        {
+            root.verify(pattern)
+        } else {
             let mut vec = Self::verify_in_mod((&self.symbols, &self.imports), &pattern.ids, root);
             if let Some(p) = &self.parent {
                 let v2 = p.verify(pattern);
@@ -343,7 +690,7 @@ impl<'ctx> From<HashMap<String, Symbol<'ctx>>> for VarMap<'ctx> {
         VarMap {
             parent: None,
             symbols,
-            imports: Vec::new()
+            imports: Vec::new(),
         }
     }
 }
@@ -352,22 +699,44 @@ impl<'ctx> From<HashMap<String, Symbol<'ctx>>> for Box<VarMap<'ctx>> {
         Box::new(VarMap {
             parent: None,
             symbols,
-            imports: Vec::new()
+            imports: Vec::new(),
         })
     }
 }
-fn merge<'ctx>(base: &mut HashMap<String, Symbol<'ctx>>, new: HashMap<String, Symbol<'ctx>>) -> Vec<String> {
+fn merge<'ctx>(
+    base: &mut HashMap<String, Symbol<'ctx>>,
+    new: HashMap<String, Symbol<'ctx>>,
+) -> Vec<String> {
     let mut out = vec![];
     for (key, val) in new {
         match base.entry(key) {
             Entry::Occupied(mut e) => match (e.get_mut(), val) {
-                (Symbol(Value {data_type: Type::Module, inter_val: Some(InterData::Module(bs, bi, _)), ..}, _), Symbol(Value {data_type: Type::Module, inter_val: Some(InterData::Module(ns, mut ni, _)), ..}, _)) => {
+                (
+                    Symbol(
+                        Value {
+                            data_type: Type::Module,
+                            inter_val: Some(InterData::Module(bs, bi, _)),
+                            ..
+                        },
+                        _,
+                    ),
+                    Symbol(
+                        Value {
+                            data_type: Type::Module,
+                            inter_val: Some(InterData::Module(ns, mut ni, _)),
+                            ..
+                        },
+                        _,
+                    ),
+                ) => {
                     bi.append(&mut ni);
                     out.extend(merge(bs, ns).into_iter().map(|x| e.key().to_owned() + &x));
-                },
-                _ => out.push(e.key().clone())
+                }
+                _ => out.push(e.key().clone()),
             },
-            Entry::Vacant(e) => {e.insert(val);}
+            Entry::Vacant(e) => {
+                e.insert(val);
+            }
         }
     }
     out

--- a/cobalt-build/src/build.rs
+++ b/cobalt-build/src/build.rs
@@ -1,20 +1,20 @@
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::io::{Write, BufWriter};
-use cobalt_errors::miette::Severity;
-use serde::*;
-use either::Either;
-use semver::{Version, VersionReq};
-use path_calculate::*;
+use crate::*;
 use anyhow::Context;
 use anyhow_std::*;
-use indexmap::IndexMap;
-use os_str_bytes::OsStrBytes;
 use cobalt_ast::ast::*;
-use cobalt_utils::CellExt as Cell;
+use cobalt_errors::miette::Severity;
 use cobalt_errors::*;
 use cobalt_parser::prelude::*;
-use crate::*;
+use cobalt_utils::CellExt as Cell;
+use either::Either;
+use indexmap::IndexMap;
+use os_str_bytes::OsStrBytes;
+use path_calculate::*;
+use semver::{Version, VersionReq};
+use serde::*;
+use std::collections::HashMap;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
 #[derive(Debug, Clone)]
 pub struct Project {
     pub name: String,
@@ -22,7 +22,7 @@ pub struct Project {
     pub author: Option<String>,
     pub co_version: Option<VersionReq>,
     pub desc: Option<String>,
-    pub targets: HashMap<String, Target>
+    pub targets: HashMap<String, Target>,
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 pub enum TargetType {
@@ -31,13 +31,13 @@ pub enum TargetType {
     #[serde(rename = "lib", alias = "library")]
     Library,
     #[serde(rename = "meta")]
-    Meta
+    Meta,
 }
 #[derive(Debug, Clone)]
 pub struct Target {
     pub target_type: TargetType,
     pub files: Option<Either<String, Vec<String>>>,
-    pub deps: HashMap<String, Dependency>
+    pub deps: HashMap<String, Dependency>,
 }
 #[derive(Deserialize)]
 #[serde(rename = "target")]
@@ -48,7 +48,7 @@ struct TargetShim {
     #[serde(with = "either::serde_untagged_optional")]
     files: Option<Either<String, Vec<String>>>,
     #[serde(default)]
-    deps: HashMap<String, Dependency>
+    deps: HashMap<String, Dependency>,
 }
 #[derive(Deserialize)]
 #[serde(rename = "target")]
@@ -57,7 +57,7 @@ struct KnownTargetShim {
     #[serde(with = "either::serde_untagged_optional")]
     files: Option<Either<String, Vec<String>>>,
     #[serde(default)]
-    deps: HashMap<String, Dependency>
+    deps: HashMap<String, Dependency>,
 }
 impl<'de> Deserialize<'de> for Project {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -66,7 +66,9 @@ impl<'de> Deserialize<'de> for Project {
         struct ProjectVisitor;
         impl<'de> Visitor<'de> for ProjectVisitor {
             type Value = Project;
-            fn expecting(&self, f: &mut Formatter) -> fmt::Result {f.write_str("struct Project")}
+            fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                f.write_str("struct Project")
+            }
             fn visit_map<V: MapAccess<'de>>(self, mut map: V) -> Result<Project, V::Error> {
                 let mut name = None;
                 let mut version = None;
@@ -74,13 +76,28 @@ impl<'de> Deserialize<'de> for Project {
                 let mut co_version = None;
                 let mut desc = None;
                 let mut targets = HashMap::new();
-                enum Field {Name, Version, Author, CoVersion, Desc, Targets, Bin, Lib, Meta, Ignore}
+                enum Field {
+                    Name,
+                    Version,
+                    Author,
+                    CoVersion,
+                    Desc,
+                    Targets,
+                    Bin,
+                    Lib,
+                    Meta,
+                    Ignore,
+                }
                 impl<'de> Deserialize<'de> for Field {
-                    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Field, D::Error> {
+                    fn deserialize<D: Deserializer<'de>>(
+                        deserializer: D,
+                    ) -> Result<Field, D::Error> {
                         struct FieldVisitor;
                         impl<'de> Visitor<'de> for FieldVisitor {
                             type Value = Field;
-                            fn expecting(&self, f: &mut Formatter<'_>) -> fmt::Result {f.write_str("field identifier")}
+                            fn expecting(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                                f.write_str("field identifier")
+                            }
                             fn visit_str<E: Error>(self, v: &str) -> Result<Field, E> {
                                 Ok(match v {
                                     "name" => Field::Name,
@@ -92,7 +109,7 @@ impl<'de> Deserialize<'de> for Project {
                                     "bin" | "binary" | "exe" | "executable" => Field::Bin,
                                     "lib" | "library" => Field::Lib,
                                     "meta" => Field::Meta,
-                                    _ => Field::Ignore
+                                    _ => Field::Ignore,
                                 })
                             }
                         }
@@ -101,24 +118,122 @@ impl<'de> Deserialize<'de> for Project {
                 }
                 while let Some(key) = map.next_key()? {
                     match key {
-                        Field::Name => if name.is_some() {return Err(Error::duplicate_field("name"))} else {name = Some(map.next_value()?)}
-                        Field::Version => if version.is_some() {return Err(Error::duplicate_field("version"))} else {version = Some(map.next_value()?)}
-                        Field::Author => if author.is_some() {return Err(Error::duplicate_field("author"))} else {author = Some(map.next_value()?)}
-                        Field::CoVersion => if co_version.is_some() {return Err(Error::duplicate_field("co_version"))} else {co_version = Some(map.next_value()?)}
-                        Field::Desc => if desc.is_some() {return Err(Error::duplicate_field("desc"))} else {desc = Some(map.next_value()?)}
-                        Field::Targets => targets.extend(&mut map.next_value::<Vec<TargetShim>>()?.into_iter().map(|TargetShim {name, target_type, deps, files}| (name, Target {target_type, deps, files}))),
-                        Field::Bin => targets.extend(&mut map.next_value::<Vec<KnownTargetShim>>()?.into_iter().map(|KnownTargetShim {name, deps, files}| (name, Target {target_type: TargetType::Executable, deps, files}))),
-                        Field::Lib => targets.extend(&mut map.next_value::<Vec<KnownTargetShim>>()?.into_iter().map(|KnownTargetShim {name, deps, files}| (name, Target {target_type: TargetType::Library, deps, files}))),
-                        Field::Meta => targets.extend(&mut map.next_value::<Vec<KnownTargetShim>>()?.into_iter().map(|KnownTargetShim {name, deps, files}| (name, Target {target_type: TargetType::Meta, deps, files}))),
+                        Field::Name => {
+                            if name.is_some() {
+                                return Err(Error::duplicate_field("name"));
+                            } else {
+                                name = Some(map.next_value()?)
+                            }
+                        }
+                        Field::Version => {
+                            if version.is_some() {
+                                return Err(Error::duplicate_field("version"));
+                            } else {
+                                version = Some(map.next_value()?)
+                            }
+                        }
+                        Field::Author => {
+                            if author.is_some() {
+                                return Err(Error::duplicate_field("author"));
+                            } else {
+                                author = Some(map.next_value()?)
+                            }
+                        }
+                        Field::CoVersion => {
+                            if co_version.is_some() {
+                                return Err(Error::duplicate_field("co_version"));
+                            } else {
+                                co_version = Some(map.next_value()?)
+                            }
+                        }
+                        Field::Desc => {
+                            if desc.is_some() {
+                                return Err(Error::duplicate_field("desc"));
+                            } else {
+                                desc = Some(map.next_value()?)
+                            }
+                        }
+                        Field::Targets => targets.extend(
+                            &mut map.next_value::<Vec<TargetShim>>()?.into_iter().map(
+                                |TargetShim {
+                                     name,
+                                     target_type,
+                                     deps,
+                                     files,
+                                 }| {
+                                    (
+                                        name,
+                                        Target {
+                                            target_type,
+                                            deps,
+                                            files,
+                                        },
+                                    )
+                                },
+                            ),
+                        ),
+                        Field::Bin => targets.extend(
+                            &mut map.next_value::<Vec<KnownTargetShim>>()?.into_iter().map(
+                                |KnownTargetShim { name, deps, files }| {
+                                    (
+                                        name,
+                                        Target {
+                                            target_type: TargetType::Executable,
+                                            deps,
+                                            files,
+                                        },
+                                    )
+                                },
+                            ),
+                        ),
+                        Field::Lib => targets.extend(
+                            &mut map.next_value::<Vec<KnownTargetShim>>()?.into_iter().map(
+                                |KnownTargetShim { name, deps, files }| {
+                                    (
+                                        name,
+                                        Target {
+                                            target_type: TargetType::Library,
+                                            deps,
+                                            files,
+                                        },
+                                    )
+                                },
+                            ),
+                        ),
+                        Field::Meta => targets.extend(
+                            &mut map.next_value::<Vec<KnownTargetShim>>()?.into_iter().map(
+                                |KnownTargetShim { name, deps, files }| {
+                                    (
+                                        name,
+                                        Target {
+                                            target_type: TargetType::Meta,
+                                            deps,
+                                            files,
+                                        },
+                                    )
+                                },
+                            ),
+                        ),
                         Field::Ignore => {}
                     }
                 }
                 let name = name.ok_or_else(|| Error::missing_field("name"))?;
                 let version = version.ok_or_else(|| Error::missing_field("version"))?;
-                Ok(Project {name, version, author, co_version, desc, targets})
+                Ok(Project {
+                    name,
+                    version,
+                    author,
+                    co_version,
+                    desc,
+                    targets,
+                })
             }
         }
-        deserializer.deserialize_struct("Project", &["name", "version", "author", "co_version", "desc", "targets"], ProjectVisitor)
+        deserializer.deserialize_struct(
+            "Project",
+            &["name", "version", "author", "co_version", "desc", "targets"],
+            ProjectVisitor,
+        )
     }
 }
 #[derive(Debug, Clone)]
@@ -130,28 +245,30 @@ pub struct BuildOptions<'a> {
     pub rebuild: bool,
     pub triple: &'a inkwell::targets::TargetTriple,
     pub profile: &'a str,
-    pub link_dirs: Vec<&'a str>
+    pub link_dirs: Vec<&'a str>,
 }
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct PkgDepSpec {
     #[serde(default)]
     pub version: semver::VersionReq,
-    pub targets: Option<Vec<String>>
+    pub targets: Option<Vec<String>>,
 }
 #[derive(Debug, Clone)]
 pub enum Dependency {
     Project,
     System,
-    Package(PkgDepSpec)
+    Package(PkgDepSpec),
 }
 impl<'de> Deserialize<'de> for Dependency {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        use std::fmt::{self, Formatter};
         use serde::de::*;
+        use std::fmt::{self, Formatter};
         struct DepVisitor;
         impl<'de> Visitor<'de> for DepVisitor {
             type Value = Dependency;
-            fn expecting(&self, f: &mut Formatter) -> fmt::Result {f.write_str(r#""project", "version", or a version statement"#)}
+            fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                f.write_str(r#""project", "version", or a version statement"#)
+            }
             fn visit_str<E: Error>(self, v: &str) -> Result<Dependency, E> {
                 Ok(match v.trim() {
                     "project" => Dependency::Project,
@@ -160,34 +277,54 @@ impl<'de> Deserialize<'de> for Dependency {
                         let mut it = v.match_indices(['@', ':']).peekable();
                         if let Some(&(next, _)) = it.peek() {
                             let mut targets: Option<Vec<String>> = None;
-                            let mut version = VersionReq::parse(&v[..next]).map_err(Error::custom)?;
+                            let mut version =
+                                VersionReq::parse(&v[..next]).map_err(Error::custom)?;
                             while let Some((idx, ch)) = it.next() {
-                                let blk = if let Some(&(next, _)) = it.peek() {v[idx..next].trim()} else {v[idx..].trim()};
+                                let blk = if let Some(&(next, _)) = it.peek() {
+                                    v[idx..next].trim()
+                                } else {
+                                    v[idx..].trim()
+                                };
                                 match ch {
-                                    "@" => version.comparators.extend(VersionReq::parse(blk).map_err(Error::custom)?.comparators),
-                                    ":" => targets.get_or_insert_with(Vec::new).extend(blk.split(',').map(str::trim).map(String::from)),
-                                    x => unreachable!("expected '@' or ':', got {x:?}")
+                                    "@" => version.comparators.extend(
+                                        VersionReq::parse(blk).map_err(Error::custom)?.comparators,
+                                    ),
+                                    ":" => targets
+                                        .get_or_insert_with(Vec::new)
+                                        .extend(blk.split(',').map(str::trim).map(String::from)),
+                                    x => unreachable!("expected '@' or ':', got {x:?}"),
                                 }
                             }
-                            PkgDepSpec {targets, version}
+                            PkgDepSpec { targets, version }
+                        } else {
+                            PkgDepSpec {
+                                targets: None,
+                                version: VersionReq::parse(x).map_err(Error::custom)?,
+                            }
                         }
-                        else {PkgDepSpec {targets: None, version: VersionReq::parse(x).map_err(Error::custom)?}}
-                    })
+                    }),
                 })
             }
             fn visit_map<M: MapAccess<'de>>(self, mut v: M) -> Result<Dependency, M::Error> {
-                enum Field {Version, Targets}
+                enum Field {
+                    Version,
+                    Targets,
+                }
                 impl<'de> Deserialize<'de> for Field {
-                    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Field, D::Error> {
+                    fn deserialize<D: Deserializer<'de>>(
+                        deserializer: D,
+                    ) -> Result<Field, D::Error> {
                         struct FieldVisitor;
                         impl<'de> Visitor<'de> for FieldVisitor {
                             type Value = Field;
-                            fn expecting(&self, f: &mut Formatter) -> fmt::Result {f.write_str("`version` or `targets`")}
+                            fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                                f.write_str("`version` or `targets`")
+                            }
                             fn visit_str<E: Error>(self, v: &str) -> Result<Field, E> {
                                 match v {
                                     "version" => Ok(Field::Version),
                                     "targets" => Ok(Field::Targets),
-                                     _ => Err(Error::unknown_field(v, &["version", "targets"]))
+                                    _ => Err(Error::unknown_field(v, &["version", "targets"])),
                                 }
                             }
                         }
@@ -198,12 +335,24 @@ impl<'de> Deserialize<'de> for Dependency {
                 let mut version: Option<VersionReq> = None;
                 while let Some(key) = v.next_key()? {
                     match key {
-                        Field::Version => if version.is_some() {return Err(Error::duplicate_field("version"))} else {version = Some(v.next_value()?)}
-                        Field::Targets => if targets.is_some() {return Err(Error::duplicate_field("targets"))} else {targets = Some(v.next_value()?)}
+                        Field::Version => {
+                            if version.is_some() {
+                                return Err(Error::duplicate_field("version"));
+                            } else {
+                                version = Some(v.next_value()?)
+                            }
+                        }
+                        Field::Targets => {
+                            if targets.is_some() {
+                                return Err(Error::duplicate_field("targets"));
+                            } else {
+                                targets = Some(v.next_value()?)
+                            }
+                        }
                     }
                 }
                 let version = version.ok_or_else(|| Error::missing_field("version"))?;
-                Ok(Dependency::Package(PkgDepSpec {targets, version}))
+                Ok(Dependency::Package(PkgDepSpec { targets, version }))
             }
         }
         deserializer.deserialize_any(DepVisitor)
@@ -213,16 +362,26 @@ pub fn clear_mod(this: &mut HashMap<String, Symbol>) {
     for (_, sym) in this.iter_mut() {
         sym.1.export = false;
         match sym {
-            Symbol(Value {data_type: Type::Module, inter_val: Some(InterData::Module(m, ..)), ..}, _) => clear_mod(m),
-            Symbol(v, d) => if let Some(inkwell::values::BasicValueEnum::PointerValue(pv)) = v.comp_val {
-                if !d.fwd && d.init {
-                    unsafe {
-                        if matches!(v.data_type, Type::Function(..)) {
-                            let f = std::mem::transmute::<_, inkwell::values::FunctionValue>(pv);
-                            f.set_linkage(inkwell::module::Linkage::AvailableExternally);
-                        }
-                        else {
-                            std::mem::transmute::<_, inkwell::values::GlobalValue>(pv).set_externally_initialized(true)
+            Symbol(
+                Value {
+                    data_type: Type::Module,
+                    inter_val: Some(InterData::Module(m, ..)),
+                    ..
+                },
+                _,
+            ) => clear_mod(m),
+            Symbol(v, d) => {
+                if let Some(inkwell::values::BasicValueEnum::PointerValue(pv)) = v.comp_val {
+                    if !d.fwd && d.init {
+                        unsafe {
+                            if matches!(v.data_type, Type::Function(..)) {
+                                let f =
+                                    std::mem::transmute::<_, inkwell::values::FunctionValue>(pv);
+                                f.set_linkage(inkwell::module::Linkage::AvailableExternally);
+                            } else {
+                                std::mem::transmute::<_, inkwell::values::GlobalValue>(pv)
+                                    .set_externally_initialized(true)
+                            }
                         }
                     }
                 }
@@ -232,7 +391,12 @@ pub fn clear_mod(this: &mut HashMap<String, Symbol>) {
 }
 /// Start building a file
 /// This stops after running the prepasses to allow them to be run on all files before continuing
-fn build_file_1(path: &Path, ctx: &CompCtx, opts: &BuildOptions, force_build: bool) -> anyhow::Result<(([PathBuf; 2], bool), Option<TopLevelAST>)> {
+fn build_file_1(
+    path: &Path,
+    ctx: &CompCtx,
+    opts: &BuildOptions,
+    force_build: bool,
+) -> anyhow::Result<(([PathBuf; 2], bool), Option<TopLevelAST>)> {
     let mut out_path = opts.build_dir.to_path_buf();
     out_path.push(".artifacts");
     out_path.push("objects");
@@ -243,9 +407,21 @@ fn build_file_1(path: &Path, ctx: &CompCtx, opts: &BuildOptions, force_build: bo
     head_path.push("headers");
     head_path.push(path.strip_prefix(opts.source_dir).unwrap_or(path));
     head_path.set_extension("coh.o");
-    if !(force_build || opts.rebuild) && out_path.exists() && head_path.exists() && (|| Ok::<bool, std::io::Error>(path.metadata()?.modified()? < out_path.metadata()?.modified()?))().unwrap_or(false) { // lambda to propagate errors
+    if !(force_build || opts.rebuild)
+        && out_path.exists()
+        && head_path.exists()
+        && (|| {
+            Ok::<bool, std::io::Error>(
+                path.metadata()?.modified()? < out_path.metadata()?.modified()?,
+            )
+        })()
+        .unwrap_or(false)
+    {
+        // lambda to propagate errors
         let conflicts = libs::load_lib(&head_path, ctx)?;
-        if !conflicts.is_empty() {anyhow::bail!(libs::ConflictingDefs(conflicts))}
+        if !conflicts.is_empty() {
+            anyhow::bail!(libs::ConflictingDefs(conflicts))
+        }
         return Ok((([out_path, head_path], false), None));
     }
     let mut fail = false;
@@ -258,17 +434,31 @@ fn build_file_1(path: &Path, ctx: &CompCtx, opts: &BuildOptions, force_build: bo
     let (ast, errs) = parse_tl().parse(&lock).into_output_errors();
     let mut ast = ast.unwrap_or_default();
     let errs = errs.into_iter().flat_map(cvt_err);
-    for err in errs {fail |= err.severity.map_or(true, |e| e > Severity::Warning); eprintln!("{:?}", Report::from(err).with_source_code(file));}
+    for err in errs {
+        fail |= err.severity.map_or(true, |e| e > Severity::Warning);
+        eprintln!("{:?}", Report::from(err).with_source_code(file));
+    }
     ast.file = Some(file);
-    if fail && !opts.continue_comp {anyhow::bail!(CompileErrors)}
+    if fail && !opts.continue_comp {
+        anyhow::bail!(CompileErrors)
+    }
     ast.run_passes(ctx);
     Ok((([out_path, head_path], fail), Some(ast)))
 }
 /// Finish building the file
 /// This picks up where `build_file_1` left off
-fn build_file_2(ast: TopLevelAST, ctx: &CompCtx, opts: &BuildOptions, (out_path, head_path): (&Path, &Path), mut fail: bool) -> anyhow::Result<()> {
+fn build_file_2(
+    ast: TopLevelAST,
+    ctx: &CompCtx,
+    opts: &BuildOptions,
+    (out_path, head_path): (&Path, &Path),
+    mut fail: bool,
+) -> anyhow::Result<()> {
     let (_, errs) = ast.codegen(ctx);
-    for err in errs {fail |= err.is_err(); eprintln!("{:?}", err.with_file(ast.file.unwrap()));}
+    for err in errs {
+        fail |= err.is_err();
+        eprintln!("{:?}", err.with_file(ast.file.unwrap()));
+    }
     if fail && !opts.continue_comp {
         ctx.with_vars(|v| clear_mod(&mut v.symbols));
         anyhow::bail!(CompileErrors)
@@ -285,17 +475,26 @@ fn build_file_2(ast: TopLevelAST, ctx: &CompCtx, opts: &BuildOptions, (out_path,
     let pm = inkwell::passes::PassManager::create(());
     opt::load_profile(Some(opts.profile), &pm);
     pm.run_on(&ctx.module);
-    let target_machine = inkwell::targets::Target::from_triple(opts.triple).unwrap().create_target_machine(
-        opts.triple,
-        "",
-        "",
-        inkwell::OptimizationLevel::None,
-        inkwell::targets::RelocMode::PIC,
-        inkwell::targets::CodeModel::Small
-    ).expect("failed to create target machine");
-    if !out_path.parent().unwrap().exists() {out_path.parent().unwrap().create_dir_all_anyhow()?}
-    if !head_path.parent().unwrap().exists() {head_path.parent().unwrap().create_dir_all_anyhow()?}
-    target_machine.write_to_file(&ctx.module, inkwell::targets::FileType::Object, out_path).unwrap();
+    let target_machine = inkwell::targets::Target::from_triple(opts.triple)
+        .unwrap()
+        .create_target_machine(
+            opts.triple,
+            "",
+            "",
+            inkwell::OptimizationLevel::None,
+            inkwell::targets::RelocMode::PIC,
+            inkwell::targets::CodeModel::Small,
+        )
+        .expect("failed to create target machine");
+    if !out_path.parent().unwrap().exists() {
+        out_path.parent().unwrap().create_dir_all_anyhow()?
+    }
+    if !head_path.parent().unwrap().exists() {
+        head_path.parent().unwrap().create_dir_all_anyhow()?
+    }
+    target_machine
+        .write_to_file(&ctx.module, inkwell::targets::FileType::Object, out_path)
+        .unwrap();
     let mut obj = libs::new_object(opts.triple);
     libs::populate_header(&mut obj, ctx);
     let mut file = BufWriter::new(std::fs::File::create(head_path)?);
@@ -307,7 +506,15 @@ fn build_file_2(ast: TopLevelAST, ctx: &CompCtx, opts: &BuildOptions, (out_path,
 /// Resolve dependencies for `build_target_single`
 /// This replaces project dependencies with packages, checks `plan` for installation versions, and
 /// assumes that all dependencies are already built
-fn resolve_deps_internal(ctx: &CompCtx, cmd: &mut cc::CompileCommand, t: &Target, pkg: &str, v: &Version, plan: &IndexMap<(&str, &str), Version>, opts: &BuildOptions) -> anyhow::Result<()> {
+fn resolve_deps_internal(
+    ctx: &CompCtx,
+    cmd: &mut cc::CompileCommand,
+    t: &Target,
+    pkg: &str,
+    v: &Version,
+    plan: &IndexMap<(&str, &str), Version>,
+    opts: &BuildOptions,
+) -> anyhow::Result<()> {
     let mut libs = vec![];
     let mut conflicts = vec![];
     let mut installed_path = cobalt_dir()?;
@@ -321,26 +528,47 @@ fn resolve_deps_internal(ctx: &CompCtx, cmd: &mut cc::CompileCommand, t: &Target
                 artifact.push(target);
                 conflicts.append(&mut libs::load_lib(&artifact, ctx)?);
                 cmd.link_abs(artifact);
-            },
+            }
             Dependency::System => libs.push(target.clone()),
-            Dependency::Package(spec) => spec.targets.clone().unwrap_or_else(|| vec!["default".to_string()]).into_iter().try_for_each(|tar| {
-                let mut path = installed_path.clone();
-                path.push(target);
-                path.push(plan[&(target.as_str(), tar.as_str())].to_string());
-                path.push(tar);
-                conflicts.append(&mut libs::load_lib(&path, ctx)?);
-                cmd.link_abs(path);
-                anyhow::Ok(())
-            })?
+            Dependency::Package(spec) => spec
+                .targets
+                .clone()
+                .unwrap_or_else(|| vec!["default".to_string()])
+                .into_iter()
+                .try_for_each(|tar| {
+                    let mut path = installed_path.clone();
+                    path.push(target);
+                    path.push(plan[&(target.as_str(), tar.as_str())].to_string());
+                    path.push(tar);
+                    conflicts.append(&mut libs::load_lib(&path, ctx)?);
+                    cmd.link_abs(path);
+                    anyhow::Ok(())
+                })?,
         }
     }
-    if !conflicts.is_empty() {anyhow::bail!(libs::ConflictingDefs(conflicts))}
-    let notfound = cmd.search_libs(libs, opts.link_dirs.iter().copied().map(String::from), Some(ctx), false)?;
-    if !notfound.is_empty() {anyhow::bail!(LibsNotFound(notfound))}
+    if !conflicts.is_empty() {
+        anyhow::bail!(libs::ConflictingDefs(conflicts))
+    }
+    let notfound = cmd.search_libs(
+        libs,
+        opts.link_dirs.iter().copied().map(String::from),
+        Some(ctx),
+        false,
+    )?;
+    if !notfound.is_empty() {
+        anyhow::bail!(LibsNotFound(notfound))
+    }
     Ok(())
 }
 /// Build a single target, for use in package installation
-pub fn build_target_single(t: &Target, pkg: &str, name: &str, v: &Version, plan: &IndexMap<(&str, &str), Version>, opts: &BuildOptions) -> anyhow::Result<PathBuf> {
+pub fn build_target_single(
+    t: &Target,
+    pkg: &str,
+    name: &str,
+    v: &Version,
+    plan: &IndexMap<(&str, &str), Version>,
+    opts: &BuildOptions,
+) -> anyhow::Result<PathBuf> {
     let ink_ctx = inkwell::context::Context::create();
     let mut ctx = CompCtx::new(&ink_ctx, "");
     ctx.flags.prepass = false;
@@ -353,55 +581,111 @@ pub fn build_target_single(t: &Target, pkg: &str, name: &str, v: &Version, plan:
             let mut asts = vec![];
             match t.files.as_ref() {
                 Some(either::Left(files)) => {
-                    for file in glob::glob((opts.source_dir.to_str().unwrap_or("").to_string() + "/" + files).as_str()).context("error in file glob")?.filter_map(Result::ok) {
-                        if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {continue}
+                    for file in glob::glob(
+                        (opts.source_dir.to_str().unwrap_or("").to_string() + "/" + files).as_str(),
+                    )
+                    .context("error in file glob")?
+                    .filter_map(Result::ok)
+                    {
+                        if std::fs::metadata(&file)
+                            .map(|m| !m.file_type().is_file())
+                            .unwrap_or(true)
+                        {
+                            continue;
+                        }
                         let (path, ast) = build_file_1(file.as_path(), &ctx, opts, true)?;
                         paths.push(path);
                         asts.push(ast);
                     }
-                },
+                }
                 Some(either::Right(files)) => {
-                    for file in files.iter().filter_map(|f| Some(opts.source_dir.to_str()?.to_string() + "/" + f)) {
-                        if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {anyhow::bail!("couldn't find file {file}")}
+                    for file in files
+                        .iter()
+                        .filter_map(|f| Some(opts.source_dir.to_str()?.to_string() + "/" + f))
+                    {
+                        if std::fs::metadata(&file)
+                            .map(|m| !m.file_type().is_file())
+                            .unwrap_or(true)
+                        {
+                            anyhow::bail!("couldn't find file {file}")
+                        }
                         let (path, ast) = build_file_1(Path::new(&file), &ctx, opts, true)?;
                         paths.push(path);
                         asts.push(ast);
                     }
-                },
-                None => anyhow::bail!("target must have files")
+                }
+                None => anyhow::bail!("target must have files"),
             }
-            paths.iter().zip(asts).try_for_each(|(([p1, p2], fail), ast)| if let Some(ast) = ast {build_file_2(ast, &ctx, opts, (p1, p2), *fail)} else {Ok(())})?;
+            paths
+                .iter()
+                .zip(asts)
+                .try_for_each(|(([p1, p2], fail), ast)| {
+                    if let Some(ast) = ast {
+                        build_file_2(ast, &ctx, opts, (p1, p2), *fail)
+                    } else {
+                        Ok(())
+                    }
+                })?;
             let mut output = opts.build_dir.to_path_buf();
             output.push(name);
             cc.objs(paths.into_iter().map(|([x, _], _)| x));
             cc.output(&output);
             let code = cc.build_cmd()?.status_anyhow()?.code().unwrap_or(-1);
-            if code != 0 {anyhow::bail!("C compiler exited with code {code}")}
+            if code != 0 {
+                anyhow::bail!("C compiler exited with code {code}")
+            }
             Ok(output)
-        },
+        }
         TargetType::Library => {
             let mut asts = vec![];
             let mut paths = vec![];
             match t.files.as_ref() {
                 Some(either::Left(files)) => {
-                    for file in glob::glob((opts.source_dir.to_str().unwrap_or("").to_string() + "/" + files).as_str()).context("error in file glob")?.filter_map(Result::ok) {
-                        if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {continue}
+                    for file in glob::glob(
+                        (opts.source_dir.to_str().unwrap_or("").to_string() + "/" + files).as_str(),
+                    )
+                    .context("error in file glob")?
+                    .filter_map(Result::ok)
+                    {
+                        if std::fs::metadata(&file)
+                            .map(|m| !m.file_type().is_file())
+                            .unwrap_or(true)
+                        {
+                            continue;
+                        }
                         let (path, ast) = build_file_1(file.as_path(), &ctx, opts, true)?;
                         paths.push(path);
                         asts.push(ast);
                     }
-                },
+                }
                 Some(either::Right(files)) => {
-                    for file in files.iter().filter_map(|f| Some(opts.source_dir.to_str()?.to_string() + "/" + f)) {
-                        if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {anyhow::bail!("couldn't find file {file}")}
+                    for file in files
+                        .iter()
+                        .filter_map(|f| Some(opts.source_dir.to_str()?.to_string() + "/" + f))
+                    {
+                        if std::fs::metadata(&file)
+                            .map(|m| !m.file_type().is_file())
+                            .unwrap_or(true)
+                        {
+                            anyhow::bail!("couldn't find file {file}")
+                        }
                         let (path, ast) = build_file_1(Path::new(&file), &ctx, opts, true)?;
                         paths.push(path);
                         asts.push(ast);
                     }
-                },
-                None => anyhow::bail!("target must have files")
+                }
+                None => anyhow::bail!("target must have files"),
             }
-            paths.iter().zip(asts).try_for_each(|(([p1, p2], fail), ast)| if let Some(ast) = ast {build_file_2(ast, &ctx, opts, (p1, p2), *fail)} else {Ok(())})?;
+            paths
+                .iter()
+                .zip(asts)
+                .try_for_each(|(([p1, p2], fail), ast)| {
+                    if let Some(ast) = ast {
+                        build_file_2(ast, &ctx, opts, (p1, p2), *fail)
+                    } else {
+                        Ok(())
+                    }
+                })?;
             let mut output = opts.build_dir.to_path_buf();
             output.push(name);
             let mut cc = cc::CompileCommand::new();
@@ -409,9 +693,11 @@ pub fn build_target_single(t: &Target, pkg: &str, name: &str, v: &Version, plan:
             cc.objs(paths.into_iter().flat_map(|x| x.0));
             cc.output(&output);
             let code = cc.build_cmd()?.status_anyhow()?.code().unwrap_or(-1);
-            if code != 0 {anyhow::bail!("C compiler exited with code {code}")}
+            if code != 0 {
+                anyhow::bail!("C compiler exited with code {code}")
+            }
             Ok(output)
-        },
+        }
         TargetType::Meta => {
             let output = opts.build_dir.join(name);
             let mut vec = Vec::new();
@@ -428,7 +714,13 @@ pub fn build_target_single(t: &Target, pkg: &str, name: &str, v: &Version, plan:
 /// Resolve dependencies for a target
 /// The header is loaded into the compilation context, and it returns a tuple containing if a
 /// dependency has been rebuilt and a Vec containing the files that need to be linked
-fn resolve_deps(ctx: &CompCtx, cmd: &mut cc::CompileCommand, t: &Target, targets: &HashMap<String, (Target, Cell<Option<PathBuf>>)>, opts: &BuildOptions) -> anyhow::Result<bool> {
+fn resolve_deps(
+    ctx: &CompCtx,
+    cmd: &mut cc::CompileCommand,
+    t: &Target,
+    targets: &HashMap<String, (Target, Cell<Option<PathBuf>>)>,
+    opts: &BuildOptions,
+) -> anyhow::Result<bool> {
     let mut out = vec![];
     let mut libs = vec![];
     let mut conflicts = vec![];
@@ -437,38 +729,85 @@ fn resolve_deps(ctx: &CompCtx, cmd: &mut cc::CompileCommand, t: &Target, targets
     for (target, version) in t.deps.iter() {
         match version {
             Dependency::Project => {
-                let (t, d) = if let Some(t) = targets.get(target.as_str()) {t} else {anyhow::bail!("target {target:?} is not a target in this project")};
-                if d.with(|d| if let Some(a) = d {libs::load_lib(a, ctx)?; anyhow::Ok(true)} else {anyhow::Ok(false)})? {continue}
+                let (t, d) = if let Some(t) = targets.get(target.as_str()) {
+                    t
+                } else {
+                    anyhow::bail!("target {target:?} is not a target in this project")
+                };
+                if d.with(|d| {
+                    if let Some(a) = d {
+                        libs::load_lib(a, ctx)?;
+                        anyhow::Ok(true)
+                    } else {
+                        anyhow::Ok(false)
+                    }
+                })? {
+                    continue;
+                }
                 let (c, artifact) = build_target(t, target, d, targets, opts)?;
                 changed |= c;
                 libs::load_lib(&artifact, ctx)?;
                 cmd.link_abs(artifact);
-            },
+            }
             Dependency::System => libs.push(target.clone()),
-            Dependency::Package(PkgDepSpec {version, targets}) => to_install.push(pkg::InstallSpec {name: target.clone(), version: version.clone(), targets: targets.clone()})
+            Dependency::Package(PkgDepSpec { version, targets }) => {
+                to_install.push(pkg::InstallSpec {
+                    name: target.clone(),
+                    version: version.clone(),
+                    targets: targets.clone(),
+                })
+            }
         }
     }
     if !to_install.is_empty() {
-        let plan = pkg::install(to_install.iter().cloned(), &pkg::InstallOptions {target: opts.triple.as_str().to_str().unwrap().to_string(), ..Default::default()})?;
+        let plan = pkg::install(
+            to_install.iter().cloned(),
+            &pkg::InstallOptions {
+                target: opts.triple.as_str().to_str().unwrap().to_string(),
+                ..Default::default()
+            },
+        )?;
         let mut installed_path = cobalt_dir()?;
         installed_path.push("installed");
-        to_install.into_iter().try_for_each(|pkg::InstallSpec {name, targets, ..}| targets.unwrap_or_else(|| vec!["default".to_string()]).into_iter().try_for_each(|target| {
-            let mut path = installed_path.clone();
-            path.push(&name);
-            path.push(plan[&(name.as_str(), target.as_str())].to_string());
-            path.push(&target);
-            conflicts.append(&mut libs::load_lib(&path, ctx)?);
-            out.push(path);
-            anyhow::Ok(())
-        }))?;
+        to_install
+            .into_iter()
+            .try_for_each(|pkg::InstallSpec { name, targets, .. }| {
+                targets
+                    .unwrap_or_else(|| vec!["default".to_string()])
+                    .into_iter()
+                    .try_for_each(|target| {
+                        let mut path = installed_path.clone();
+                        path.push(&name);
+                        path.push(plan[&(name.as_str(), target.as_str())].to_string());
+                        path.push(&target);
+                        conflicts.append(&mut libs::load_lib(&path, ctx)?);
+                        out.push(path);
+                        anyhow::Ok(())
+                    })
+            })?;
     }
-    if !conflicts.is_empty() {anyhow::bail!(libs::ConflictingDefs(conflicts))}
-    let notfound = cmd.search_libs(libs, opts.link_dirs.iter().copied().map(String::from), Some(ctx), false)?;
-    if !notfound.is_empty() {anyhow::bail!(LibsNotFound(notfound))}
+    if !conflicts.is_empty() {
+        anyhow::bail!(libs::ConflictingDefs(conflicts))
+    }
+    let notfound = cmd.search_libs(
+        libs,
+        opts.link_dirs.iter().copied().map(String::from),
+        Some(ctx),
+        false,
+    )?;
+    if !notfound.is_empty() {
+        anyhow::bail!(LibsNotFound(notfound))
+    }
     Ok(changed)
 }
 /// Build a single target. This is used with the `build` entry function
-fn build_target(t: &Target, name: &str, data: &Cell<Option<PathBuf>>, targets: &HashMap<String, (Target, Cell<Option<PathBuf>>)>, opts: &BuildOptions) -> anyhow::Result<(bool, PathBuf)> {
+fn build_target(
+    t: &Target,
+    name: &str,
+    data: &Cell<Option<PathBuf>>,
+    targets: &HashMap<String, (Target, Cell<Option<PathBuf>>)>,
+    opts: &BuildOptions,
+) -> anyhow::Result<(bool, PathBuf)> {
     let ink_ctx = inkwell::context::Context::create();
     let mut ctx = CompCtx::new(&ink_ctx, "");
     ctx.flags.prepass = false;
@@ -482,26 +821,45 @@ fn build_target(t: &Target, name: &str, data: &Cell<Option<PathBuf>>, targets: &
             match t.files.as_ref() {
                 Some(either::Left(files)) => {
                     let mut passed = false;
-                    for file in glob::glob((opts.source_dir.to_str().unwrap_or("").to_string() + "/" + files).as_str()).context("error in file glob")?.filter_map(Result::ok) {
-                        if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {continue}
+                    for file in glob::glob(
+                        (opts.source_dir.to_str().unwrap_or("").to_string() + "/" + files).as_str(),
+                    )
+                    .context("error in file glob")?
+                    .filter_map(Result::ok)
+                    {
+                        if std::fs::metadata(&file)
+                            .map(|m| !m.file_type().is_file())
+                            .unwrap_or(true)
+                        {
+                            continue;
+                        }
                         let (path, ast) = build_file_1(file.as_path(), &ctx, opts, rebuild)?;
                         changed |= ast.is_some();
                         paths.push(path);
                         asts.push(ast);
                         passed = true;
                     }
-                    if !passed {warning!("no files matching glob {files}")}
-                },
+                    if !passed {
+                        warning!("no files matching glob {files}")
+                    }
+                }
                 Some(either::Right(files)) => {
                     let mut failed = None;
-                    for file in files.iter().filter_map(|f| Some(opts.source_dir.to_str()?.to_string() + "/" + f)) {
-                        if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {
+                    for file in files
+                        .iter()
+                        .filter_map(|f| Some(opts.source_dir.to_str()?.to_string() + "/" + f))
+                    {
+                        if std::fs::metadata(&file)
+                            .map(|m| !m.file_type().is_file())
+                            .unwrap_or(true)
+                        {
                             if opts.continue_build {
                                 error!("couldn't find file {file}");
                                 failed = Some(file);
-                                continue
+                                continue;
+                            } else {
+                                anyhow::bail!("couldn't find file {file}")
                             }
-                            else {anyhow::bail!("couldn't find file {file}")}
                         }
                         let (path, ast) = build_file_1(Path::new(&file), &ctx, opts, rebuild)?;
                         changed |= ast.is_some();
@@ -511,45 +869,75 @@ fn build_target(t: &Target, name: &str, data: &Cell<Option<PathBuf>>, targets: &
                     if let Some(file) = failed {
                         anyhow::bail!("couldn't find file {file}")
                     }
-                },
-                None => anyhow::bail!("target must have files")
+                }
+                None => anyhow::bail!("target must have files"),
             }
-            paths.iter().zip(asts).try_for_each(|(([p1, p2], fail), ast)| if let Some(ast) = ast {build_file_2(ast, &ctx, opts, (p1, p2), *fail)} else {Ok(())})?;
+            paths
+                .iter()
+                .zip(asts)
+                .try_for_each(|(([p1, p2], fail), ast)| {
+                    if let Some(ast) = ast {
+                        build_file_2(ast, &ctx, opts, (p1, p2), *fail)
+                    } else {
+                        Ok(())
+                    }
+                })?;
             let mut output = opts.build_dir.to_path_buf();
             output.push(name);
             cc.objs(paths.into_iter().map(|([x, _], _)| x));
             cc.output(&output);
             let code = cc.build_cmd()?.status_anyhow()?.code().unwrap_or(-1);
-            if code != 0 {anyhow::bail!("C compiler exited with code {code}")}
+            if code != 0 {
+                anyhow::bail!("C compiler exited with code {code}")
+            }
             data.set(Some(output.clone()));
             Ok((changed, output))
-        },
+        }
         TargetType::Library => {
             let mut asts = vec![];
             let mut paths = vec![];
             match t.files.as_ref() {
                 Some(either::Left(files)) => {
                     let mut passed = false;
-                    for file in glob::glob((opts.source_dir.to_str().unwrap_or("").to_string() + "/" + files).as_str()).context("error in file glob")?.filter_map(Result::ok) {
-                        if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {continue}
+                    for file in glob::glob(
+                        (opts.source_dir.to_str().unwrap_or("").to_string() + "/" + files).as_str(),
+                    )
+                    .context("error in file glob")?
+                    .filter_map(Result::ok)
+                    {
+                        if std::fs::metadata(&file)
+                            .map(|m| !m.file_type().is_file())
+                            .unwrap_or(true)
+                        {
+                            continue;
+                        }
                         let (path, ast) = build_file_1(file.as_path(), &ctx, opts, rebuild)?;
                         changed |= ast.is_some();
                         paths.push(path);
                         asts.push(ast);
                         passed = true;
                     }
-                    if !passed {warning!("no files matching glob {files}")}
-                },
+                    if !passed {
+                        warning!("no files matching glob {files}")
+                    }
+                }
                 Some(either::Right(files)) => {
                     let mut failed = None;
-                    for file in files.iter().filter_map(|f| Some(opts.source_dir.to_str()?.to_string() + "/" + f)) {
-                        if std::fs::metadata(&file).map(|m| !m.file_type().is_file()).unwrap_or(true) {
+                    for file in files
+                        .iter()
+                        .filter_map(|f| Some(opts.source_dir.to_str()?.to_string() + "/" + f))
+                    {
+                        if std::fs::metadata(&file)
+                            .map(|m| !m.file_type().is_file())
+                            .unwrap_or(true)
+                        {
                             if opts.continue_build {
                                 error!("couldn't find file {file}");
                                 failed = Some(file);
-                                continue
+                                continue;
+                            } else {
+                                anyhow::bail!("couldn't find file {file}")
                             }
-                            else {anyhow::bail!("couldn't find file {file}")}
                         }
                         let (path, ast) = build_file_1(Path::new(&file), &ctx, opts, rebuild)?;
                         changed |= ast.is_some();
@@ -559,20 +947,31 @@ fn build_target(t: &Target, name: &str, data: &Cell<Option<PathBuf>>, targets: &
                     if let Some(file) = failed {
                         anyhow::bail!("couldn't find file {file}")
                     }
-                },
-                None => anyhow::bail!("target must have files")
+                }
+                None => anyhow::bail!("target must have files"),
             }
-            paths.iter().zip(asts).try_for_each(|(([p1, p2], fail), ast)| if let Some(ast) = ast {build_file_2(ast, &ctx, opts, (p1, p2), *fail)} else {Ok(())})?;
+            paths
+                .iter()
+                .zip(asts)
+                .try_for_each(|(([p1, p2], fail), ast)| {
+                    if let Some(ast) = ast {
+                        build_file_2(ast, &ctx, opts, (p1, p2), *fail)
+                    } else {
+                        Ok(())
+                    }
+                })?;
             let mut output = opts.build_dir.to_path_buf();
             output.push(libs::format_lib(name, opts.triple));
             cc.lib(true);
             cc.objs(paths.into_iter().flat_map(|x| x.0));
             cc.output(&output);
             let code = cc.build_cmd()?.status_anyhow()?.code().unwrap_or(-1);
-            if code != 0 {anyhow::bail!("C compiler exited with code {code}")}
+            if code != 0 {
+                anyhow::bail!("C compiler exited with code {code}")
+            }
             data.set(Some(output.clone()));
             Ok((changed, output))
-        },
+        }
         TargetType::Meta => {
             let output = opts.build_dir.join(name.to_string() + ".meta");
             let mut vec = Vec::new();
@@ -588,25 +987,41 @@ fn build_target(t: &Target, name: &str, data: &Cell<Option<PathBuf>>, targets: &
     }
 }
 /// Build the project. If to_build is None, all targets are built
-pub fn build(pkg: Project, to_build: Option<Vec<String>>, opts: &BuildOptions) -> anyhow::Result<()> {
+pub fn build(
+    pkg: Project,
+    to_build: Option<Vec<String>>,
+    opts: &BuildOptions,
+) -> anyhow::Result<()> {
     if let Some(v) = &pkg.co_version {
         if !v.matches(&env!("CARGO_PKG_VERSION").parse::<Version>().unwrap()) {
-            anyhow::bail!(r#"project has Cobalt version requirement "{v}", but Cobalt version is {}"#, env!("CARGO_PKG_VERSION"));
+            anyhow::bail!(
+                r#"project has Cobalt version requirement "{v}", but Cobalt version is {}"#,
+                env!("CARGO_PKG_VERSION")
+            );
         }
     }
-    let targets = pkg.targets.into_iter().map(|(n, t)| (n, (t, Cell::default()))).collect::<HashMap<_, (Target, Cell<Option<PathBuf>>)>>();
+    let targets = pkg
+        .targets
+        .into_iter()
+        .map(|(n, t)| (n, (t, Cell::default())))
+        .collect::<HashMap<_, (Target, Cell<Option<PathBuf>>)>>();
     if let Some(tb) = to_build {
         for target_name in tb {
-            let (target, data) = if let Some(t) = targets.get(&target_name) {t} else {
+            let (target, data) = if let Some(t) = targets.get(&target_name) {
+                t
+            } else {
                 anyhow::bail!("target {target_name:?} is not a target in this project");
             };
-            if data.with(|x| x.is_some()) {continue}
+            if data.with(|x| x.is_some()) {
+                continue;
+            }
             build_target(target, &target_name, data, &targets, opts)?;
         }
-    }
-    else {
+    } else {
         for (name, (target, data)) in targets.iter() {
-            if data.with(|x| x.is_some()) {continue}
+            if data.with(|x| x.is_some()) {
+                continue;
+            }
             build_target(target, name, data, &targets, opts)?;
         }
     }

--- a/cobalt-build/src/graph.rs
+++ b/cobalt-build/src/graph.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
+use crate::{build, pkg};
+use lasso::{Spur, ThreadedRodeo};
+use semver::{Comparator, Version, VersionReq};
 use std::collections::{HashMap, VecDeque};
-use semver::{Version, VersionReq, Comparator};
-use lasso::{ThreadedRodeo, Spur};
-use crate::{pkg, build};
 pub type Id = Spur;
 lazy_static::lazy_static! {
     pub static ref STRINGS: ThreadedRodeo = ThreadedRodeo::new();
@@ -12,7 +12,7 @@ struct PkgNode {
     pub comps: Vec<(Comparator, (Id, Id))>,
     pub dependencies: Vec<((Id, Id), VersionReq)>,
     pub dependents: usize,
-    pub init: bool
+    pub init: bool,
 }
 impl Default for PkgNode {
     fn default() -> Self {
@@ -21,7 +21,7 @@ impl Default for PkgNode {
             comps: vec![],
             dependencies: vec![],
             dependents: 0,
-            init: false
+            init: false,
         }
     }
 }
@@ -29,35 +29,99 @@ impl PkgNode {
     /// Update the dependency graph
     /// If this node was already visited, check to see if the same version is still applicable and
     /// if so, recreate the graph.
-    pub fn update(&mut self, pkg: Id, target: Id, ctx: &mut DependencyGraph, queue: &mut VecDeque<(Id, Id)>) -> anyhow::Result<()> {
+    pub fn update(
+        &mut self,
+        pkg: Id,
+        target: Id,
+        ctx: &mut DependencyGraph,
+        queue: &mut VecDeque<(Id, Id)>,
+    ) -> anyhow::Result<()> {
         // find a suitable release
-        let (r, version) = ctx.registry.get(&pkg)
+        let (r, version) = ctx
+            .registry
+            .get(&pkg)
             .ok_or_else(|| pkg::InstallError::CantFindPkg(STRINGS.resolve(&pkg)))?
-            .releases.iter().filter_map(|(v, p)| self.comps.iter().all(|(c, _)| c.matches(v)).then_some((p, v))).last()
-            .ok_or_else(|| pkg::InstallError::NoMatchingVersion(STRINGS.resolve(&pkg), VersionReq {comparators: self.comps.iter().map(|(c, _)| c.clone()).collect()}))?;
-        if self.init && version == &self.version {return Ok(())} // everything is fine.
+            .releases
+            .iter()
+            .filter_map(|(v, p)| {
+                self.comps
+                    .iter()
+                    .all(|(c, _)| c.matches(v))
+                    .then_some((p, v))
+            })
+            .last()
+            .ok_or_else(|| {
+                pkg::InstallError::NoMatchingVersion(
+                    STRINGS.resolve(&pkg),
+                    VersionReq {
+                        comparators: self.comps.iter().map(|(c, _)| c.clone()).collect(),
+                    },
+                )
+            })?;
+        if self.init && version == &self.version {
+            return Ok(());
+        } // everything is fine.
         let proj = r.project(STRINGS.resolve(&pkg), version, ctx.is_frozen)?;
         // get target
         let mut deps = {
-            let target = proj.targets.get(STRINGS.resolve(&target)).ok_or_else(|| pkg::InstallError::NoMatchingTarget(STRINGS.resolve(&pkg), self.version.clone(), STRINGS.resolve(&target)))?;
+            let target = proj.targets.get(STRINGS.resolve(&target)).ok_or_else(|| {
+                pkg::InstallError::NoMatchingTarget(
+                    STRINGS.resolve(&pkg),
+                    self.version.clone(),
+                    STRINGS.resolve(&target),
+                )
+            })?;
             let mut deps = Vec::new();
             for (k, x) in target.deps.iter() {
                 match x {
-                    build::Dependency::Project       => deps.push(((pkg, STRINGS.get_or_intern(k)), VersionReq {comparators: vec![Comparator {op: semver::Op::Exact, major: version.major, minor: Some(version.minor), patch: Some(version.patch), pre: version.pre.clone()}]})),
-                    build::Dependency::System        => {},
-                    build::Dependency::Package(info) => deps.extend(info.targets.as_ref().cloned()
-                        .or_else(|| proj.targets.contains_key("default").then(|| vec!["default".to_string()]))
-                        .ok_or_else(|| pkg::InstallError::NoDefaultTarget(STRINGS.resolve(&pkg)))?.iter()
-                        .map(|x| ((STRINGS.get_or_intern(k), STRINGS.get_or_intern(x)), info.version.clone())))
+                    build::Dependency::Project => deps.push((
+                        (pkg, STRINGS.get_or_intern(k)),
+                        VersionReq {
+                            comparators: vec![Comparator {
+                                op: semver::Op::Exact,
+                                major: version.major,
+                                minor: Some(version.minor),
+                                patch: Some(version.patch),
+                                pre: version.pre.clone(),
+                            }],
+                        },
+                    )),
+                    build::Dependency::System => {}
+                    build::Dependency::Package(info) => deps.extend(
+                        info.targets
+                            .as_ref()
+                            .cloned()
+                            .or_else(|| {
+                                proj.targets
+                                    .contains_key("default")
+                                    .then(|| vec!["default".to_string()])
+                            })
+                            .ok_or_else(|| {
+                                pkg::InstallError::NoDefaultTarget(STRINGS.resolve(&pkg))
+                            })?
+                            .iter()
+                            .map(|x| {
+                                (
+                                    (STRINGS.get_or_intern(k), STRINGS.get_or_intern(x)),
+                                    info.version.clone(),
+                                )
+                            }),
+                    ),
                 }
             }
             deps
         };
         // filter dependencies into "good" (still needed) and "bad" (no longer used)
-        let (good, bad): (Vec<_>, Vec<_>) = std::mem::take(&mut self.dependencies).into_iter().partition(|(p, _)| deps.iter().any(|(x, _)| x == p));
+        let (good, bad): (Vec<_>, Vec<_>) = std::mem::take(&mut self.dependencies)
+            .into_iter()
+            .partition(|(p, _)| deps.iter().any(|(x, _)| x == p));
         deps.retain(|(p, _)| !good.iter().any(|(x, _)| x == p)); // remove any "good" dependencies from the "good" list
         assert!(!self.init || bad.is_empty()); // there should not be any bad packages if this is the first time
-        bad.into_iter().for_each(|(p, _)| unsafe {(*(&mut ctx.packages as *mut HashMap<(Id, Id), PkgNode>)).get_mut(&p)}.unwrap().remove_dependent(p, (pkg, target), ctx, queue));
+        bad.into_iter().for_each(|(p, _)| {
+            unsafe { (*(&mut ctx.packages as *mut HashMap<(Id, Id), PkgNode>)).get_mut(&p) }
+                .unwrap()
+                .remove_dependent(p, (pkg, target), ctx, queue)
+        });
         queue.reserve(good.len() + deps.len());
         good.into_iter().for_each(|(x, v)| {
             let comps = &mut ctx.packages.get_mut(&x).unwrap().comps;
@@ -65,33 +129,64 @@ impl PkgNode {
             comps.extend(v.comparators.into_iter().map(|v| (v, x))); // ...and add the new ones
             queue.push_front(x); // updating these needs to be the priority
         });
-        deps.into_iter().for_each(|(p, v)| ctx.packages.entry(p).or_default().add_dependent(p, (pkg, target), v, queue));
+        deps.into_iter().for_each(|(p, v)| {
+            ctx.packages
+                .entry(p)
+                .or_default()
+                .add_dependent(p, (pkg, target), v, queue)
+        });
         self.init = true;
         Ok(())
     }
     /// Remove one of the dependents for this node
     /// If there are no more dependents, remove this node and all queued dependencies
     /// This uses reference counting, so any cycles won't be removed
-    fn remove_dependent(&mut self, this: (Id, Id), deps: (Id, Id), ctx: &mut DependencyGraph, queue: &mut VecDeque<(Id, Id)>) {
+    fn remove_dependent(
+        &mut self,
+        this: (Id, Id),
+        deps: (Id, Id),
+        ctx: &mut DependencyGraph,
+        queue: &mut VecDeque<(Id, Id)>,
+    ) {
         self.dependents -= 1;
         if self.dependents == 0 {
             queue.retain(|x| x != &this);
             ctx.packages.remove(&this);
-            self.dependencies.iter().for_each(|(p, _)| unsafe {(*(&mut ctx.packages as *mut HashMap<(Id, Id), PkgNode>)).get_mut(p)}.unwrap().remove_dependent(*p, this, ctx, queue)); // This probably won't cause any issues
-        }
-        else {self.comps.retain(|(_, x)| x != &deps)};
+            self.dependencies.iter().for_each(|(p, _)| {
+                unsafe { (*(&mut ctx.packages as *mut HashMap<(Id, Id), PkgNode>)).get_mut(p) }
+                    .unwrap()
+                    .remove_dependent(*p, this, ctx, queue)
+            }); // This probably won't cause any issues
+        } else {
+            self.comps.retain(|(_, x)| x != &deps)
+        };
     }
     /// Add a dependent to this node
     /// If the node didn't already exist (no dependents), it queues itself
-    fn add_dependent(&mut self, this: (Id, Id), dep: (Id, Id), ver: VersionReq, queue: &mut VecDeque<(Id, Id)>) {
-        if self.dependents == 0 {queue.push_back(this)}
+    fn add_dependent(
+        &mut self,
+        this: (Id, Id),
+        dep: (Id, Id),
+        ver: VersionReq,
+        queue: &mut VecDeque<(Id, Id)>,
+    ) {
+        if self.dependents == 0 {
+            queue.push_back(this)
+        }
         self.dependents += 1;
-        self.comps.extend(ver.comparators.into_iter().map(|v| (v, dep)));
+        self.comps
+            .extend(ver.comparators.into_iter().map(|v| (v, dep)));
     }
     /// Use a DFS to find a cycle in the packages
     /// While a valid graph can be created with cycles, a proper build order cannot.
-    pub(self) fn find_cycle(&self, start: (Id, Id), ctx: &DependencyGraph) -> Option<VecDeque<(Id, Id)>> {
-        if self.dependencies.iter().any(|(d, _)| d == &start) {return Some(VecDeque::new())}
+    pub(self) fn find_cycle(
+        &self,
+        start: (Id, Id),
+        ctx: &DependencyGraph,
+    ) -> Option<VecDeque<(Id, Id)>> {
+        if self.dependencies.iter().any(|(d, _)| d == &start) {
+            return Some(VecDeque::new());
+        }
         self.dependencies.iter().find_map(|(d, _)| {
             let mut deque = ctx.packages.get(d)?.find_cycle(start, ctx)?;
             deque.push_front(*d);
@@ -102,33 +197,44 @@ impl PkgNode {
 pub struct DependencyGraph {
     pub(self) registry: HashMap<Id, &'static pkg::Package>,
     pub(self) packages: HashMap<(Id, Id), PkgNode>,
-    pub is_frozen: bool
+    pub is_frozen: bool,
 }
 impl DependencyGraph {
     /// Create a new dependency graph
     /// The registry is used from `pkg::REGISTRY`, and `packages` is initially empty
     pub fn new() -> Self {
         Self {
-            registry: pkg::REGISTRY.iter().map(|pkg| (STRINGS.get_or_intern_static(&pkg.name), pkg)).collect(),
+            registry: pkg::REGISTRY
+                .iter()
+                .map(|pkg| (STRINGS.get_or_intern_static(&pkg.name), pkg))
+                .collect(),
             packages: HashMap::new(),
-            is_frozen: false
+            is_frozen: false,
         }
     }
     /// Create a new dependency graph, but with `is_frozen` set to `true`.
     pub fn frozen() -> Self {
         Self {
-            registry: pkg::REGISTRY.iter().map(|pkg| (STRINGS.get_or_intern_static(&pkg.name), pkg)).collect(),
+            registry: pkg::REGISTRY
+                .iter()
+                .map(|pkg| (STRINGS.get_or_intern_static(&pkg.name), pkg))
+                .collect(),
             packages: HashMap::new(),
-            is_frozen: false
+            is_frozen: false,
         }
     }
     /// Clear the DependencyGraph
     /// This is cheaper than creating a new one because the HashMap registry doesn't need to be
     /// rebuilt.
-    pub fn clear(&mut self) {self.packages.clear()}
+    pub fn clear(&mut self) {
+        self.packages.clear()
+    }
     /// Build the dependency tree from the installation specification
     #[allow(unreachable_code, unused_variables)]
-    pub fn build_tree<I: IntoIterator<Item = pkg::InstallSpec>>(&mut self, pkgs: I) -> anyhow::Result<()> {
+    pub fn build_tree<I: IntoIterator<Item = pkg::InstallSpec>>(
+        &mut self,
+        pkgs: I,
+    ) -> anyhow::Result<()> {
         unimplemented!("package management is hard, okay?");
         let mut node = PkgNode {
             dependents: 1,
@@ -137,7 +243,12 @@ impl DependencyGraph {
         };
         let idef = STRINGS.get_or_intern_static("default");
         let ientry = STRINGS.get_or_intern_static("<installation entry>");
-        for pkg::InstallSpec {name, targets, version} in pkgs {
+        for pkg::InstallSpec {
+            name,
+            targets,
+            version,
+        } in pkgs
+        {
             let iname = STRINGS.get_or_intern(&name);
             if let Some(targets) = targets {
                 node.dependencies.reserve(targets.len());
@@ -145,29 +256,45 @@ impl DependencyGraph {
                     let itarg = STRINGS.get_or_intern(target);
                     node.dependencies.push(((iname, itarg), version.clone()));
                 }
-            }
-            else {
-                let (r, v) = self.registry.get(&iname)
+            } else {
+                let (r, v) = self
+                    .registry
+                    .get(&iname)
                     .ok_or_else(|| pkg::InstallError::CantFindPkg(STRINGS.resolve(&iname)))?
-                    .releases.iter().filter_map(|(v, p)| version.matches(v).then_some((p, v))).last()
-                    .ok_or_else(|| pkg::InstallError::NoMatchingVersion(STRINGS.resolve(&iname), version.clone()))?;
+                    .releases
+                    .iter()
+                    .filter_map(|(v, p)| version.matches(v).then_some((p, v)))
+                    .last()
+                    .ok_or_else(|| {
+                        pkg::InstallError::NoMatchingVersion(
+                            STRINGS.resolve(&iname),
+                            version.clone(),
+                        )
+                    })?;
                 let proj = r.project(&name, v, self.is_frozen)?;
                 if proj.targets.contains_key("default") {
                     node.dependencies.push(((iname, idef), version.clone()));
+                } else {
+                    anyhow::bail!(pkg::InstallError::NoDefaultTarget(STRINGS.resolve(&idef)))
                 }
-                else {anyhow::bail!(pkg::InstallError::NoDefaultTarget(STRINGS.resolve(&idef)))}
             }
         }
         self.packages.insert((ientry, ientry), node);
         let mut queue: VecDeque<(Id, Id)> = [(ientry, ientry)].into();
-        while let Some((p, t)) = queue.pop_front() {unsafe {(*(&mut self.packages as *mut HashMap<(Id, Id), PkgNode>)).get_mut(&(p, t))}.unwrap().update(p, t, self, &mut queue)?}
+        while let Some((p, t)) = queue.pop_front() {
+            unsafe { (*(&mut self.packages as *mut HashMap<(Id, Id), PkgNode>)).get_mut(&(p, t)) }
+                .unwrap()
+                .update(p, t, self, &mut queue)?
+        }
         Ok(())
     }
     /// Find a suitable build order from the built dependency tree
     /// If this fails, it returns at least one cycle in the graph
     /// The DependencyGraph will be left in the empty state after a call to this function
     /// This implementation uses Kahn's algorithm
-    pub fn build_order(&mut self) -> Result<VecDeque<(Id, Id, Version)>, VecDeque<(Id, Id, Version)>> {
+    pub fn build_order(
+        &mut self,
+    ) -> Result<VecDeque<(Id, Id, Version)>, VecDeque<(Id, Id, Version)>> {
         let ientry = STRINGS.get_or_intern_static("<installation entry>");
         let mut nodes: VecDeque<(Id, Id)> = [(ientry, ientry)].into();
         let mut out: VecDeque<(Id, Id, Version)> = VecDeque::new();
@@ -177,21 +304,34 @@ impl DependencyGraph {
             for (dep, _) in n.dependencies.iter() {
                 let node = &mut self.packages.get_mut(dep).unwrap();
                 node.dependents -= 1;
-                if node.dependents == 0 {nodes.push_back(*dep)}
+                if node.dependents == 0 {
+                    nodes.push_back(*dep)
+                }
             }
         }
-        if self.packages.is_empty() {Ok(out)}
-        else {
-            let out = self.packages.iter().find_map(|(&k, x)| {
-                let mut out = x.find_cycle(k, self)?;
-                out.push_front(k);
-                Some(out.into_iter().map(|(p, t)| (p, t, self.packages[&(p, t)].version.clone())).collect())
-            }).unwrap();
+        if self.packages.is_empty() {
+            Ok(out)
+        } else {
+            let out = self
+                .packages
+                .iter()
+                .find_map(|(&k, x)| {
+                    let mut out = x.find_cycle(k, self)?;
+                    out.push_front(k);
+                    Some(
+                        out.into_iter()
+                            .map(|(p, t)| (p, t, self.packages[&(p, t)].version.clone()))
+                            .collect(),
+                    )
+                })
+                .unwrap();
             self.packages.clear(); // Just to be sure that the result is in a clean state
             Err(out)
         }
     }
 }
 impl Default for DependencyGraph {
-    fn default() -> Self {Self::new()}
+    fn default() -> Self {
+        Self::new()
+    }
 }

--- a/cobalt-build/src/lib.rs
+++ b/cobalt-build/src/lib.rs
@@ -1,21 +1,21 @@
 #![allow(clippy::type_complexity)]
+pub mod build;
+pub mod cc;
+pub mod graph;
 pub mod libs;
 pub mod opt;
-pub mod build;
 pub mod pkg;
-pub mod graph;
-pub mod cc;
 
 pub mod obj;
 
-use thiserror::Error;
+pub use build::clear_mod;
 use cobalt_ast::*;
-use std::io::{self, prelude::*, ErrorKind};
-use path_calculate::*;
-use std::path::{Path, PathBuf};
 use cobalt_errors::error;
 use cobalt_llvm::*;
-pub use build::clear_mod;
+use path_calculate::*;
+use std::io::{self, prelude::*, ErrorKind};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 #[error("compiler errors were encountered")]
@@ -30,37 +30,76 @@ pub struct NoCobaltDir;
 pub struct LibsNotFound(pub Vec<String>);
 
 pub fn cobalt_dir() -> Result<PathBuf, NoCobaltDir> {
-    if let Ok(path) = std::env::var("COBALT_DIR") {Ok(path.into())}
-    else if let Ok(path) = std::env::var("HOME") {Ok(Path::new(&path).join(".cobalt"))}
-    else {Err(NoCobaltDir)}
+    if let Ok(path) = std::env::var("COBALT_DIR") {
+        Ok(path.into())
+    } else if let Ok(path) = std::env::var("HOME") {
+        Ok(Path::new(&path).join(".cobalt"))
+    } else {
+        Err(NoCobaltDir)
+    }
 }
 pub fn load_projects() -> io::Result<Vec<[String; 2]>> {
-    let mut cobalt_dir = cobalt_dir().map_err(|_| io::Error::new(ErrorKind::Other, "cobalt directory could not be found"))?;
-    if !cobalt_dir.exists() {std::fs::create_dir_all(&cobalt_dir)?;}
+    let mut cobalt_dir = cobalt_dir()
+        .map_err(|_| io::Error::new(ErrorKind::Other, "cobalt directory could not be found"))?;
+    if !cobalt_dir.exists() {
+        std::fs::create_dir_all(&cobalt_dir)?;
+    }
     cobalt_dir.push("tracked.txt");
-    let mut file = std::fs::OpenOptions::new().read(true).write(true).create(true).open(cobalt_dir)?;
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(cobalt_dir)?;
     let mut buf = String::new();
     file.read_to_string(&mut buf)?;
     let mut it = buf.split('\0');
     let len = it.size_hint();
     let mut vec = Vec::<[String; 2]>::with_capacity(len.1.unwrap_or(len.0));
-    while let (Some(name), Some(path)) = (it.next(), it.next()) {if Path::new(path).exists() {vec.push([name.to_string(), path.to_string()])}}
+    while let (Some(name), Some(path)) = (it.next(), it.next()) {
+        if Path::new(path).exists() {
+            vec.push([name.to_string(), path.to_string()])
+        }
+    }
     Ok(vec)
 }
 pub fn track_project(name: &str, path: PathBuf, vec: &mut Vec<[String; 2]>) {
-    if let Some(entry) = vec.iter_mut().find(|[_, p]| if let Ok(path) = path.as_absolute_path() {path == Path::new(&p)} else {false}) {entry[0] = name.to_string()}
-    else if let Some(entry) = vec.iter_mut().find(|[n, _]| n == name) {entry[1] = path.as_absolute_path().unwrap().to_string_lossy().to_string()}
-    else {
+    if let Some(entry) = vec.iter_mut().find(|[_, p]| {
+        if let Ok(path) = path.as_absolute_path() {
+            path == Path::new(&p)
+        } else {
+            false
+        }
+    }) {
+        entry[0] = name.to_string()
+    } else if let Some(entry) = vec.iter_mut().find(|[n, _]| n == name) {
+        entry[1] = path
+            .as_absolute_path()
+            .unwrap()
+            .to_string_lossy()
+            .to_string()
+    } else {
         vec.sort_by(|[n1, _], [n2, _]| n1.cmp(n2));
         vec.dedup_by(|[n1, _], [n2, _]| n1 == n2);
-        vec.push([name.to_string(), path.as_absolute_path().unwrap().to_string_lossy().to_string()])
+        vec.push([
+            name.to_string(),
+            path.as_absolute_path()
+                .unwrap()
+                .to_string_lossy()
+                .to_string(),
+        ])
     }
 }
 pub fn save_projects(vec: Vec<[String; 2]>) -> io::Result<()> {
-    let mut cobalt_dir = cobalt_dir().map_err(|_| io::Error::new(ErrorKind::Other, "cobalt directory could not be found"))?;
-    if !cobalt_dir.exists() {std::fs::create_dir_all(&cobalt_dir)?;}
+    let mut cobalt_dir = cobalt_dir()
+        .map_err(|_| io::Error::new(ErrorKind::Other, "cobalt directory could not be found"))?;
+    if !cobalt_dir.exists() {
+        std::fs::create_dir_all(&cobalt_dir)?;
+    }
     cobalt_dir.push("tracked.txt");
-    let mut file = std::fs::OpenOptions::new().write(true).create(true).open(cobalt_dir)?;
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(cobalt_dir)?;
     vec.into_iter().flatten().try_for_each(|s| {
         file.write_all(s.as_bytes())?;
         file.write_all(&[0])

--- a/cobalt-build/src/libs.rs
+++ b/cobalt-build/src/libs.rs
@@ -1,15 +1,17 @@
-use std::path::Path;
-use std::fmt;
-use os_str_bytes::OsStrBytes;
-use object::{SectionKind, write::Object};
 use cobalt_ast::CompCtx;
 use cobalt_llvm::inkwell;
+use object::{write::Object, SectionKind};
+use os_str_bytes::OsStrBytes;
+use std::fmt;
+use std::path::Path;
 /// This is a list of all symbols defined in multiple files
 #[derive(Debug)]
 pub struct ConflictingDefs(pub Vec<String>);
 impl fmt::Display for ConflictingDefs {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.iter().try_for_each(|v| writeln!(f, "conflicting defintions for {v}"))
+        self.0
+            .iter()
+            .try_for_each(|v| writeln!(f, "conflicting defintions for {v}"))
     }
 }
 impl std::error::Error for ConflictingDefs {}
@@ -19,8 +21,8 @@ pub fn new_object<'a>(triple: &inkwell::targets::TargetTriple) -> Object<'a> {
     let triple = triple.as_str().to_str().unwrap();
     let components = triple.split('-').collect::<Vec<&str>>();
     use object::Architecture::*;
-    use object::Endianness::*;
     use object::BinaryFormat::*;
+    use object::Endianness::*;
     let mut wasm = false;
     let arch = match components.first().copied() {
         Some("aarch64") => Aarch64,
@@ -34,23 +36,34 @@ pub fn new_object<'a>(triple: &inkwell::targets::TargetTriple) -> Object<'a> {
         Some(x) if x.starts_with("riscv32") => Riscv32,
         Some(x) if x.starts_with("riscv64") => Riscv64,
         Some("x86_64") => X86_64,
-        Some("wasm" | "wasm32") => {wasm = true; Wasm32}
-        _ => Unknown
+        Some("wasm" | "wasm32") => {
+            wasm = true;
+            Wasm32
+        }
+        _ => Unknown,
     };
     let endian = match arch {
         Mips | Mips64 => Big,
         PowerPc | PowerPc64 | Arm | Aarch64 | Wasm32 | X86_64 | I386 => Little,
-        _ => if 1i16.to_be_bytes()[0] == 1 {Little} else {Big}
+        _ => {
+            if 1i16.to_be_bytes()[0] == 1 {
+                Little
+            } else {
+                Big
+            }
+        }
     };
-    let format = if wasm {Wasm} else {
+    let format = if wasm {
+        Wasm
+    } else {
         match components.get(1).copied() {
             Some("apple") => MachO,
             Some("linux") => Elf,
             _ => match components.get(2).copied() {
                 Some("apple" | "ios" | "darwin") => MachO,
                 Some("windows") => Coff,
-                _ => Elf
-            }
+                _ => Elf,
+            },
         }
     };
     Object::new(format, arch, endian)
@@ -63,15 +76,17 @@ pub fn new_object<'a>(triple: &inkwell::targets::TargetTriple) -> Object<'a> {
 pub fn format_lib(base: &str, triple: &inkwell::targets::TargetTriple) -> String {
     let triple = triple.as_str().to_str().unwrap();
     let mut components = triple.split('-');
-    if matches!(components.next(), Some("wasm" | "wasm32")) {format!("{base}.wasm")} else {
+    if matches!(components.next(), Some("wasm" | "wasm32")) {
+        format!("{base}.wasm")
+    } else {
         match components.next() {
             Some("apple") => format!("lib{base}.dylib"),
             Some("linux") => format!("lib{base}.so"),
             _ => match components.next() {
                 Some("apple" | "ios" | "darwin") => format!("lib{base}.dylib"),
                 Some("windows") => format!("{base}.dylib"),
-                _ => format!("lib{base}.so")
-            }
+                _ => format!("lib{base}.so"),
+            },
         }
     }
 }
@@ -80,17 +95,18 @@ pub fn populate_header(obj: &mut Object, ctx: &CompCtx) {
     let mut buf = Vec::<u8>::new();
     ctx.save(&mut buf).unwrap();
     let colib = obj.add_section(
-        obj.segment_name(object::write::StandardSegment::Text).to_vec(),
-        b".colib".to_vec(), 
-        SectionKind::Text
+        obj.segment_name(object::write::StandardSegment::Text)
+            .to_vec(),
+        b".colib".to_vec(),
+        SectionKind::Text,
     );
     let colib = obj.section_mut(colib);
     colib.set_data(buf, 1);
 }
 /// Load the data in the `.colib` header from the file at the specified path
 pub fn load_lib(path: &Path, ctx: &CompCtx) -> anyhow::Result<Vec<String>> {
-    use object::read::{Object, ObjectSection};
     use anyhow_std::PathAnyhow;
+    use object::read::{Object, ObjectSection};
     let buf = path.read_anyhow()?;
     let mut conflicts = vec![];
     if buf.len() >= 4 && &buf[..4] == b"META" {
@@ -99,10 +115,12 @@ pub fn load_lib(path: &Path, ctx: &CompCtx) -> anyhow::Result<Vec<String>> {
             anyhow::Ok(())
         })?;
         Ok(conflicts)
-    }
-    else {
+    } else {
         let obj = object::File::parse(buf.as_slice())?;
-        if let Some(colib) = obj.section_by_name(".colib").and_then(|v| v.uncompressed_data().ok()) {
+        if let Some(colib) = obj
+            .section_by_name(".colib")
+            .and_then(|v| v.uncompressed_data().ok())
+        {
             conflicts.append(&mut ctx.load(&mut &*colib)?);
         }
         Ok(conflicts)

--- a/cobalt-build/src/obj.rs
+++ b/cobalt-build/src/obj.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use object::{self, write, Object, ObjectSection, ObjectSymbol, ObjectComdat};
+use object::{self, write, Object, ObjectComdat, ObjectSection, ObjectSymbol};
 
 pub fn get_writeable_object_from_file(in_object: object::File) -> object::write::Object {
     let mut out_object = object::write::Object::new(
@@ -81,7 +81,9 @@ pub fn get_writeable_object_from_file(in_object: object::File) -> object::write:
 
         let flags = match in_symbol.flags() {
             object::SymbolFlags::None => object::SymbolFlags::None,
-            object::SymbolFlags::Elf { st_info, st_other } => object::SymbolFlags::Elf { st_info, st_other },
+            object::SymbolFlags::Elf { st_info, st_other } => {
+                object::SymbolFlags::Elf { st_info, st_other }
+            }
             object::SymbolFlags::MachO { n_desc } => object::SymbolFlags::MachO { n_desc },
             object::SymbolFlags::CoffSection {
                 selection,

--- a/cobalt-build/src/opt.rs
+++ b/cobalt-build/src/opt.rs
@@ -1,11 +1,11 @@
-use std::process::exit;
-use std::fs::read;
-use std::env::var;
-use inkwell::passes::*;
-use inkwell::OptimizationLevel::*;
-use inkwell::module::Module;
 use cobalt_errors::{error, warning};
 use cobalt_llvm::inkwell;
+use inkwell::module::Module;
+use inkwell::passes::*;
+use inkwell::OptimizationLevel::*;
+use std::env::var;
+use std::fs::read;
+use std::process::exit;
 pub enum AdditionalArg {
     Null,
     Bool(bool),
@@ -176,8 +176,12 @@ cobalt_llvm::if_llvm_16! {
 pub fn from_file(data: &str, pm: &PassManager<Module>) {
     for (n, mut line) in data.split('\n').enumerate() {
         let n = n + 1;
-        if let Some(idx) = line.find('#') {line = &line[..idx];}
-        if line.trim().is_empty() {continue}
+        if let Some(idx) = line.find('#') {
+            line = &line[..idx];
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
         if let Some(idx) = line.find('=') {
             let pass = line[..idx].trim();
             let val = line[(idx + 1)..].trim().to_lowercase();
@@ -185,30 +189,25 @@ pub fn from_file(data: &str, pm: &PassManager<Module>) {
                 if !add_pass(pm, pass, Null) {
                     warning!("{n}: unknown pass '{pass}'");
                 }
-            }
-            else if val == "true" {
+            } else if val == "true" {
                 if !add_pass(pm, pass, Bool(true)) {
                     warning!("{n}: unknown pass '{pass}'");
                 }
-            }
-            else if val == "false" {
+            } else if val == "false" {
                 if !add_pass(pm, pass, Bool(false)) {
                     warning!("{n}: unknown pass '{pass}'");
                 }
-            }
-            else if let Ok(val) = val.parse() {
+            } else if let Ok(val) = val.parse() {
                 if !add_pass(pm, pass, Int(val)) {
                     warning!("{n}: unknown pass '{pass}'");
                 }
-            }
-            else {
+            } else {
                 warning!("{n}: unrecognized value '{val}'");
                 if !add_pass(pm, pass, Null) {
                     warning!("{n}: unknown pass '{pass}'");
                 }
             }
-        }
-        else {
+        } else {
             let pass = line.trim();
             if !add_pass(pm, pass, Null) {
                 warning!("{n}: unknown pass '{pass}'");
@@ -243,22 +242,22 @@ pub fn load_profile(name: Option<&str>, pm: &PassManager<Module>) {
         return;
     }
     match name {
-        "default" | "none" | "0" => {},
+        "default" | "none" | "0" => {}
         "less" | "1" => {
             let pmb = PassManagerBuilder::create();
             pmb.set_optimization_level(Less);
             pmb.populate_module_pass_manager(pm);
-        },
+        }
         "some" | "2" => {
             let pmb = PassManagerBuilder::create();
             pmb.set_optimization_level(Default);
             pmb.populate_module_pass_manager(pm);
-        },
+        }
         "aggressive" | "3" => {
             let pmb = PassManagerBuilder::create();
             pmb.set_optimization_level(Aggressive);
             pmb.populate_module_pass_manager(pm);
-        },
+        }
         _ => {
             error!("couldn't find profile {name}");
             exit(103);

--- a/cobalt-build/src/pkg.rs
+++ b/cobalt-build/src/pkg.rs
@@ -1,15 +1,15 @@
 #![allow(dead_code)]
-use serde::{Serialize, Deserialize};
-use std::path::{Path, PathBuf};
-use std::collections::{HashMap, BTreeMap, VecDeque};
-use either::Either;
+use crate::*;
 use anyhow_std::*;
+use cobalt_errors::error;
+use either::Either;
+use indexmap::IndexMap;
 use path_calculate::path_absolutize::Absolutize;
 use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::path::{Path, PathBuf};
 use thiserror::Error;
-use indexmap::IndexMap;
-use crate::*;
-use cobalt_errors::error;
 /// Information about a cloned repository
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitInfo {
@@ -17,7 +17,7 @@ pub struct GitInfo {
     url: String, // URL/path of repository
     #[serde(flatten)]
     branch: Option<GitLocation>, // branch/commit/tag to use
-    dir: Option<PathBuf> // subdirectory
+    dir: Option<PathBuf>, // subdirectory
 }
 /// What to checkout to
 /// Branches are updated, commits aren't
@@ -26,7 +26,7 @@ pub enum GitLocation {
     #[serde(rename = "branch")]
     Branch(String),
     #[serde(rename = "commit", alias = "tag")]
-    Commit(String)
+    Commit(String),
 }
 /// Location of a registry
 /// This defines what happens when update() is called
@@ -41,14 +41,14 @@ pub enum RegistryType {
     #[serde(rename = "cmd", alias = "shell")]
     Cmd(String), // Command to run to update
     #[serde(rename = "manual", alias = "other")]
-    Manual       // Something we don't have to worry about handles it
+    Manual, // Something we don't have to worry about handles it
 }
 /// The actual registry: its type and path
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Registry {
     #[serde(flatten)]
     pub reg_type: RegistryType,
-    pub path: PathBuf
+    pub path: PathBuf,
 }
 /// Shim for serde
 /// Registries are supposed to be defined as a list of tables in TOML, so this helps
@@ -56,7 +56,7 @@ pub struct Registry {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegistryList {
     #[serde(default)]
-    pub registry: Vec<Registry>
+    pub registry: Vec<Registry>,
 }
 /// A general structure describing how to install a project
 /// While Projects describe how to build a project, Packages define how to install it, storing
@@ -67,7 +67,7 @@ pub struct Package {
     pub author: String,
     #[serde(alias = "description")]
     pub desc: Option<String>,
-    pub releases: BTreeMap<Version, Release>
+    pub releases: BTreeMap<Version, Release>,
 }
 /// A single version of a project
 /// Every release must have a source, but can also optionally have prebuilds and a separate
@@ -80,31 +80,46 @@ pub struct Release {
     pub prebuilds: HashMap<String, HashMap<String, String>>,
     /// An optional URL to download just the `cobalt.toml` file
     #[serde(alias = "proj_file", alias = "proj-file")]
-    pub project: Option<String>
+    pub project: Option<String>,
 }
 impl Release {
     /// Get the manifest for this release
-    pub fn project(&self, name: &str, version: &Version, frozen: bool) -> anyhow::Result<build::Project> {
+    pub fn project(
+        &self,
+        name: &str,
+        version: &Version,
+        frozen: bool,
+    ) -> anyhow::Result<build::Project> {
         let mut path = cobalt_dir()?;
         path.push("packages");
         path.push(name);
         path.push(version.to_string());
-        if !path.exists() {path.create_dir_all_anyhow()?}
+        if !path.exists() {
+            path.create_dir_all_anyhow()?
+        }
         path.push("cobalt.toml");
-        if path.exists() {return Ok(toml::from_str(&path.read_to_string_anyhow()?)?)}
+        if path.exists() {
+            return Ok(toml::from_str(&path.read_to_string_anyhow()?)?);
+        }
         path.pop();
         path.push("src");
         path.push("cobalt.toml");
-        if path.exists() {return Ok(toml::from_str(&path.read_to_string_anyhow()?)?)}
+        if path.exists() {
+            return Ok(toml::from_str(&path.read_to_string_anyhow()?)?);
+        }
         path.pop();
         path.pop();
         path.push("cobalt.toml");
         if let Some(mut project) = self.project.as_deref() {
-            if if project.starts_with("file://") {project = &project[7..]; true} else {project.starts_with('/')} {
+            if if project.starts_with("file://") {
+                project = &project[7..];
+                true
+            } else {
+                project.starts_with('/')
+            } {
                 Path::new(project).copy_anyhow(&path)?;
                 return Ok(toml::from_str(&path.read_to_string_anyhow()?)?);
-            }
-            else if !frozen {
+            } else if !frozen {
                 let buf = ureq::get(project).call()?.into_string()?;
                 path.write_anyhow(&buf)?;
                 return Ok(toml::from_str(&buf)?);
@@ -128,31 +143,52 @@ pub enum Source {
     #[serde(rename = "tar", alias = "tarball", alias = "tgz")]
     Tar(String),
     #[serde(rename = "zip", alias = "zipball")]
-    Zip(String)
+    Zip(String),
 }
 impl Source {
     /// Install the source to a given location
     /// The returned `PathBuf` is in case the target was a subdirectory of a Git repository
     pub fn install<P: AsRef<Path>>(&self, to: P) -> anyhow::Result<PathBuf> {
         let mut to = to.as_ref().to_path_buf();
-        if to.exists() {to.remove_dir_all_anyhow()?}
+        if to.exists() {
+            to.remove_dir_all_anyhow()?
+        }
         match self {
-            Self::Git(Either::Left(url) | Either::Right(GitInfo {url, branch: None, ..})) => {git2::Repository::clone_recurse(url, &to)?;},
-            Self::Git(Either::Right(GitInfo {url, branch: Some(GitLocation::Branch(commit) | GitLocation::Commit(commit)), ..})) => {
+            Self::Git(
+                Either::Left(url)
+                | Either::Right(GitInfo {
+                    url, branch: None, ..
+                }),
+            ) => {
+                git2::Repository::clone_recurse(url, &to)?;
+            }
+            Self::Git(Either::Right(GitInfo {
+                url,
+                branch: Some(GitLocation::Branch(commit) | GitLocation::Commit(commit)),
+                ..
+            })) => {
                 let repo = git2::Repository::clone_recurse(url, &to)?;
                 let (object, reference) = repo.revparse_ext(commit)?;
                 repo.checkout_tree(&object, None)?;
-                if let Some(gref) = reference {repo.set_head(std::str::from_utf8(gref.name_bytes())?)?}
-                else {repo.set_head_detached(object.id())?}
-            },
-            Self::Tar(url) => tar::Archive::new(flate2::read::GzDecoder::new(ureq::get(url).call()?.into_reader())).unpack(&to)?,
+                if let Some(gref) = reference {
+                    repo.set_head(std::str::from_utf8(gref.name_bytes())?)?
+                } else {
+                    repo.set_head_detached(object.id())?
+                }
+            }
+            Self::Tar(url) => tar::Archive::new(flate2::read::GzDecoder::new(
+                ureq::get(url).call()?.into_reader(),
+            ))
+            .unpack(&to)?,
             Self::Zip(url) => {
                 let mut buf = vec![];
                 ureq::get(url).call()?.into_reader().read_to_end(&mut buf)?;
                 zip_extract::extract(std::io::Cursor::new(buf), &to, true)?;
             }
         }
-        if let Self::Git(Either::Right(GitInfo {dir: Some(p), ..})) = self {to.push(p)}
+        if let Self::Git(Either::Right(GitInfo { dir: Some(p), .. })) = self {
+            to.push(p)
+        }
         Ok(to)
     }
 }
@@ -163,20 +199,32 @@ lazy_static::lazy_static! {
 pub fn get_packages() -> anyhow::Result<Vec<Package>> {
     let cdir = cobalt_dir()?;
     let reg_path = cdir.join("registries.toml");
-    if !reg_path.exists() {return Ok(vec![])}
+    if !reg_path.exists() {
+        return Ok(vec![]);
+    }
     let registries = toml::from_str::<RegistryList>(&reg_path.read_to_string_anyhow()?)?;
     let mut out = vec![];
     let reg_dir = cdir.join("registries");
     reg_dir.create_dir_all_anyhow()?;
     for reg in registries.registry {
         let mut path = reg.path.absolutize_from(&reg_dir)?.to_path_buf();
-        if let RegistryType::Git(Either::Right(GitInfo {dir: Some(ref dir), ..})) = reg.reg_type {path.push(dir)}
+        if let RegistryType::Git(Either::Right(GitInfo {
+            dir: Some(ref dir), ..
+        })) = reg.reg_type
+        {
+            path.push(dir)
+        }
         let it = path.read_dir_anyhow()?;
         let bounds = it.size_hint();
-        if let Some(upper) = bounds.1 {out.reserve(upper);}
-        else {out.reserve(bounds.0);}
+        if let Some(upper) = bounds.1 {
+            out.reserve(upper);
+        } else {
+            out.reserve(bounds.0);
+        }
         for entry in it {
-            out.push(toml::from_str::<Package>(&entry?.path().read_to_string_anyhow()?)?);
+            out.push(toml::from_str::<Package>(
+                &entry?.path().read_to_string_anyhow()?,
+            )?);
         }
     }
     Ok(out)
@@ -185,7 +233,9 @@ pub fn get_packages() -> anyhow::Result<Vec<Package>> {
 pub fn update_packages() -> anyhow::Result<()> {
     let cdir = cobalt_dir()?;
     let reg_path = cdir.join("registries.toml");
-    if !reg_path.exists() {return Ok(())}
+    if !reg_path.exists() {
+        return Ok(());
+    }
     let registries = toml::from_str::<RegistryList>(&reg_path.read_to_string_anyhow()?)?;
     let reg_dir = cdir.join("registries");
     reg_dir.create_dir_all_anyhow()?;
@@ -193,14 +243,22 @@ pub fn update_packages() -> anyhow::Result<()> {
         let path = reg.path.absolutize_from(&reg_dir)?;
         use RegistryType::*;
         match reg.reg_type {
-            Git(Either::Left(url) | Either::Right(GitInfo {url, branch: None, ..})) => {
+            Git(
+                Either::Left(url)
+                | Either::Right(GitInfo {
+                    url, branch: None, ..
+                }),
+            ) => {
                 if path.exists() {
                     let repo = git2::Repository::open(&path)?;
                     let remotes = repo.remotes()?;
                     let mut it = remotes.iter();
                     if let Some(remote_name) = it.next() {
                         if it.next().is_some() {
-                            anyhow::bail!("multiple remotes are available for repository at {}", path.display());
+                            anyhow::bail!(
+                                "multiple remotes are available for repository at {}",
+                                path.display()
+                            );
                         }
                         if let Some(remote_name) = remote_name {
                             let mut remote = repo.find_remote(remote_name)?;
@@ -210,38 +268,66 @@ pub fn update_packages() -> anyhow::Result<()> {
                             let fetch_head = repo.find_reference("FETCH_HEAD")?;
                             let fetch_commit = repo.reference_to_annotated_commit(&fetch_head)?;
                             let analysis = repo.merge_analysis(&[&fetch_commit])?;
-                            if analysis.0.is_up_to_date() {return anyhow::Ok(())}
-                            else if analysis.0.is_fast_forward() {
+                            if analysis.0.is_up_to_date() {
+                                return anyhow::Ok(());
+                            } else if analysis.0.is_fast_forward() {
                                 let refname = format!("refs/heads/{name}");
                                 let mut reference = repo.find_reference(&refname)?;
                                 reference.set_target(fetch_commit.id(), "Fast-Forward")?;
                                 repo.set_head(&refname)?;
-                                repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
+                                repo.checkout_head(Some(
+                                    git2::build::CheckoutBuilder::default().force(),
+                                ))?;
+                            } else {
+                                anyhow::bail!(
+                                    "remote {remote_name} in repo {} is not fast-forward",
+                                    path.display()
+                                )
                             }
-                            else {anyhow::bail!("remote {remote_name} in repo {} is not fast-forward", path.display())}
+                        } else {
+                            anyhow::bail!("remote name is not UTF-8")
                         }
-                        else {anyhow::bail!("remote name is not UTF-8")}
+                    } else {
+                        anyhow::bail!("no remotes are avaiable in {}", path.display())
                     }
-                    else {anyhow::bail!("no remotes are avaiable in {}", path.display())}
+                } else {
+                    git2::Repository::clone_recurse(&url, &path)?;
                 }
-                else {git2::Repository::clone_recurse(&url, &path)?;}
-            },
-            Git(Either::Right(GitInfo {url, branch: Some(GitLocation::Commit(commit)), ..})) => {
+            }
+            Git(Either::Right(GitInfo {
+                url,
+                branch: Some(GitLocation::Commit(commit)),
+                ..
+            })) => {
                 if !path.exists() {
                     let repo = git2::Repository::clone_recurse(&url, &path)?;
                     let (object, reference) = repo.revparse_ext(&commit)?;
                     repo.checkout_tree(&object, None)?;
-                    if let Some(gref) = reference {repo.set_head(std::str::from_utf8(gref.name_bytes())?)?}
-                    else {repo.set_head_detached(object.id())?}
+                    if let Some(gref) = reference {
+                        repo.set_head(std::str::from_utf8(gref.name_bytes())?)?
+                    } else {
+                        repo.set_head_detached(object.id())?
+                    }
                 }
-            },
-            Git(Either::Right(GitInfo {url, branch: Some(GitLocation::Branch(branch)), ..})) => {
-                let repo = if path.exists() {git2::Repository::open(&path)?} else {git2::Repository::clone_recurse(&url, &path)?};
+            }
+            Git(Either::Right(GitInfo {
+                url,
+                branch: Some(GitLocation::Branch(branch)),
+                ..
+            })) => {
+                let repo = if path.exists() {
+                    git2::Repository::open(&path)?
+                } else {
+                    git2::Repository::clone_recurse(&url, &path)?
+                };
                 let remotes = repo.remotes()?;
                 let mut it = remotes.iter();
                 if let Some(remote_name) = it.next() {
                     if it.next().is_some() {
-                        anyhow::bail!("multiple remotes are available for repository at {}", path.display());
+                        anyhow::bail!(
+                            "multiple remotes are available for repository at {}",
+                            path.display()
+                        );
                     }
                     if let Some(remote_name) = remote_name {
                         let mut remote = repo.find_remote(remote_name)?;
@@ -251,27 +337,47 @@ pub fn update_packages() -> anyhow::Result<()> {
                         let fetch_head = repo.find_reference("FETCH_HEAD")?;
                         let fetch_commit = repo.reference_to_annotated_commit(&fetch_head)?;
                         let analysis = repo.merge_analysis(&[&fetch_commit])?;
-                        if analysis.0.is_up_to_date() {return anyhow::Ok(())}
-                        else if analysis.0.is_fast_forward() {
+                        if analysis.0.is_up_to_date() {
+                            return anyhow::Ok(());
+                        } else if analysis.0.is_fast_forward() {
                             let refname = format!("refs/heads/{name}");
                             let mut reference = repo.find_reference(&refname)?;
                             reference.set_target(fetch_commit.id(), "Fast-Forward")?;
                             repo.set_head(&refname)?;
-                            repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
+                            repo.checkout_head(Some(
+                                git2::build::CheckoutBuilder::default().force(),
+                            ))?;
+                        } else {
+                            anyhow::bail!(
+                                "remote {remote_name} in repo {} is not fast-forward",
+                                path.display()
+                            )
                         }
-                        else {anyhow::bail!("remote {remote_name} in repo {} is not fast-forward", path.display())}
+                    } else {
+                        anyhow::bail!("remote name is not UTF-8")
                     }
-                    else {anyhow::bail!("remote name is not UTF-8")}
+                } else {
+                    anyhow::bail!("no remotes are avaiable in {}", path.display())
                 }
-                else {anyhow::bail!("no remotes are avaiable in {}", path.display())}
-            },
-            Tar(url) => tar::Archive::new(flate2::read::GzDecoder::new(ureq::get(&url).call()?.into_reader())).unpack(path)?,
+            }
+            Tar(url) => tar::Archive::new(flate2::read::GzDecoder::new(
+                ureq::get(&url).call()?.into_reader(),
+            ))
+            .unpack(path)?,
             Zip(url) => {
                 let mut buf = vec![];
-                ureq::get(&url).call()?.into_reader().read_to_end(&mut buf)?;
+                ureq::get(&url)
+                    .call()?
+                    .into_reader()
+                    .read_to_end(&mut buf)?;
                 zip_extract::extract(std::io::Cursor::new(buf), &path, true)?;
-            },
-            Cmd(cmd) => {std::process::Command::new("sh").arg("-c").arg(cmd).status()?;},
+            }
+            Cmd(cmd) => {
+                std::process::Command::new("sh")
+                    .arg("-c")
+                    .arg(cmd)
+                    .status()?;
+            }
             Manual => {}
         }
     }
@@ -283,11 +389,23 @@ pub fn update_packages() -> anyhow::Result<()> {
 pub struct InstallSpec {
     pub name: String,
     pub version: VersionReq,
-    pub targets: Option<Vec<String>>
+    pub targets: Option<Vec<String>>,
 }
 impl InstallSpec {
-    pub fn new(name: String, version: VersionReq, targets: Option<Vec<String>>) -> Self {Self {name, version, targets}}
-    pub fn from_pkgdep(name: String, spec: build::PkgDepSpec) -> Self {Self {name, version: spec.version, targets: spec.targets}}
+    pub fn new(name: String, version: VersionReq, targets: Option<Vec<String>>) -> Self {
+        Self {
+            name,
+            version,
+            targets,
+        }
+    }
+    pub fn from_pkgdep(name: String, spec: build::PkgDepSpec) -> Self {
+        Self {
+            name,
+            version: spec.version,
+            targets: spec.targets,
+        }
+    }
 }
 impl std::str::FromStr for InstallSpec {
     type Err = semver::Error;
@@ -295,16 +413,32 @@ impl std::str::FromStr for InstallSpec {
         let mut targets: Option<Vec<String>> = None;
         let mut version = VersionReq::STAR;
         let mut it = req.match_indices(['@', ':']).peekable();
-        let name = if let Some(&(idx, _)) = it.peek() {req[..idx].to_string()} else {req.to_string()};
+        let name = if let Some(&(idx, _)) = it.peek() {
+            req[..idx].to_string()
+        } else {
+            req.to_string()
+        };
         while let Some((idx, ch)) = it.next() {
-            let blk = if let Some(&(next, _)) = it.peek() {req[idx..next].trim()} else {req[idx..].trim()};
+            let blk = if let Some(&(next, _)) = it.peek() {
+                req[idx..next].trim()
+            } else {
+                req[idx..].trim()
+            };
             match ch {
-                "@" => version.comparators.append(&mut VersionReq::parse(blk)?.comparators),
-                ":" => targets.get_or_insert_with(Vec::new).extend(blk.split(',').map(str::trim).map(String::from)),
-                x => unreachable!("should be '@' or ':', got {x:?}")
+                "@" => version
+                    .comparators
+                    .append(&mut VersionReq::parse(blk)?.comparators),
+                ":" => targets
+                    .get_or_insert_with(Vec::new)
+                    .extend(blk.split(',').map(str::trim).map(String::from)),
+                x => unreachable!("should be '@' or ':', got {x:?}"),
             }
         }
-        Ok(Self {name, version, targets})
+        Ok(Self {
+            name,
+            version,
+            targets,
+        })
     }
 }
 #[derive(Debug, Clone, Error)]
@@ -329,14 +463,26 @@ pub enum InstallError {
     /// ending with the first package
     /// This only prints out one cycle, but there could be multiple.
     #[error("dependencies couldn't be resolved due to a cycle: {}", DisplayCycle(.0))]
-    DependencyCycle(VecDeque<(graph::Id, graph::Id, Version)>)
+    DependencyCycle(VecDeque<(graph::Id, graph::Id, Version)>),
 }
 struct DisplayCycle<'a>(pub &'a VecDeque<(graph::Id, graph::Id, Version)>);
 impl std::fmt::Display for DisplayCycle<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        for (pkg, tar, v) in self.0 {write!(f, "{}.{}@{v} -> ", graph::STRINGS.resolve(pkg), graph::STRINGS.resolve(tar))?}
+        for (pkg, tar, v) in self.0 {
+            write!(
+                f,
+                "{}.{}@{v} -> ",
+                graph::STRINGS.resolve(pkg),
+                graph::STRINGS.resolve(tar)
+            )?
+        }
         let (pkg, tar, v) = self.0.front().unwrap();
-        write!(f, "{}.{}@{v}", graph::STRINGS.resolve(pkg), graph::STRINGS.resolve(tar))
+        write!(
+            f,
+            "{}.{}@{v}",
+            graph::STRINGS.resolve(pkg),
+            graph::STRINGS.resolve(tar)
+        )
     }
 }
 /// Installation options
@@ -345,19 +491,27 @@ pub struct InstallOptions {
     pub force_build: bool,
     pub frozen: bool,
     /// This is the target triple
-    pub target: String
+    pub target: String,
 }
 impl Default for InstallOptions {
     fn default() -> Self {
         Self {
             force_build: false,
             frozen: false,
-            target: inkwell::targets::TargetMachine::get_default_triple().as_str().to_str().unwrap().to_string()
+            target: inkwell::targets::TargetMachine::get_default_triple()
+                .as_str()
+                .to_str()
+                .unwrap()
+                .to_string(),
         }
     }
 }
 /// Convenience method to find the path that a package is installed to
-pub fn installed_path(package: &str, target: &str, version: &Version) -> Result<PathBuf, NoCobaltDir> {
+pub fn installed_path(
+    package: &str,
+    target: &str,
+    version: &Version,
+) -> Result<PathBuf, NoCobaltDir> {
     let mut path = cobalt_dir()?;
     path.push("installed");
     path.push(package);
@@ -366,18 +520,41 @@ pub fn installed_path(package: &str, target: &str, version: &Version) -> Result<
     Ok(path)
 }
 /// Install a singular package. It is assumed that all of its dependencies are already met
-fn install_single(pkg: &'static str, tar: &'static str, version: &Version, opts: &InstallOptions, package: &Package, plan: &IndexMap<(&str, &str), Version>) -> anyhow::Result<()> {
+fn install_single(
+    pkg: &'static str,
+    tar: &'static str,
+    version: &Version,
+    opts: &InstallOptions,
+    package: &Package,
+    plan: &IndexMap<(&str, &str), Version>,
+) -> anyhow::Result<()> {
     let path = installed_path(pkg, tar, version)?;
-    if !opts.force_build && path.exists() {return Ok(())} // already exists
+    if !opts.force_build && path.exists() {
+        return Ok(());
+    } // already exists
     if !opts.force_build {
         // Search for prebuilds that match the target
         // If opts.frozen == true, only allow files starting with "/" or "file://", which are
         // recognized as local files
-        if let Some(mut url) = package.releases[version].prebuilds.iter().flat_map(|(os, ts)| ts.iter().map(|(tar, url)| (os.as_str(), tar, url))).find_map(|(os, t, url)| ((!opts.frozen || url.starts_with('/') || url.starts_with("file://")) && t == tar && glob::Pattern::new(os).ok()?.matches(&opts.target)).then_some(url.as_str())) {
-            if if url.starts_with("file://") {url = &url[7..]; true} else {url.starts_with('/')} {
+        if let Some(mut url) = package.releases[version]
+            .prebuilds
+            .iter()
+            .flat_map(|(os, ts)| ts.iter().map(|(tar, url)| (os.as_str(), tar, url)))
+            .find_map(|(os, t, url)| {
+                ((!opts.frozen || url.starts_with('/') || url.starts_with("file://"))
+                    && t == tar
+                    && glob::Pattern::new(os).ok()?.matches(&opts.target))
+                .then_some(url.as_str())
+            })
+        {
+            if if url.starts_with("file://") {
+                url = &url[7..];
+                true
+            } else {
+                url.starts_with('/')
+            } {
                 Path::new(url).copy_anyhow(path)?;
-            }
-            else {
+            } else {
                 assert!(!opts.frozen); // this should always be true, but one small assertion won't hurt performance
                 let mut file = std::fs::File::create(path)?;
                 std::io::copy(&mut ureq::get(url).call()?.into_reader(), &mut file)?;
@@ -390,9 +567,15 @@ fn install_single(pkg: &'static str, tar: &'static str, version: &Version, opts:
     src_path.push(pkg);
     src_path.push(version.to_string());
     src_path.push("src");
-    if let Source::Git(Either::Right(GitInfo {dir: Some(p), ..})) = &package.releases[version].source {src_path.push(p)}
+    if let Source::Git(Either::Right(GitInfo { dir: Some(p), .. })) =
+        &package.releases[version].source
+    {
+        src_path.push(p)
+    }
     if !src_path.exists() {
-        if opts.frozen {anyhow::bail!(InstallError::Frozen(pkg.to_string()))}
+        if opts.frozen {
+            anyhow::bail!(InstallError::Frozen(pkg.to_string()))
+        }
         package.releases[version].source.install(&src_path)?;
     }
     let mut build_path = cobalt_dir()?;
@@ -400,29 +583,53 @@ fn install_single(pkg: &'static str, tar: &'static str, version: &Version, opts:
     build_path.push(pkg);
     build_path.push(version.to_string());
     build_path.push("build");
-    let proj = toml::from_str::<build::Project>(&src_path.join("cobalt.toml").read_to_string_anyhow()?)?;
-    let target = proj.targets.get(tar).ok_or(InstallError::NoMatchingTarget(pkg, version.clone(), tar))?;
-    let out = build::build_target_single(target, pkg, tar, version, plan, &build::BuildOptions {
-        source_dir: &src_path,
-        build_dir: &build_path,
-        continue_comp: false,
-        continue_build: false,
-        rebuild: true,
-        profile: "default",
-        triple: &inkwell::targets::TargetTriple::create(&opts.target),
-        link_dirs: vec![]
-    })?;
+    let proj =
+        toml::from_str::<build::Project>(&src_path.join("cobalt.toml").read_to_string_anyhow()?)?;
+    let target =
+        proj.targets
+            .get(tar)
+            .ok_or(InstallError::NoMatchingTarget(pkg, version.clone(), tar))?;
+    let out = build::build_target_single(
+        target,
+        pkg,
+        tar,
+        version,
+        plan,
+        &build::BuildOptions {
+            source_dir: &src_path,
+            build_dir: &build_path,
+            continue_comp: false,
+            continue_build: false,
+            rebuild: true,
+            profile: "default",
+            triple: &inkwell::targets::TargetTriple::create(&opts.target),
+            link_dirs: vec![],
+        },
+    )?;
     out.copy_anyhow(path)?;
     Ok(())
 }
 /// Installation entry point
 /// All packages can just be given, and everything is handled
-pub fn install<I: IntoIterator<Item = InstallSpec>>(pkgs: I, opts: &InstallOptions) -> anyhow::Result<IndexMap<(&'static str, &'static str), Version>> {
-    let reg = REGISTRY.iter().map(|pkg| (pkg.name.as_str(), pkg)).collect::<HashMap<&'static str, _>>();
+pub fn install<I: IntoIterator<Item = InstallSpec>>(
+    pkgs: I,
+    opts: &InstallOptions,
+) -> anyhow::Result<IndexMap<(&'static str, &'static str), Version>> {
+    let reg = REGISTRY
+        .iter()
+        .map(|pkg| (pkg.name.as_str(), pkg))
+        .collect::<HashMap<&'static str, _>>();
     let mut graph = graph::DependencyGraph::new();
     graph.is_frozen = opts.frozen;
     graph.build_tree(pkgs)?;
-    let order = graph.build_order().map_err(InstallError::DependencyCycle)?.into_iter().map(|(p, t, v)| ((graph::STRINGS.resolve(&p), graph::STRINGS.resolve(&t)), v)).collect::<IndexMap<_, _>>();
-    order.iter().try_for_each(|((p, t), v)| install_single(p, t, v, &Default::default(), reg[p], &order))?;
+    let order = graph
+        .build_order()
+        .map_err(InstallError::DependencyCycle)?
+        .into_iter()
+        .map(|(p, t, v)| ((graph::STRINGS.resolve(&p), graph::STRINGS.resolve(&t)), v))
+        .collect::<IndexMap<_, _>>();
+    order
+        .iter()
+        .try_for_each(|((p, t), v)| install_single(p, t, v, &Default::default(), reg[p], &order))?;
     Ok(order)
 }

--- a/cobalt-cli/build.rs
+++ b/cobalt-cli/build.rs
@@ -1,6 +1,9 @@
 use std::process::{Command, Output};
 fn git_info() -> Option<()> {
-    let Output {stdout, status, ..} = Command::new("git").args(["rev-parse", "HEAD", "--abbrev-ref", "HEAD"]).output().ok()?;
+    let Output { stdout, status, .. } = Command::new("git")
+        .args(["rev-parse", "HEAD", "--abbrev-ref", "HEAD"])
+        .output()
+        .ok()?;
     if status.success() {
         let info = std::str::from_utf8(&stdout).ok()?;
         let (commit, branch) = info.split_once('\n')?;

--- a/cobalt-errors/src/error.rs
+++ b/cobalt-errors/src/error.rs
@@ -1,6 +1,6 @@
 use crate::CobaltFile;
-use thiserror::Error;
 use miette::{Diagnostic, SourceSpan};
+use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error, Diagnostic)]
 pub enum CobaltError {
@@ -18,7 +18,7 @@ pub enum CobaltError {
         #[label("right type is `{rhs}`")]
         rloc: SourceSpan,
         #[label]
-        oloc: SourceSpan
+        oloc: SourceSpan,
     },
     #[error(r#"prefix operator "{op}" is not defined for type `{val}`"#)]
     PreOpNotDefined {
@@ -27,7 +27,7 @@ pub enum CobaltError {
         #[label("value type is `{val}`")]
         vloc: SourceSpan,
         #[label]
-        oloc: SourceSpan
+        oloc: SourceSpan,
     },
     #[error(r#"postfix operator "{op}" is not defined for type `{val}`"#)]
     PostOpNotDefined {
@@ -36,7 +36,7 @@ pub enum CobaltError {
         #[label("value type is `{val}`")]
         vloc: SourceSpan,
         #[label]
-        oloc: SourceSpan
+        oloc: SourceSpan,
     },
     #[error("cannot subscript value of type `{val}` with `{sub}`")]
     SubscriptNotDefined {
@@ -45,7 +45,7 @@ pub enum CobaltError {
         #[label("value type is `{val}`")]
         vloc: SourceSpan,
         #[label("subscript type is `{sub}`")]
-        sloc: SourceSpan
+        sloc: SourceSpan,
     },
     #[error("value of type `{val}` has no attribute `{attr}`")]
     AttrNotDefined {
@@ -54,7 +54,7 @@ pub enum CobaltError {
         #[label("value type is `{val}`")]
         vloc: SourceSpan,
         #[label("attribute is `{attr}`")]
-        aloc: SourceSpan
+        aloc: SourceSpan,
     },
     #[error("value of type `{val}` cannot be {}plicitly converted to `{ty}`", if *.is_expl {"ex"} else {"im"})]
     InvalidConversion {
@@ -66,7 +66,7 @@ pub enum CobaltError {
         #[label("target type is `{ty}`")]
         tloc: Option<SourceSpan>,
         #[label]
-        oloc: SourceSpan
+        oloc: SourceSpan,
     },
     #[error("cannot call value of type `{val}` with arguments ({})", .args.join(", "))]
     CannotCallWithArgs {
@@ -77,13 +77,13 @@ pub enum CobaltError {
         #[label("argument types are ({})", .args.join(", "))]
         aloc: Option<SourceSpan>,
         #[related]
-        nargs: Vec<ArgError>
+        nargs: Vec<ArgError>,
     },
     #[error("invalid call to inline assembly")]
     InvalidInlineAsmCall {
         loc: SourceSpan,
         #[related]
-        args: Vec<InvalidAsmArg>
+        args: Vec<InvalidAsmArg>,
     },
     #[error("cannot access element {idx} of a tuple with length {len}")]
     TupleIdxOutOfBounds {
@@ -92,7 +92,7 @@ pub enum CobaltError {
         #[label("tuple length is {len}")]
         tloc: SourceSpan,
         #[label("index is {idx}")]
-        iloc: SourceSpan
+        iloc: SourceSpan,
     },
     #[error("cannot mutate an immutable value")]
     CantMutateImmut {
@@ -103,7 +103,7 @@ pub enum CobaltError {
         oloc: Option<SourceSpan>,
         op: String,
         #[label("defined as immutable here")]
-        floc: SourceSpan
+        floc: SourceSpan,
     },
 
     // Misc stuff
@@ -112,30 +112,30 @@ pub enum CobaltError {
         pos: usize,
         msg: String,
         #[label("error at byte {pos} of glob: {msg}")]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("value cannot be determined at compile-time")]
     NotCompileTime {
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("constant functions aren't yet supported")]
     ConstFnsArentSupported {
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("{}", if let Some(p) = param {format!("cannot convert convert self_t ({self_t}) to {p} for self parameter")} else {"function must have a self parameter".to_string()})]
     InvalidSelfParam {
         self_t: String,
         param: Option<String>,
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error(r#"unknown intrinsic "@{name}""#)]
     UnknownIntrinsic {
         name: String,
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("couldn't call `@{name}`")]
     InvalidIntrinsicCall {
@@ -143,7 +143,7 @@ pub enum CobaltError {
         #[label]
         loc: SourceSpan,
         #[related]
-        errs: Vec<CobaltError>
+        errs: Vec<CobaltError>,
     },
     #[error("@sizeof requires all arguments to be types")]
     ExpectedType {
@@ -151,7 +151,7 @@ pub enum CobaltError {
         loc: SourceSpan,
         #[label("argument type is {ty}")]
         aloc: SourceSpan,
-        ty: String
+        ty: String,
     },
     #[error("bit cast target must be the same size as the source")]
     DifferentBitCastSizes {
@@ -175,20 +175,20 @@ pub enum CobaltError {
         from_loc: SourceSpan,
         to_ty: String,
         #[label("source type is {from_ty}")]
-        to_loc: SourceSpan
+        to_loc: SourceSpan,
     },
     #[error(r#"unknown suffix "{suf}" for {lit} literal"#)]
     UnknownLiteralSuffix {
         suf: String,
         lit: &'static str, // integer, floating-point, character, or string
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("this array has {len} elements, but the maximum is 4294697295")]
     ArrayTooLong {
         len: usize,
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("elements in array aren't the same type")]
     ArrayElementsDontMatch {
@@ -197,30 +197,30 @@ pub enum CobaltError {
         #[label("element type is {new}")]
         loc: SourceSpan,
         #[label("element type previously determined to be {current} here")]
-        prev: SourceSpan
+        prev: SourceSpan,
     },
     #[error("expected UTF-8 string")]
     NonUtf8String {
         pos: usize,
         #[label("this string should be valid UTF-8, but there was an error at byte {pos}")]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("parameter type can't be mutable")]
     #[help("try `mut param: T` instead")]
     ParamCantBeMut {
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("return type can't be mutable")]
     ReturnCantBeMut {
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("can't move out of a reference")]
     CantMoveFromReference {
         #[label("`{ty}` has a destructor, so it can't be moved out of references")]
         loc: SourceSpan,
-        ty: String
+        ty: String,
     },
     #[error("cannot move from variable twice")]
     DoubleMove {
@@ -229,7 +229,7 @@ pub enum CobaltError {
         #[label("previously moved here")]
         prev: Option<SourceSpan>,
         name: String,
-        guaranteed: bool
+        guaranteed: bool,
     },
     #[error("invalid parameters for overloaded operator function")]
     #[help("for `{op}`, the parameters should be ({ex})")]
@@ -238,7 +238,7 @@ pub enum CobaltError {
         loc: SourceSpan,
         op: &'static str,
         ex: &'static str,
-        found: Vec<String>
+        found: Vec<String>,
     },
 
     // @asm issues
@@ -252,7 +252,7 @@ pub enum CobaltError {
         #[label("second argument type is {type2} ({})", if *.const2 {"constant"} else {"runtime-only"})]
         loc2: SourceSpan,
         type2: String,
-        const2: bool
+        const2: bool,
     },
     #[error("invalid creation of inline assembly")]
     #[help("arguments should be a type, then two constant strings (i8 const* or i8[] const&)")]
@@ -268,14 +268,14 @@ pub enum CobaltError {
         #[label("third argument type is {type3} ({})", if *.const3 {"constant"} else {"runtime-only"})]
         loc3: SourceSpan,
         type3: String,
-        const3: bool
+        const3: bool,
     },
     #[error("invalid creation of inline assembly")]
     #[help("valid forms are (constraints, body) and (return, constraints, body)")]
     InvalidInlineAsm {
         nargs: usize,
         #[label("expected 2 or 3 arguments, got {nargs}")]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
 
     // @alloca
@@ -283,18 +283,18 @@ pub enum CobaltError {
     NonRuntimeAllocaType {
         ty: String,
         #[label("type is {ty}")]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("all arguments to @alloca (except for an optional type) must be integral")]
     NonIntegralAllocaArg {
         ty: String,
         #[label("argument type is {ty}")]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("@alloca needs at least one argument, but none were given")]
     AllocaNeedsArgs {
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
 
     // Annotations
@@ -303,7 +303,7 @@ pub enum CobaltError {
         name: String,
         def: &'static str, // "variable", "constant", "type", or "function"
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("{} argument for @{name} annotation{}", if .expected.is_some() {"invalid"} else {"unexpected"}, .found.as_ref().map_or_else(String::new, |f| format!(r#": "{f}""#)))]
     InvalidAnnArgument {
@@ -311,7 +311,7 @@ pub enum CobaltError {
         found: Option<String>,
         expected: Option<&'static str>,
         #[label("{}{}", .expected.as_ref().map_or_else(|| "no arguments should be given".to_string(), |ex| format!("expected {ex}")), .found.as_ref().map_or_else(String::new, |f| format!(r#", found "{f}""#)))]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("@{name} cannot be respecified")]
     RedefAnnArgument {
@@ -319,19 +319,19 @@ pub enum CobaltError {
         #[label]
         loc: SourceSpan,
         #[label("previously defined here")]
-        prev: SourceSpan
+        prev: SourceSpan,
     },
     #[error("@{name} can only be specified for global variables")]
     MustBeGlobal {
         name: &'static str,
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("@{name} can only be specified for local variables")]
     MustBeLocal {
         name: &'static str,
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
 
     // Variables
@@ -341,25 +341,22 @@ pub enum CobaltError {
         module: String,
         container: &'static str, // "module" or "type"
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error(r#""{name}" has not been initialized, most likely because of a cyclical dependency"#)]
     UninitializedGlobal {
         name: String,
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("runtime variable cannot have a const-only type")]
     #[diagnostic(help("consider using `const` instead"))]
-    TypeIsConstOnly {
-        ty: String,
-        loc: SourceSpan
-    },
+    TypeIsConstOnly { ty: String, loc: SourceSpan },
     #[error("{name} is not a module")]
     NotAModule {
         name: String,
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("{name} has already been defined")]
     RedefVariable {
@@ -367,7 +364,7 @@ pub enum CobaltError {
         #[label]
         loc: SourceSpan,
         #[label("previously defined here")]
-        prev: Option<SourceSpan>
+        prev: Option<SourceSpan>,
     },
 
     // warnings
@@ -375,8 +372,8 @@ pub enum CobaltError {
     #[diagnostic(severity(warning))]
     UselessImport {
         #[label]
-        loc: SourceSpan
-    }
+        loc: SourceSpan,
+    },
 }
 #[derive(Debug, Clone, PartialEq, Eq, Error, Diagnostic)]
 pub enum ArgError {
@@ -384,7 +381,7 @@ pub enum ArgError {
     WrongNumArgs {
         found: usize,
         expected: usize,
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("value of type `{val}` cannot be implicitly converted to `{ty}` in {} argument", ordinal::Ordinal(.n + 1))]
     InvalidArg {
@@ -392,40 +389,51 @@ pub enum ArgError {
         ty: String,
         n: usize,
         #[label]
-        loc: SourceSpan
+        loc: SourceSpan,
     },
     #[error("{} parameter is const, but the argument is not", ordinal::Ordinal(.n + 1))]
     ArgMustBeConst {
         n: usize,
         #[label]
-        loc: SourceSpan
-    }
+        loc: SourceSpan,
+    },
 }
 #[derive(Debug, Clone, PartialEq, Eq, Error, Diagnostic)]
 #[error("cannot pass argument of type {0} into inline assembly")]
-pub struct InvalidAsmArg(pub String, #[label("{0} is not a valid assembly type")] pub SourceSpan);
+pub struct InvalidAsmArg(
+    pub String,
+    #[label("{0} is not a valid assembly type")] pub SourceSpan,
+);
 impl CobaltError {
     pub fn with_file(self, file: CobaltFile) -> SourcedCobaltError {
-        if let Self::OtherFile(err) = self {*err}
-        else {SourcedCobaltError {err: self, file}}
+        if let Self::OtherFile(err) = self {
+            *err
+        } else {
+            SourcedCobaltError { err: self, file }
+        }
     }
     pub fn is_err(&self) -> bool {
-        self.severity().map_or(true, |s| s == miette::Severity::Error)
+        self.severity()
+            .map_or(true, |s| s == miette::Severity::Error)
     }
 }
 impl From<SourcedCobaltError> for CobaltError {
     #[inline]
-    fn from(err: SourcedCobaltError) -> Self {Self::OtherFile(Box::new(err))}
+    fn from(err: SourcedCobaltError) -> Self {
+        Self::OtherFile(Box::new(err))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Diagnostic)]
 pub struct SourcedCobaltError {
     err: CobaltError,
     #[source_code]
-    file: CobaltFile
+    file: CobaltFile,
 }
 impl std::fmt::Display for SourcedCobaltError {
     #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {write!(f, "{}", self.err)}
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.err)
+    }
 }
 impl std::error::Error for SourcedCobaltError {}

--- a/cobalt-errors/src/files.rs
+++ b/cobalt-errors/src/files.rs
@@ -1,11 +1,13 @@
-use miette::{SourceCode, SpanContents, SourceSpan, MietteError};
-use parking_lot::{RwLock, RwLockReadGuard, MappedRwLockReadGuard};
+use miette::{MietteError, SourceCode, SourceSpan, SpanContents};
 use once_cell::sync::Lazy;
+use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
 static UNIT_REF: () = ();
 #[allow(clippy::type_complexity)]
 pub struct FileRegistry(Lazy<RwLock<Vec<(String, Vec<InnerFile>)>>>);
 impl FileRegistry {
-    pub(self) const fn new() -> Self {Self(Lazy::new(|| RwLock::new(vec![(String::new(), vec![])])))}
+    pub(self) const fn new() -> Self {
+        Self(Lazy::new(|| RwLock::new(vec![(String::new(), vec![])])))
+    }
     pub fn add_module(&self, name: String) -> usize {
         let mut lock = self.0.write();
         lock.push((name, vec![]));
@@ -14,7 +16,9 @@ impl FileRegistry {
     pub fn add_file(&self, module: usize, mut name: String, contents: String) -> CobaltFile {
         let mut lock = self.0.write();
         let (mname, vec) = &mut lock[module];
-        if !mname.is_empty() {name = format!("{mname}//{name}")} // format files in other modules as module//path/to/file
+        if !mname.is_empty() {
+            name = format!("{mname}//{name}")
+        } // format files in other modules as module//path/to/file
         vec.push(InnerFile(name, contents));
         CobaltFile(module, vec.len() - 1)
     }
@@ -22,43 +26,84 @@ impl FileRegistry {
 /// Wrapper around a span to optionally add a name
 struct MaybeNamed<'a>(Box<dyn SpanContents<'a> + 'a>, Option<&'a str>);
 impl<'a> SpanContents<'a> for MaybeNamed<'a> {
-    fn data(&self) -> &'a [u8] {self.0.data()}
-    fn span(&self) -> &SourceSpan {self.0.span()}
-    fn line(&self) -> usize {self.0.line()}
-    fn column(&self) -> usize {self.0.column()}
-    fn line_count(&self) -> usize {self.0.line_count()}
-    fn name(&self) -> Option<&str> {self.1}
+    fn data(&self) -> &'a [u8] {
+        self.0.data()
+    }
+    fn span(&self) -> &SourceSpan {
+        self.0.span()
+    }
+    fn line(&self) -> usize {
+        self.0.line()
+    }
+    fn column(&self) -> usize {
+        self.0.column()
+    }
+    fn line_count(&self) -> usize {
+        self.0.line_count()
+    }
+    fn name(&self) -> Option<&str> {
+        self.1
+    }
 }
 /// Span carrying a lock guard for thread safety
 /// This has to be implemented like this because the guard requires a reference, and the Box is
 /// owned
-struct LockedSpan<'a>(Box<dyn SpanContents<'a> + 'a>, MappedRwLockReadGuard<'a, ()>);
+struct LockedSpan<'a>(
+    Box<dyn SpanContents<'a> + 'a>,
+    MappedRwLockReadGuard<'a, ()>,
+);
 impl<'a> SpanContents<'a> for LockedSpan<'a> {
-    fn data(&self) -> &'a [u8] {self.0.data()}
-    fn span(&self) -> &SourceSpan {self.0.span()}
-    fn line(&self) -> usize {self.0.line()}
-    fn column(&self) -> usize {self.0.column()}
-    fn line_count(&self) -> usize {self.0.line_count()}
-    fn name(&self) -> Option<&str> {self.0.name()}
+    fn data(&self) -> &'a [u8] {
+        self.0.data()
+    }
+    fn span(&self) -> &SourceSpan {
+        self.0.span()
+    }
+    fn line(&self) -> usize {
+        self.0.line()
+    }
+    fn column(&self) -> usize {
+        self.0.column()
+    }
+    fn line_count(&self) -> usize {
+        self.0.line_count()
+    }
+    fn name(&self) -> Option<&str> {
+        self.0.name()
+    }
 }
 /// File implementation. It's like `miette::NamedSource`, but returns a `MaybeNamed`, so it is
 /// unnamed if the file name is an empty string
 struct InnerFile(String, String);
 impl SourceCode for InnerFile {
-    fn read_span<'a>(&'a self, span: &SourceSpan, clb: usize, cla: usize) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
-        Ok(Box::new(MaybeNamed(self.1.read_span(span, clb, cla)?, (!self.0.is_empty()).then_some(&self.0))))
+    fn read_span<'a>(
+        &'a self,
+        span: &SourceSpan,
+        clb: usize,
+        cla: usize,
+    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+        Ok(Box::new(MaybeNamed(
+            self.1.read_span(span, clb, cla)?,
+            (!self.0.is_empty()).then_some(&self.0),
+        )))
     }
 }
-/// Lightweight, copyable 
+/// Lightweight, copyable
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CobaltFile(usize, usize);
 impl CobaltFile {
     /// Get the name of the file that this points to.
-    pub fn name(self) -> MappedRwLockReadGuard<'static, str> {RwLockReadGuard::map(FILES.0.read(), |lock| lock[self.0].1[self.1].0.as_str())}
+    pub fn name(self) -> MappedRwLockReadGuard<'static, str> {
+        RwLockReadGuard::map(FILES.0.read(), |lock| lock[self.0].1[self.1].0.as_str())
+    }
     /// Get the contents of the file.
-    pub fn contents(self) -> MappedRwLockReadGuard<'static, str> {RwLockReadGuard::map(FILES.0.read(), |lock| lock[self.0].1[self.1].1.as_str())}
+    pub fn contents(self) -> MappedRwLockReadGuard<'static, str> {
+        RwLockReadGuard::map(FILES.0.read(), |lock| lock[self.0].1[self.1].1.as_str())
+    }
     /// Extract the module identifier.
-    pub fn module_id(self) -> usize {self.0}
+    pub fn module_id(self) -> usize {
+        self.0
+    }
     /// Return the source location of a point
     pub fn source_loc(self, loc: usize) -> Result<(usize, usize), MietteError> {
         let lock = FILES.0.read();
@@ -68,10 +113,17 @@ impl CobaltFile {
     }
 }
 impl SourceCode for CobaltFile {
-    fn read_span<'a>(&'a self, span: &SourceSpan, clb: usize, cla: usize) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    fn read_span<'a>(
+        &'a self,
+        span: &SourceSpan,
+        clb: usize,
+        cla: usize,
+    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
         let mut res: Option<Result<Box<dyn SpanContents<'a> + 'a>, MietteError>> = None;
         let lock = RwLockReadGuard::map(FILES.0.read(), |lock| {
-            res = Some(unsafe {std::mem::transmute(lock[self.0].1[self.1].read_span(span, clb, cla))}); // transmute to avoid borrowing
+            res = Some(unsafe {
+                std::mem::transmute(lock[self.0].1[self.1].read_span(span, clb, cla))
+            }); // transmute to avoid borrowing
             &UNIT_REF // we need to return a reference to something
         });
         Ok(Box::new(LockedSpan(res.unwrap()?, lock)))

--- a/cobalt-errors/src/lib.rs
+++ b/cobalt-errors/src/lib.rs
@@ -1,8 +1,8 @@
 /// Convenience re-exports so miette doesn't have to be a dependency
-pub use miette::{SourceSpan, Report};
+pub use miette::{Report, SourceSpan};
 /// File registry
 pub mod files;
-pub use files::{FILES, CobaltFile};
+pub use files::{CobaltFile, FILES};
 /// `warning!` and `error!`
 pub mod color;
 /// CobaltError and SourcedError
@@ -10,9 +10,11 @@ pub mod error;
 pub use error::*;
 pub use miette;
 
-pub fn unreachable_span() -> SourceSpan {(usize::MAX, usize::MAX).into()}
+pub fn unreachable_span() -> SourceSpan {
+    (usize::MAX, usize::MAX).into()
+}
 pub fn merge_spans(a: SourceSpan, b: SourceSpan) -> SourceSpan {
-    use std::cmp::{min, max};
+    use std::cmp::{max, min};
     let start = min(a.offset(), b.offset());
     let end = max(a.offset() + a.len(), b.offset() + b.len());
     (start, end - start).into()

--- a/cobalt-llvm/build.rs
+++ b/cobalt-llvm/build.rs
@@ -3,6 +3,7 @@
 // - Linking method is prefer-dynamic by default
 // - Small refactors have been made to satisfy Clippy
 
+use const_format::formatcp;
 use lazy_static::lazy_static;
 use regex::Regex;
 use semver::Version;
@@ -11,7 +12,6 @@ use std::ffi::OsStr;
 use std::io::{self, ErrorKind};
 use std::path::PathBuf;
 use std::process::Command;
-use const_format::formatcp;
 
 #[cfg(not(any(feature = "llvm-15", feature = "llvm-16")))]
 compile_error!("Either LLVM 15 or LLVM 16 must be specified!");
@@ -47,7 +47,6 @@ lazy_static! {
     /// Filesystem path to an llvm-config binary for the correct version.
     static ref LLVM_CONFIG_PATH: Option<PathBuf> = locate_llvm_config();
 }
-
 
 fn target_os_is(name: &str) -> bool {
     match env::var_os("CARGO_CFG_TARGET_OS") {
@@ -102,7 +101,7 @@ fn llvm_config_binary_names() -> std::vec::IntoIter<String> {
         formatcp!("llvm-config-{LLVM_MAJOR}").into(),
         formatcp!("llvm{LLVM_MAJOR}-config").into(),
         formatcp!("llvm-config-{LLVM_MAJOR}.0").into(),
-        formatcp!("llvm-config{LLVM_MAJOR}0").into()
+        formatcp!("llvm-config{LLVM_MAJOR}0").into(),
     ];
 
     // On Windows, also search for llvm-config.exe
@@ -139,7 +138,9 @@ fn is_blocklisted_llvm(llvm_version: &Version) -> Option<&'static str> {
 
     for &(major, minor, patch, reason) in BLOCKLIST.iter() {
         let bad_version = Version {
-            major, minor, patch,
+            major,
+            minor,
+            patch,
             pre: semver::Prerelease::EMPTY,
             build: semver::BuildMetadata::EMPTY,
         };
@@ -171,7 +172,6 @@ fn is_compatible_llvm(llvm_version: &Version) -> bool {
             || (llvm_version.major == CRATE_VERSION.major
                 && llvm_version.minor >= CRATE_VERSION.minor)
     }
-
 }
 
 /// Get the output from running `llvm-config` with the given argument.
@@ -244,7 +244,6 @@ fn llvm_version<S: AsRef<OsStr>>(binary: &S) -> io::Result<Version> {
     };
     Ok(Version::parse(&s).unwrap())
 }
-
 
 fn main() {
     // Behavior can be significantly affected by these vars.

--- a/cobalt-llvm/src/lib.rs
+++ b/cobalt-llvm/src/lib.rs
@@ -17,7 +17,7 @@ macro_rules! if_llvm_15 {
 #[cfg(not(feature = "llvm-15"))]
 #[macro_export]
 macro_rules! if_llvm_15 {
-    ($($tok:tt)*) => {}
+    ($($tok:tt)*) => {};
 }
 
 #[cfg(feature = "llvm-16")]
@@ -29,5 +29,5 @@ macro_rules! if_llvm_16 {
 #[cfg(not(feature = "llvm-16"))]
 #[macro_export]
 macro_rules! if_llvm_16 {
-    ($($tok:tt)*) => {}
+    ($($tok:tt)*) => {};
 }

--- a/cobalt-parser/src/lib.rs
+++ b/cobalt-parser/src/lib.rs
@@ -1,13 +1,13 @@
+use chumsky::{error::RichReason, prelude::*};
+use cobalt_ast::{ast::*, *};
+use cobalt_errors::miette::{LabeledSpan, MietteDiagnostic, SourceSpan};
 use cobalt_errors::*;
-use cobalt_ast::{*, ast::*};
 use unicode_ident::*;
-use chumsky::{prelude::*, error::RichReason};
-use cobalt_errors::miette::{MietteDiagnostic, LabeledSpan, SourceSpan};
 mod utils;
 pub mod prelude {
+    pub use super::cvt_err;
     pub use super::parse_expr;
     pub use super::parse_tl;
-    pub use super::cvt_err;
     pub use chumsky::Parser as _;
 }
 fn cvt_reason(span: SimpleSpan, err: RichReason<'_, char, &'static str>) -> Vec<MietteDiagnostic> {
@@ -15,10 +15,11 @@ fn cvt_reason(span: SimpleSpan, err: RichReason<'_, char, &'static str>) -> Vec<
         errs.sort();
         errs.dedup();
         errs.into_iter().flat_map(|e| cvt_reason(span, e)).collect()
-    }
-    else {
+    } else {
         let mut msg = err.to_string();
-        if let Some(idx) = msg.find(" expected") {msg.insert(idx, ',')} // the lack of the comma was bothering me
+        if let Some(idx) = msg.find(" expected") {
+            msg.insert(idx, ',')
+        } // the lack of the comma was bothering me
         vec![MietteDiagnostic::new(msg).with_label(LabeledSpan::underline(span.into_range()))]
     }
 }
@@ -29,18 +30,20 @@ pub fn cvt_err(err: Rich<char>) -> Vec<MietteDiagnostic> {
 }
 /// for use with map_with_span
 #[inline(always)]
-fn add_loc<T>(val: T, loc: SimpleSpan) -> (T, SourceSpan) {(val, loc.into_range().into())}
+fn add_loc<T>(val: T, loc: SimpleSpan) -> (T, SourceSpan) {
+    (val, loc.into_range().into())
+}
 /// wrapper around Box::new that makes the output dyn
 #[inline(always)]
-fn box_ast<T: AST + 'static>(val: T) -> Box<dyn AST> {Box::new(val)}
+fn box_ast<T: AST + 'static>(val: T) -> Box<dyn AST> {
+    Box::new(val)
+}
 // useful type definitions
 type Extras<'a> = chumsky::extra::Full<Rich<'a, char>, (), ()>;
 type BoxedParser<'a, 'b, T> = Boxed<'a, 'b, &'a str, T, Extras<'a>>;
 type BoxedASTParser<'a, 'b> = BoxedParser<'a, 'b, Box<dyn AST>>;
 static KEYWORDS: &[&str] = &[
-    "let", "mut", "const", "fn",
-    "if", "else", "while", "for",
-    "null", "type"
+    "let", "mut", "const", "fn", "if", "else", "while", "for", "null", "type",
 ];
 /// parse an identifier. unicode-aware
 fn ident<'a>() -> impl Parser<'a, &'a str, &'a str, Extras<'a>> + Copy {
@@ -48,13 +51,34 @@ fn ident<'a>() -> impl Parser<'a, &'a str, &'a str, Extras<'a>> + Copy {
         .filter(|&c| c == '_' || is_xid_start(c))
         .then(any().filter(|&c| is_xid_continue(c)).repeated())
         .slice()
-        .try_map(|val, span| if KEYWORDS.contains(&val) {Err(Rich::custom(span, format!("`{val}` is a keyword and cannot be used as an identifier")))} else {Ok(val)})
+        .try_map(|val, span| {
+            if KEYWORDS.contains(&val) {
+                Err(Rich::custom(
+                    span,
+                    format!("`{val}` is a keyword and cannot be used as an identifier"),
+                ))
+            } else {
+                Ok(val)
+            }
+        })
         .labelled("an identifier")
 }
-fn local_id<'a>() -> impl Parser<'a, &'a str, DottedName, Extras<'a>> + Copy {ident().map_with_span(|id, loc| DottedName::local((id.to_string(), loc.into_range().into()))).labelled("a local identifier")}
+fn local_id<'a>() -> impl Parser<'a, &'a str, DottedName, Extras<'a>> + Copy {
+    ident()
+        .map_with_span(|id, loc| DottedName::local((id.to_string(), loc.into_range().into())))
+        .labelled("a local identifier")
+}
 fn global_id<'a>() -> impl Parser<'a, &'a str, DottedName, Extras<'a>> + Copy {
-    just('.').or_not().map(|o| o.is_some())
-        .then(ident().map_with_span(|id, loc| (id.to_string(), loc.into_range().into())).separated_by(just('.')).at_least(1).collect())
+    just('.')
+        .or_not()
+        .map(|o| o.is_some())
+        .then(
+            ident()
+                .map_with_span(|id, loc| (id.to_string(), loc.into_range().into()))
+                .separated_by(just('.'))
+                .at_least(1)
+                .collect(),
+        )
         .map(|(global, ids)| DottedName::new(ids, global))
         .labelled("a global identifier")
 }
@@ -64,12 +88,18 @@ fn ignored<'a>() -> impl Parser<'a, &'a str, (), Extras<'a>> + Copy {
         any().filter(|c: &char| c.is_whitespace()).ignored(),
         // multiline comment
         just('#').ignore_then(just('=').repeated().at_least(1).count().then_with_ctx({
-            let term = just('=').repeated().configure(|cfg, &ctx| cfg.exactly(ctx)).then_ignore(just('#'));
+            let term = just('=')
+                .repeated()
+                .configure(|cfg, &ctx| cfg.exactly(ctx))
+                .then_ignore(just('#'));
             any().and_is(term.not()).repeated().then_ignore(term)
         })),
         // single-line comment
-        just('#').ignore_then(any().and_is(text::newline().not()).repeated())
-    )).repeated().ignored().labelled("whitespace")
+        just('#').ignore_then(any().and_is(text::newline().not()).repeated()),
+    ))
+    .repeated()
+    .ignored()
+    .labelled("whitespace")
 }
 /// where a declaration is being parsed
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -79,42 +109,50 @@ enum DeclLoc {
     /// method scope- in the method block of a type definition
     Method,
     /// global scope- do I need to explain this?
-    Global
+    Global,
 }
-fn annotation<'a>() -> impl Parser<'a, &'a str, (String, Option<String>, SourceSpan), Extras<'a>> + Copy {
+fn annotation<'a>(
+) -> impl Parser<'a, &'a str, (String, Option<String>, SourceSpan), Extras<'a>> + Copy {
     just('@')
         .ignore_then(ident())
-        .then(none_of(')').repeated().collect().delimited_by(just('('), just(')')).or_not())
+        .then(
+            none_of(')')
+                .repeated()
+                .collect()
+                .delimited_by(just('('), just(')'))
+                .or_not(),
+        )
         .map_with_span(|(name, arg), loc| (name.to_string(), arg, loc.into_range().into()))
         .labelled("an annotation")
 }
 fn cdn<'a>() -> impl Parser<'a, &'a str, CompoundDottedName, Extras<'a>> + Clone {
     use CompoundDottedNameSegment::*;
-    let cdns = recursive(|cdns| choice((
-        ident().map_with_span(|id, loc| Identifier(id.to_string(), loc.into_range().into())),
-        just('*').map_with_span(|_, loc: SimpleSpan| Glob(loc.into_range().into())),
-        cdns
-            .separated_by(just('.')
-                .padded_by(ignored())
-                .ignored()
-                .recover_with(skip_then_retry_until(none_of(".,}").ignored(), one_of(".,}").ignored()))
-            )
+    let cdns = recursive(|cdns| {
+        choice((
+            ident().map_with_span(|id, loc| Identifier(id.to_string(), loc.into_range().into())),
+            just('*').map_with_span(|_, loc: SimpleSpan| Glob(loc.into_range().into())),
+            cdns.separated_by(just('.').padded_by(ignored()).ignored().recover_with(
+                skip_then_retry_until(none_of(".,}").ignored(), one_of(".,}").ignored()),
+            ))
             .collect()
-            .separated_by(just(',')
-                .padded_by(ignored())
-                .ignored()
-                .recover_with(skip_then_retry_until(none_of(",}").ignored(), one_of(",}").ignored()))
-            )
+            .separated_by(just(',').padded_by(ignored()).ignored().recover_with(
+                skip_then_retry_until(none_of(",}").ignored(), one_of(",}").ignored()),
+            ))
             .collect()
             .delimited_by(just('{'), just('}'))
-            .map(Group)
-    )));
-    just('.').or_not().map(|o| o.is_some()).then_ignore(ignored())
-        .then(cdns
-                .separated_by(just('.')
-                .padded_by(ignored()).ignored()
-                .recover_with(skip_then_retry_until(none_of(".,}").ignored(), one_of(".,}").ignored())))
-            .collect())
+            .map(Group),
+        ))
+    });
+    just('.')
+        .or_not()
+        .map(|o| o.is_some())
+        .then_ignore(ignored())
+        .then(
+            cdns.separated_by(just('.').padded_by(ignored()).ignored().recover_with(
+                skip_then_retry_until(none_of(".,}").ignored(), one_of(".,}").ignored()),
+            ))
+            .collect(),
+        )
         .map(|(global, ids)| CompoundDottedName::new(ids, global))
 }
 fn import<'a>() -> impl Parser<'a, &'a str, ImportAST, Extras<'a>> + Clone {
@@ -124,107 +162,350 @@ fn import<'a>() -> impl Parser<'a, &'a str, ImportAST, Extras<'a>> + Clone {
         .then(cdn())
         .map(|((anns, loc), cdn)| ImportAST::new(loc.into_range().into(), cdn, anns))
         .labelled("an import")
-} 
+}
 /// parse declarations. these are:
 /// - functions
 /// - variables
 /// - type definitions
-fn declarations<'a>(loc: DeclLoc, metd: Option<BoxedASTParser<'a, 'a>>, part_expr: &BoxedASTParser<'a, 'a>) -> impl Parser<'a, &'a str, Box<dyn AST>, Extras<'a>> + Clone + 'a {
+fn declarations<'a>(
+    loc: DeclLoc,
+    metd: Option<BoxedASTParser<'a, 'a>>,
+    part_expr: &BoxedASTParser<'a, 'a>,
+) -> impl Parser<'a, &'a str, Box<dyn AST>, Extras<'a>> + Clone + 'a {
     let full_expr = add_assigns(part_expr.clone());
     let expr_clone = part_expr.clone();
-    let metd = metd.unwrap_or_else(|| recursive(move |m| declarations(DeclLoc::Method, Some(m.boxed()), &expr_clone)).boxed());
-    let id = if loc == DeclLoc::Global {global_id().boxed()} else {local_id().boxed()}; // TODO: remove allocation
+    let metd = metd.unwrap_or_else(|| {
+        recursive(move |m| declarations(DeclLoc::Method, Some(m.boxed()), &expr_clone)).boxed()
+    });
+    let id = if loc == DeclLoc::Global {
+        global_id().boxed()
+    } else {
+        local_id().boxed()
+    }; // TODO: remove allocation
     let anns = annotation().padded_by(ignored()).repeated().collect();
-    let param = choice((text::keyword("mut").to(ParamType::Mutable), text::keyword("const").to(ParamType::Constant), empty().to(ParamType::Normal)))
-        .then_ignore(ignored())
-        .then(ident()
+    let param = choice((
+        text::keyword("mut").to(ParamType::Mutable),
+        text::keyword("const").to(ParamType::Constant),
+        empty().to(ParamType::Normal),
+    ))
+    .then_ignore(ignored())
+    .then(
+        ident()
             .or_not()
             .map(|v| v.map_or_else(String::new, String::from))
-            .labelled("parameter name"))
-        .then_ignore(ignored())
-        .then(just(':')
-            .recover_with(skip_then_retry_until(any().filter(|&c| is_xid_continue(c)).repeated().at_least(1).ignored().or(any().ignored()), one_of(":=)").ignored()))
-            .recover_with(skip_until(any().ignored(), one_of(":,;=)").ignored().or(end()), || '-'))
+            .labelled("parameter name"),
+    )
+    .then_ignore(ignored())
+    .then(
+        just(':')
+            .recover_with(skip_then_retry_until(
+                any()
+                    .filter(|&c| is_xid_continue(c))
+                    .repeated()
+                    .at_least(1)
+                    .ignored()
+                    .or(any().ignored()),
+                one_of(":=)").ignored(),
+            ))
+            .recover_with(skip_until(
+                any().ignored(),
+                one_of(":,;=)").ignored().or(end()),
+                || '-',
+            ))
             .ignore_then(ignored())
-            .ignore_then(part_expr.clone().recover_with(via_parser(none_of(";,=)").repeated().map_with_span(|_, loc: SimpleSpan| box_ast(ErrorTypeAST::new(loc.into_range().into()))))))
-            .labelled("parameter type"))
-        .then_ignore(ignored())
-        .then(just('=')
+            .ignore_then(
+                part_expr.clone().recover_with(via_parser(
+                    none_of(";,=)")
+                        .repeated()
+                        .map_with_span(|_, loc: SimpleSpan| {
+                            box_ast(ErrorTypeAST::new(loc.into_range().into()))
+                        }),
+                )),
+            )
+            .labelled("parameter type"),
+    )
+    .then_ignore(ignored())
+    .then(
+        just('=')
             .ignore_then(ignored())
-            .ignore_then(full_expr.clone().recover_with(via_parser(none_of(",)").repeated().map_with_span(|_, span: SimpleSpan| box_ast(ErrorAST::new(span.end.into())))))).or_not().labelled("default value"))
-        .map(|(((pty, name), ty), default)| (name, pty, ty, default))
-        .and_is(none_of("),").rewind())
-        .boxed();
+            .ignore_then(
+                full_expr.clone().recover_with(via_parser(
+                    none_of(",)")
+                        .repeated()
+                        .map_with_span(|_, span: SimpleSpan| {
+                            box_ast(ErrorAST::new(span.end.into()))
+                        }),
+                )),
+            )
+            .or_not()
+            .labelled("default value"),
+    )
+    .map(|(((pty, name), ty), default)| (name, pty, ty, default))
+    .and_is(none_of("),").rewind())
+    .boxed();
     choice([
         anns.then(text::keyword("let").map_with_span(|_, loc: SimpleSpan| loc.into_range().into()))
             .then_ignore(ignored())
-            .then(text::keyword("mut").ignore_then(ignored()).or_not().map(|o| o.is_some()))
+            .then(
+                text::keyword("mut")
+                    .ignore_then(ignored())
+                    .or_not()
+                    .map(|o| o.is_some()),
+            )
             .then(
                 id.clone()
-                .recover_with(skip_then_retry_until(any().filter(|&c| is_xid_continue(c)).repeated().at_least(1).ignored().or(any().ignored()), one_of(":=;").ignored()))
-                .recover_with(skip_until(any().ignored(), one_of(":=;").rewind().ignored().or(end()), || DottedName::local(("<error>".to_string(), unreachable_span())))))
+                    .recover_with(skip_then_retry_until(
+                        any()
+                            .filter(|&c| is_xid_continue(c))
+                            .repeated()
+                            .at_least(1)
+                            .ignored()
+                            .or(any().ignored()),
+                        one_of(":=;").ignored(),
+                    ))
+                    .recover_with(skip_until(
+                        any().ignored(),
+                        one_of(":=;").rewind().ignored().or(end()),
+                        || DottedName::local(("<error>".to_string(), unreachable_span())),
+                    )),
+            )
             .then_ignore(ignored())
-            .then(just(':').labelled("variable type").ignore_then(ignored()).ignore_then(part_expr.clone().recover_with(via_parser(none_of(",=;").repeated().map_with_span(|_, span: SimpleSpan| box_ast(ErrorTypeAST::new(span.end.into())))))).or_not())
+            .then(
+                just(':')
+                    .labelled("variable type")
+                    .ignore_then(ignored())
+                    .ignore_then(part_expr.clone().recover_with(
+                        via_parser(none_of(",=;").repeated().map_with_span(
+                            |_, span: SimpleSpan| box_ast(ErrorTypeAST::new(span.end.into())),
+                        )),
+                    ))
+                    .or_not(),
+            )
             .then_ignore(ignored())
-            .then(just('=').labelled("variable value").ignore_then(ignored()).ignore_then(full_expr.clone().recover_with(via_parser(none_of(",;").repeated().map_with_span(|_, span: SimpleSpan| box_ast(ErrorAST::new(span.end.into())))))).or_not().map_with_span(|expr, loc| expr.unwrap_or_else(|| box_ast(NullAST::new(loc.into_range().into())))))
-            .map(move |(((((anns, l), is_mut), name), ty), val)| box_ast(VarDefAST::new(l, name, val, ty, anns, loc == DeclLoc::Global, is_mut)))
+            .then(
+                just('=')
+                    .labelled("variable value")
+                    .ignore_then(ignored())
+                    .ignore_then(full_expr.clone().recover_with(
+                        via_parser(none_of(",;").repeated().map_with_span(
+                            |_, span: SimpleSpan| box_ast(ErrorAST::new(span.end.into())),
+                        )),
+                    ))
+                    .or_not()
+                    .map_with_span(|expr, loc| {
+                        expr.unwrap_or_else(|| box_ast(NullAST::new(loc.into_range().into())))
+                    }),
+            )
+            .map(move |(((((anns, l), is_mut), name), ty), val)| {
+                box_ast(VarDefAST::new(
+                    l,
+                    name,
+                    val,
+                    ty,
+                    anns,
+                    loc == DeclLoc::Global,
+                    is_mut,
+                ))
+            })
             .boxed(),
-        anns.then(text::keyword("const").map_with_span(|_, loc: SimpleSpan| loc.into_range().into()))
-            .then_ignore(ignored())
-            .then(
-                id.clone()
-                .recover_with(skip_then_retry_until(any().filter(|&c| is_xid_continue(c)).repeated().at_least(1).ignored().or(any().ignored()), one_of(":=;").ignored()))
-                .recover_with(skip_until(any().ignored(), one_of(":=;").rewind().ignored().or(end()), || DottedName::local(("<error>".to_string(), unreachable_span())))))
-            .then_ignore(ignored())
-            .then(just(':').labelled("variable type").ignore_then(ignored()).ignore_then(part_expr.clone().recover_with(via_parser(none_of(",=;").repeated().map_with_span(|_, span: SimpleSpan| box_ast(ErrorTypeAST::new(span.end.into())))))).or_not())
-            .then_ignore(ignored())
-            .then(just('=').labelled("variable value").ignore_then(ignored()).ignore_then(full_expr.clone().recover_with(via_parser(none_of(",;").repeated().map_with_span(|_, span: SimpleSpan| box_ast(ErrorAST::new(span.end.into())))))).or_not().map_with_span(|expr, loc| expr.unwrap_or_else(|| box_ast(NullAST::new(loc.into_range().into())))))
-            .map(move |((((anns, l), name), ty), val)| box_ast(ConstDefAST::new(l, name, val, ty, anns)))
-            .boxed(),
-        anns.then(text::keyword("type").map_with_span(|_, loc: SimpleSpan| loc.into_range().into()))
-            .then_ignore(ignored())
-            .then(
-                id.clone()
-                .recover_with(skip_then_retry_until(any().filter(|&c| is_xid_continue(c)).repeated().at_least(1).ignored().or(any().ignored()), one_of(":=;").ignored()))
-                .recover_with(skip_until(any().ignored(), one_of(":=;").rewind().ignored().or(end()), || DottedName::local(("<error>".to_string(), unreachable_span())))))
-            .then_ignore(ignored())
-            .then(just('=')
+        anns.then(
+            text::keyword("const").map_with_span(|_, loc: SimpleSpan| loc.into_range().into()),
+        )
+        .then_ignore(ignored())
+        .then(
+            id.clone()
+                .recover_with(skip_then_retry_until(
+                    any()
+                        .filter(|&c| is_xid_continue(c))
+                        .repeated()
+                        .at_least(1)
+                        .ignored()
+                        .or(any().ignored()),
+                    one_of(":=;").ignored(),
+                ))
+                .recover_with(skip_until(
+                    any().ignored(),
+                    one_of(":=;").rewind().ignored().or(end()),
+                    || DottedName::local(("<error>".to_string(), unreachable_span())),
+                )),
+        )
+        .then_ignore(ignored())
+        .then(
+            just(':')
+                .labelled("variable type")
+                .ignore_then(ignored())
+                .ignore_then(
+                    part_expr.clone().recover_with(via_parser(
+                        none_of(",=;")
+                            .repeated()
+                            .map_with_span(|_, span: SimpleSpan| {
+                                box_ast(ErrorTypeAST::new(span.end.into()))
+                            }),
+                    )),
+                )
+                .or_not(),
+        )
+        .then_ignore(ignored())
+        .then(
+            just('=')
+                .labelled("variable value")
+                .ignore_then(ignored())
+                .ignore_then(
+                    full_expr.clone().recover_with(via_parser(
+                        none_of(",;")
+                            .repeated()
+                            .map_with_span(|_, span: SimpleSpan| {
+                                box_ast(ErrorAST::new(span.end.into()))
+                            }),
+                    )),
+                )
+                .or_not()
+                .map_with_span(|expr, loc| {
+                    expr.unwrap_or_else(|| box_ast(NullAST::new(loc.into_range().into())))
+                }),
+        )
+        .map(move |((((anns, l), name), ty), val)| {
+            box_ast(ConstDefAST::new(l, name, val, ty, anns))
+        })
+        .boxed(),
+        anns.then(
+            text::keyword("type").map_with_span(|_, loc: SimpleSpan| loc.into_range().into()),
+        )
+        .then_ignore(ignored())
+        .then(
+            id.clone()
+                .recover_with(skip_then_retry_until(
+                    any()
+                        .filter(|&c| is_xid_continue(c))
+                        .repeated()
+                        .at_least(1)
+                        .ignored()
+                        .or(any().ignored()),
+                    one_of(":=;").ignored(),
+                ))
+                .recover_with(skip_until(
+                    any().ignored(),
+                    one_of(":=;").rewind().ignored().or(end()),
+                    || DottedName::local(("<error>".to_string(), unreachable_span())),
+                )),
+        )
+        .then_ignore(ignored())
+        .then(
+            just('=')
                 .ignore_then(ignored())
                 .ignore_then(full_expr.clone())
                 .labelled("type body")
                 .recover_with(via_parser(
-                    any().and_is(just("::").or(just(";"))
-                        .not())
+                    any()
+                        .and_is(just("::").or(just(";")).not())
                         .repeated()
-                        .ignore_then(empty().to_span().map(|loc: SimpleSpan| box_ast(ErrorTypeAST::new(loc.end.into()))))))
-                    )
-            .then_ignore(ignored())
-            .then(just("::").then_ignore(ignored())
-                .ignore_then(metd
-                    .padded_by(ignored())
-                    .then_ignore(just(';').recover_with(skip_then_retry_until(none_of(";}").ignored(), end())).ignore_then(ignored()).ignore_then(ignored()))
-                    .repeated().collect()
-                    .delimited_by(just('{'), just('}')))
-                        .or_not().map(Option::unwrap_or_default))
-            .map(|((((anns, loc), name), val), metds)| box_ast(TypeDefAST::new(loc, name, val, anns, metds)))
-            .boxed(),
+                        .ignore_then(
+                            empty()
+                                .to_span()
+                                .map(|loc: SimpleSpan| box_ast(ErrorTypeAST::new(loc.end.into()))),
+                        ),
+                )),
+        )
+        .then_ignore(ignored())
+        .then(
+            just("::")
+                .then_ignore(ignored())
+                .ignore_then(
+                    metd.padded_by(ignored())
+                        .then_ignore(
+                            just(';')
+                                .recover_with(skip_then_retry_until(none_of(";}").ignored(), end()))
+                                .ignore_then(ignored())
+                                .ignore_then(ignored()),
+                        )
+                        .repeated()
+                        .collect()
+                        .delimited_by(just('{'), just('}')),
+                )
+                .or_not()
+                .map(Option::unwrap_or_default),
+        )
+        .map(|((((anns, loc), name), val), metds)| {
+            box_ast(TypeDefAST::new(loc, name, val, anns, metds))
+        })
+        .boxed(),
         anns.then(text::keyword("fn").map_with_span(|_, loc: SimpleSpan| loc.into_range().into()))
             .then_ignore(ignored())
             .then(
                 id.clone()
-                .recover_with(skip_then_retry_until(any().filter(|&c| is_xid_continue(c)).repeated().at_least(1).ignored().or(any().ignored()), one_of(":=;").ignored()))
-                .recover_with(skip_until(any().ignored(), one_of(":=;").rewind().ignored().or(end()), || DottedName::local(("<error>".to_string(), unreachable_span())))))
+                    .recover_with(skip_then_retry_until(
+                        any()
+                            .filter(|&c| is_xid_continue(c))
+                            .repeated()
+                            .at_least(1)
+                            .ignored()
+                            .or(any().ignored()),
+                        one_of(":=;").ignored(),
+                    ))
+                    .recover_with(skip_until(
+                        any().ignored(),
+                        one_of(":=;").rewind().ignored().or(end()),
+                        || DottedName::local(("<error>".to_string(), unreachable_span())),
+                    )),
+            )
             .then_ignore(ignored())
-            .then(param
-                .separated_by(just(',').padded_by(ignored()).recover_with(skip_then_retry_until(none_of(":=;").ignored(), one_of(":=;").ignored()))).allow_trailing().collect()
-                .delimited_by(just('('), just(')').recover_with(skip_then_retry_until(none_of(":=;").ignored(), one_of(":=;").ignored()))))
+            .then(
+                param
+                    .separated_by(just(',').padded_by(ignored()).recover_with(
+                        skip_then_retry_until(none_of(":=;").ignored(), one_of(":=;").ignored()),
+                    ))
+                    .allow_trailing()
+                    .collect()
+                    .delimited_by(
+                        just('('),
+                        just(')').recover_with(skip_then_retry_until(
+                            none_of(":=;").ignored(),
+                            one_of(":=;").ignored(),
+                        )),
+                    ),
+            )
             .then_ignore(ignored())
-            .then(just(':').ignore_then(ignored()).ignore_then(part_expr.clone().recover_with(via_parser(none_of(",=;").repeated().map_with_span(|_, span: SimpleSpan| box_ast(ErrorTypeAST::new(span.end.into())))))).or_not().map_with_span(|expr, loc| expr.unwrap_or_else(|| box_ast(NullAST::new(loc.into_range().into())))))
+            .then(
+                just(':')
+                    .ignore_then(ignored())
+                    .ignore_then(part_expr.clone().recover_with(
+                        via_parser(none_of(",=;").repeated().map_with_span(
+                            |_, span: SimpleSpan| box_ast(ErrorTypeAST::new(span.end.into())),
+                        )),
+                    ))
+                    .or_not()
+                    .map_with_span(|expr, loc| {
+                        expr.unwrap_or_else(|| box_ast(NullAST::new(loc.into_range().into())))
+                    }),
+            )
             .then_ignore(ignored())
-            .then(just('=').ignore_then(ignored()).ignore_then(full_expr.clone().recover_with(via_parser(none_of(",;").repeated().map_with_span(|_, span: SimpleSpan| box_ast(ErrorAST::new(span.end.into())))))).or_not().map_with_span(|expr, loc| expr.unwrap_or_else(|| box_ast(NullAST::new(loc.into_range().into())))))
-            .map(move |(((((anns, l), name), params), ret), body)| box_ast(FnDefAST::new(l, name, ret, params, body, anns, loc == DeclLoc::Method)))
+            .then(
+                just('=')
+                    .ignore_then(ignored())
+                    .ignore_then(full_expr.clone().recover_with(
+                        via_parser(none_of(",;").repeated().map_with_span(
+                            |_, span: SimpleSpan| box_ast(ErrorAST::new(span.end.into())),
+                        )),
+                    ))
+                    .or_not()
+                    .map_with_span(|expr, loc| {
+                        expr.unwrap_or_else(|| box_ast(NullAST::new(loc.into_range().into())))
+                    }),
+            )
+            .map(move |(((((anns, l), name), params), ret), body)| {
+                box_ast(FnDefAST::new(
+                    l,
+                    name,
+                    ret,
+                    params,
+                    body,
+                    anns,
+                    loc == DeclLoc::Method,
+                ))
+            })
             .boxed(),
-    ]).labelled("a declaration")
+    ])
+    .labelled("a declaration")
 }
 /// create a parser for a statement.
 /// it requires an expression parser to passed, otherwise it would require infinite recursion
@@ -232,193 +513,465 @@ fn def_stmt<'a>(expr: BoxedASTParser<'a, 'a>) -> BoxedASTParser<'a, 'a> {
     choice((
         declarations(DeclLoc::Local, None, &expr),
         import().map(box_ast),
-        add_assigns(expr)
-    )).boxed()
+        add_assigns(expr),
+    ))
+    .boxed()
 }
 fn top_level<'a>() -> impl Parser<'a, &'a str, Box<dyn AST>, Extras<'a>> + Clone {
     let anns = annotation().padded_by(ignored()).repeated().collect();
-    recursive(|tl| choice((
-        declarations(DeclLoc::Global, None, &expr_impl()).padded_by(ignored())
-            .then_ignore(just(';').recover_with(skip_then_retry_until(none_of(';').ignored(), end())).ignore_then(ignored())),
-        import().then_ignore(ignored().then_ignore(just(';')).recover_with(skip_until(empty(), any().ignored(), || ()))).map(box_ast),
-        anns.then(text::keyword("module").map_with_span(|_, loc: SimpleSpan| loc.into_range().into()))
+    recursive(|tl| {
+        choice((
+            declarations(DeclLoc::Global, None, &expr_impl())
+                .padded_by(ignored())
+                .then_ignore(
+                    just(';')
+                        .recover_with(skip_then_retry_until(none_of(';').ignored(), end()))
+                        .ignore_then(ignored()),
+                ),
+            import()
+                .then_ignore(ignored().then_ignore(just(';')).recover_with(skip_until(
+                    empty(),
+                    any().ignored(),
+                    || (),
+                )))
+                .map(box_ast),
+            anns.then(
+                text::keyword("module").map_with_span(|_, loc: SimpleSpan| loc.into_range().into()),
+            )
             .then_ignore(ignored())
-            .then(global_id()
-                .recover_with(skip_then_retry_until(any().filter(|&c| is_xid_continue(c)).repeated().at_least(1).ignored().or(any().ignored()), one_of("{=;").ignored()))
-                .recover_with(skip_until(any().ignored(), one_of("{=;").rewind().ignored().or(end()), || DottedName::local(("<error>".to_string(), unreachable_span())))))
+            .then(
+                global_id()
+                    .recover_with(skip_then_retry_until(
+                        any()
+                            .filter(|&c| is_xid_continue(c))
+                            .repeated()
+                            .at_least(1)
+                            .ignored()
+                            .or(any().ignored()),
+                        one_of("{=;").ignored(),
+                    ))
+                    .recover_with(skip_until(
+                        any().ignored(),
+                        one_of("{=;").rewind().ignored().or(end()),
+                        || DottedName::local(("<error>".to_string(), unreachable_span())),
+                    )),
+            )
             .then_ignore(ignored())
             .then(choice((
                 tl.repeated().collect().delimited_by(just('{'), just('}')),
-                just('=').then_ignore(ignored()).ignore_then(cdn()).map_with_span(|cdn, loc| vec![box_ast(ImportAST::new(loc.into_range().into(), cdn, vec![]))]).then_ignore(just(';')),
-                just(';').to(vec![])
+                just('=')
+                    .then_ignore(ignored())
+                    .ignore_then(cdn())
+                    .map_with_span(|cdn, loc| {
+                        vec![box_ast(ImportAST::new(
+                            loc.into_range().into(),
+                            cdn,
+                            vec![],
+                        ))]
+                    })
+                    .then_ignore(just(';')),
+                just(';').to(vec![]),
             )))
             .map(|(((anns, loc), name), body)| box_ast(ModuleAST::new(loc, name, body, anns))),
-        just(';').to_span().map(|l: SimpleSpan| box_ast(NullAST::new(l.into_range().into())))
-    ))).labelled("a top-level declaration")
+            just(';')
+                .to_span()
+                .map(|l: SimpleSpan| box_ast(NullAST::new(l.into_range().into()))),
+        ))
+    })
+    .labelled("a top-level declaration")
 }
 /// add assignments and control flow to parser
-fn add_assigns<'a: 'b, 'b>(expr: impl Parser<'a, &'a str, Box<dyn AST>, Extras<'a>> + Clone + 'a) -> BoxedASTParser<'a, 'b> {
-    let prev = expr.clone()
-        .then(choice(["=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>="]
-            .map(just))
+fn add_assigns<'a: 'b, 'b>(
+    expr: impl Parser<'a, &'a str, Box<dyn AST>, Extras<'a>> + Clone + 'a,
+) -> BoxedASTParser<'a, 'b> {
+    let prev = expr
+        .clone()
+        .then(
+            choice(
+                [
+                    "=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=",
+                ]
+                .map(just),
+            )
             .map_with_span(|op, span: SimpleSpan| (op.to_string(), span.into_range().into()))
             .labelled("an operator")
-        .padded_by(ignored()))
-        .repeated().foldr(expr, |(lhs, (op, loc)), rhs| box_ast(BinOpAST::new(loc, op, lhs, rhs))).labelled("an expression").boxed();
-    recursive(|expr| choice([
-        text::keyword("if").ignore_then(ignored())
-            .ignore_then(one_of("({").or_not().rewind().then(expr.clone()).validate(|(o, ast), loc, e| {
-                if o.is_none() {e.emit(Rich::custom(loc, "condition must be wrapped in either parentheses or braces"))}
-                ast
-            }).labelled("a condition"))
-            .then(expr.clone().padded_by(ignored()))
-            .then(text::keyword("else").ignore_then(expr.clone().padded_by(ignored())).or_not().map_with_span(|expr, loc| expr.unwrap_or_else(|| box_ast(NullAST::new(loc.into_range().into())))))
-            .map_with_span(|((cond, if_true), if_false), span| box_ast(IfAST::new(span.into_range().into(), cond, if_true, if_false))).boxed(),
-        text::keyword("while").ignore_then(ignored())
-            .ignore_then(one_of("({").or_not().rewind().then(expr.clone()).validate(|(o, ast), loc, e| {
-                if o.is_none() {e.emit(Rich::custom(loc, "condition must be wrapped in either parentheses or braces"))}
-                ast
-            }).labelled("a condition"))
-            .then(expr.clone().padded_by(ignored()))
-            .map_with_span(|(cond, body), span| box_ast(WhileAST::new(span.into_range().into(), cond, body))).boxed(),
-        prev
-    ]).recover_with(via_parser(text::keyword("else").ignore_then(expr)))).labelled("an expression").boxed()
+            .padded_by(ignored()),
+        )
+        .repeated()
+        .foldr(expr, |(lhs, (op, loc)), rhs| {
+            box_ast(BinOpAST::new(loc, op, lhs, rhs))
+        })
+        .labelled("an expression")
+        .boxed();
+    recursive(|expr| {
+        choice([
+            text::keyword("if")
+                .ignore_then(ignored())
+                .ignore_then(
+                    one_of("({")
+                        .or_not()
+                        .rewind()
+                        .then(expr.clone())
+                        .validate(|(o, ast), loc, e| {
+                            if o.is_none() {
+                                e.emit(Rich::custom(
+                                    loc,
+                                    "condition must be wrapped in either parentheses or braces",
+                                ))
+                            }
+                            ast
+                        })
+                        .labelled("a condition"),
+                )
+                .then(expr.clone().padded_by(ignored()))
+                .then(
+                    text::keyword("else")
+                        .ignore_then(expr.clone().padded_by(ignored()))
+                        .or_not()
+                        .map_with_span(|expr, loc| {
+                            expr.unwrap_or_else(|| box_ast(NullAST::new(loc.into_range().into())))
+                        }),
+                )
+                .map_with_span(|((cond, if_true), if_false), span| {
+                    box_ast(IfAST::new(
+                        span.into_range().into(),
+                        cond,
+                        if_true,
+                        if_false,
+                    ))
+                })
+                .boxed(),
+            text::keyword("while")
+                .ignore_then(ignored())
+                .ignore_then(
+                    one_of("({")
+                        .or_not()
+                        .rewind()
+                        .then(expr.clone())
+                        .validate(|(o, ast), loc, e| {
+                            if o.is_none() {
+                                e.emit(Rich::custom(
+                                    loc,
+                                    "condition must be wrapped in either parentheses or braces",
+                                ))
+                            }
+                            ast
+                        })
+                        .labelled("a condition"),
+                )
+                .then(expr.clone().padded_by(ignored()))
+                .map_with_span(|(cond, body), span| {
+                    box_ast(WhileAST::new(span.into_range().into(), cond, body))
+                })
+                .boxed(),
+            prev,
+        ])
+        .recover_with(via_parser(text::keyword("else").ignore_then(expr)))
+    })
+    .labelled("an expression")
+    .boxed()
 }
 /// create a parser for expressions, without assignment
 fn expr_impl<'a: 'b, 'b>() -> BoxedASTParser<'a, 'b> {
     type Cbi = utils::CharBytesIterator;
     let int_literal = choice((
-        just("0x").ignore_then(text::digits(16).at_least(1)).slice().map(|v| i128::from_str_radix(v, 16).unwrap()),
-        just("0o").ignore_then(text::digits(8).at_least(1)).slice().map(|v| i128::from_str_radix(v, 8).unwrap()),
-        just("0b").ignore_then(text::digits(2).at_least(1)).slice().map(|v| i128::from_str_radix(v, 2).unwrap()),
-        text::digits(10).slice().from_str().unwrapped()
-    )).map_with_span(add_loc).then_ignore(ignored())
-        .then(ident().map_with_span(|suf, span| (suf.to_string(), span.into_range().into())).or_not())
-        .map(|((val, loc), suf)| box_ast(IntLiteralAST::new(loc, val, suf)));
-    let float_literal =
-        text::digits(10).then(just('.')).then(text::digits(10).at_least(1))
-        .or(text::digits(10).at_least(1).then(just('.')).then(ident().not().rewind()))
-        .slice().from_str().unwrapped()
-        .map_with_span(add_loc).then_ignore(ignored())
-        .then(ident().map_with_span(|suf, span| (suf.to_string(), span.into_range().into())).or_not())
+        just("0x")
+            .ignore_then(text::digits(16).at_least(1))
+            .slice()
+            .map(|v| i128::from_str_radix(v, 16).unwrap()),
+        just("0o")
+            .ignore_then(text::digits(8).at_least(1))
+            .slice()
+            .map(|v| i128::from_str_radix(v, 8).unwrap()),
+        just("0b")
+            .ignore_then(text::digits(2).at_least(1))
+            .slice()
+            .map(|v| i128::from_str_radix(v, 2).unwrap()),
+        text::digits(10).slice().from_str().unwrapped(),
+    ))
+    .map_with_span(add_loc)
+    .then_ignore(ignored())
+    .then(
+        ident()
+            .map_with_span(|suf, span| (suf.to_string(), span.into_range().into()))
+            .or_not(),
+    )
+    .map(|((val, loc), suf)| box_ast(IntLiteralAST::new(loc, val, suf)));
+    let float_literal = text::digits(10)
+        .then(just('.'))
+        .then(text::digits(10).at_least(1))
+        .or(text::digits(10)
+            .at_least(1)
+            .then(just('.'))
+            .then(ident().not().rewind()))
+        .slice()
+        .from_str()
+        .unwrapped()
+        .map_with_span(add_loc)
+        .then_ignore(ignored())
+        .then(
+            ident()
+                .map_with_span(|suf, span| (suf.to_string(), span.into_range().into()))
+                .or_not(),
+        )
         .map(|((val, loc), suf)| box_ast(FloatLiteralAST::new(loc, val, suf)));
-    let char_literal = just('\'').ignore_then(choice((
-        none_of("\\'").map(u32::from),
-        just("\\0").to(0x00u32),
-        just("\\n").to(0x0au32),
-        just("\\r").to(0x0du32),
-        just("\\t").to(0x09u32),
-        just("\\v").to(0x0au32),
-        just("\\b").to(0x08u32),
-        just("\\e").to(0x1bu32),
-        just("\\a").to(0x07u32),
-        just("\\c").ignore_then(
-            text::digits(16)
-            .exactly(2).slice()
-            .map(|v| u32::from_str_radix(v, 16).unwrap())
-            .recover_with(via_parser(empty().to(0u32)))),
-        just("\\u").ignore_then(
-            text::digits(16)
-            .at_least(2).at_most(6).slice()
-            .map(|v| u32::from_str_radix(v, 16).unwrap())
-            .recover_with(skip_until(none_of("}'").ignored(), one_of("}'").ignored(), || 0u32))
-            .delimited_by(just('{'), just('}'))
-            .recover_with(skip_until(none_of("}'").ignored(), one_of("}'").ignored(), || 0u32))),
-        just('\\').ignore_then(any()).map(u32::from)
-    ))).then_ignore(just('\''))
-        .map_with_span(add_loc).then_ignore(ignored())
-        .then(ident().map_with_span(|suf, span| (suf.to_string(), span.into_range().into())).or_not())
-        .map(|((val, loc), suf)| box_ast(CharLiteralAST::new(loc, val, suf)));
-    let str_literal = just('"').ignore_then(choice((
-        none_of("\\\"").map(Cbi::from_char),
-        just("\\0").to(Cbi::from_u8(0x00)),
-        just("\\n").to(Cbi::from_u8(0x0a)),
-        just("\\r").to(Cbi::from_u8(0x0d)),
-        just("\\t").to(Cbi::from_u8(0x09)),
-        just("\\v").to(Cbi::from_u8(0x0a)),
-        just("\\b").to(Cbi::from_u8(0x08)),
-        just("\\e").to(Cbi::from_u8(0x1b)),
-        just("\\a").to(Cbi::from_u8(0x07)),
-        just("\\c").ignore_then(
-            text::digits(16)
-            .exactly(2).slice()
-            .map(|v| Cbi::from_u8(u8::from_str_radix(v, 16).unwrap()))
-            .recover_with(via_parser(empty().to(Cbi::from_u8(0))))),
-        just("\\x").ignore_then(
+    let char_literal = just('\'')
+        .ignore_then(choice((
+            none_of("\\'").map(u32::from),
+            just("\\0").to(0x00u32),
+            just("\\n").to(0x0au32),
+            just("\\r").to(0x0du32),
+            just("\\t").to(0x09u32),
+            just("\\v").to(0x0au32),
+            just("\\b").to(0x08u32),
+            just("\\e").to(0x1bu32),
+            just("\\a").to(0x07u32),
+            just("\\c").ignore_then(
                 text::digits(16)
-                .exactly(2).slice()
-                .map(|v| Cbi::raw(u8::from_str_radix(v, 16).unwrap()))
-                .recover_with(via_parser(empty().to(Cbi::from_u8(0))))),
-        just("\\u").ignore_then(
-            text::digits(16)
-            .at_least(2).at_most(6).slice()
-            .validate(|v, span, e| {
-                let v = u32::from_str_radix(v, 16).unwrap();
-                Cbi::from_u32(v).unwrap_or_else(|| {
-                    e.emit(Rich::custom(span, format!("{v:0>4X} is not a valid Unicode codepoint")));
-                    Cbi::from_u8(0)
-                })
-            })
-            .recover_with(skip_until(none_of("}'").ignored(), one_of("}'").ignored(), || Cbi::from_u8(0)))
-            .delimited_by(just('{'), just('}'))
-            .recover_with(skip_until(none_of("}'").ignored(), one_of("}'").ignored(), || Cbi::from_u8(0)))),
-        just('\\').ignore_then(any()).map(Cbi::from_char)
-    )).repeated().collect::<Vec<Cbi>>()).then_ignore(just('"'))
-        .map_with_span(add_loc).then_ignore(ignored())
-        .then(ident().map_with_span(|suf, span| (suf.to_string(), span.into_range().into())).or_not())
-        .map(|((val, loc), suf)| box_ast(StringLiteralAST::new(loc, val.into_iter().flatten().collect(), suf)));
-    let literal = choice((int_literal, float_literal, char_literal, str_literal)).labelled("a literal");
-    let varget = just('.').or_not().map(|o| o.is_some()).then(ident()).map_with_span(|(global, name), loc| box_ast(VarGetAST::new(loc.into_range().into(), name.to_string(), global)));
+                    .exactly(2)
+                    .slice()
+                    .map(|v| u32::from_str_radix(v, 16).unwrap())
+                    .recover_with(via_parser(empty().to(0u32))),
+            ),
+            just("\\u").ignore_then(
+                text::digits(16)
+                    .at_least(2)
+                    .at_most(6)
+                    .slice()
+                    .map(|v| u32::from_str_radix(v, 16).unwrap())
+                    .recover_with(skip_until(
+                        none_of("}'").ignored(),
+                        one_of("}'").ignored(),
+                        || 0u32,
+                    ))
+                    .delimited_by(just('{'), just('}'))
+                    .recover_with(skip_until(
+                        none_of("}'").ignored(),
+                        one_of("}'").ignored(),
+                        || 0u32,
+                    )),
+            ),
+            just('\\').ignore_then(any()).map(u32::from),
+        )))
+        .then_ignore(just('\''))
+        .map_with_span(add_loc)
+        .then_ignore(ignored())
+        .then(
+            ident()
+                .map_with_span(|suf, span| (suf.to_string(), span.into_range().into()))
+                .or_not(),
+        )
+        .map(|((val, loc), suf)| box_ast(CharLiteralAST::new(loc, val, suf)));
+    let str_literal = just('"')
+        .ignore_then(
+            choice((
+                none_of("\\\"").map(Cbi::from_char),
+                just("\\0").to(Cbi::from_u8(0x00)),
+                just("\\n").to(Cbi::from_u8(0x0a)),
+                just("\\r").to(Cbi::from_u8(0x0d)),
+                just("\\t").to(Cbi::from_u8(0x09)),
+                just("\\v").to(Cbi::from_u8(0x0a)),
+                just("\\b").to(Cbi::from_u8(0x08)),
+                just("\\e").to(Cbi::from_u8(0x1b)),
+                just("\\a").to(Cbi::from_u8(0x07)),
+                just("\\c").ignore_then(
+                    text::digits(16)
+                        .exactly(2)
+                        .slice()
+                        .map(|v| Cbi::from_u8(u8::from_str_radix(v, 16).unwrap()))
+                        .recover_with(via_parser(empty().to(Cbi::from_u8(0)))),
+                ),
+                just("\\x").ignore_then(
+                    text::digits(16)
+                        .exactly(2)
+                        .slice()
+                        .map(|v| Cbi::raw(u8::from_str_radix(v, 16).unwrap()))
+                        .recover_with(via_parser(empty().to(Cbi::from_u8(0)))),
+                ),
+                just("\\u").ignore_then(
+                    text::digits(16)
+                        .at_least(2)
+                        .at_most(6)
+                        .slice()
+                        .validate(|v, span, e| {
+                            let v = u32::from_str_radix(v, 16).unwrap();
+                            Cbi::from_u32(v).unwrap_or_else(|| {
+                                e.emit(Rich::custom(
+                                    span,
+                                    format!("{v:0>4X} is not a valid Unicode codepoint"),
+                                ));
+                                Cbi::from_u8(0)
+                            })
+                        })
+                        .recover_with(skip_until(
+                            none_of("}'").ignored(),
+                            one_of("}'").ignored(),
+                            || Cbi::from_u8(0),
+                        ))
+                        .delimited_by(just('{'), just('}'))
+                        .recover_with(skip_until(
+                            none_of("}'").ignored(),
+                            one_of("}'").ignored(),
+                            || Cbi::from_u8(0),
+                        )),
+                ),
+                just('\\').ignore_then(any()).map(Cbi::from_char),
+            ))
+            .repeated()
+            .collect::<Vec<Cbi>>(),
+        )
+        .then_ignore(just('"'))
+        .map_with_span(add_loc)
+        .then_ignore(ignored())
+        .then(
+            ident()
+                .map_with_span(|suf, span| (suf.to_string(), span.into_range().into()))
+                .or_not(),
+        )
+        .map(|((val, loc), suf)| {
+            box_ast(StringLiteralAST::new(
+                loc,
+                val.into_iter().flatten().collect(),
+                suf,
+            ))
+        });
+    let literal =
+        choice((int_literal, float_literal, char_literal, str_literal)).labelled("a literal");
+    let varget = just('.')
+        .or_not()
+        .map(|o| o.is_some())
+        .then(ident())
+        .map_with_span(|(global, name), loc| {
+            box_ast(VarGetAST::new(
+                loc.into_range().into(),
+                name.to_string(),
+                global,
+            ))
+        });
     let special = choice((
-        text::keyword("null").to_span().map(|span: SimpleSpan| box_ast(NullAST::new(span.into_range().into()))),
-        text::keyword("type").to_span().map(|span: SimpleSpan| box_ast(TypeLiteralAST::new(span.into_range().into())))
-    )).labelled("a literal");
-    let intrinsic = just('@').ignore_then(ident()).map_with_span(|name, span| box_ast(IntrinsicAST::new(span.into_range().into(), name.to_string()))).labelled("an intrinsic");
+        text::keyword("null")
+            .to_span()
+            .map(|span: SimpleSpan| box_ast(NullAST::new(span.into_range().into()))),
+        text::keyword("type")
+            .to_span()
+            .map(|span: SimpleSpan| box_ast(TypeLiteralAST::new(span.into_range().into()))),
+    ))
+    .labelled("a literal");
+    let intrinsic = just('@')
+        .ignore_then(ident())
+        .map_with_span(|name, span| {
+            box_ast(IntrinsicAST::new(
+                span.into_range().into(),
+                name.to_string(),
+            ))
+        })
+        .labelled("an intrinsic");
     recursive(move |raw_expr| {
         let expr = add_assigns(raw_expr.clone());
-        let maybe_expr = expr.clone().or_not().map_with_span(|ast, span: SimpleSpan| ast.unwrap_or_else(|| box_ast(NullAST::new(span.into_iter().into()))));
+        let maybe_expr = expr
+            .clone()
+            .or_not()
+            .map_with_span(|ast, span: SimpleSpan| {
+                ast.unwrap_or_else(|| box_ast(NullAST::new(span.into_iter().into())))
+            });
         let atom = choice((
             literal,
             special,
             varget,
             intrinsic,
             choice((
-                maybe_expr.clone().padded_by(ignored()).then_ignore(just(')').rewind()),
-                maybe_expr.clone()
-                    .recover_with(skip_then_retry_until(none_of(",;)}").ignored(), one_of(",;)}").ignored()))
+                maybe_expr
+                    .clone()
                     .padded_by(ignored())
-                    .separated_by(just(';')
-                        .recover_with(skip_then_retry_until(none_of(";)").ignored(), one_of(";)").ignored())))
-                        .at_least(2).collect()
+                    .then_ignore(just(')').rewind()),
+                maybe_expr
+                    .clone()
+                    .recover_with(skip_then_retry_until(
+                        none_of(",;)}").ignored(),
+                        one_of(",;)}").ignored(),
+                    ))
+                    .padded_by(ignored())
+                    .separated_by(just(';').recover_with(skip_then_retry_until(
+                        none_of(";)").ignored(),
+                        one_of(";)").ignored(),
+                    )))
+                    .at_least(2)
+                    .collect()
                     .map(|vals| box_ast(GroupAST::new(vals))),
                 expr.clone()
-                    .recover_with(skip_then_retry_until(none_of(",;)}").ignored(), one_of(",;)}").ignored()))
+                    .recover_with(skip_then_retry_until(
+                        none_of(",;)}").ignored(),
+                        one_of(",;)}").ignored(),
+                    ))
                     .padded_by(ignored())
-                    .separated_by(just(',')
-                        .recover_with(skip_then_retry_until(none_of(",)").ignored(), one_of(",)").ignored())))
-                        .allow_trailing().at_least(1).collect()
+                    .separated_by(just(',').recover_with(skip_then_retry_until(
+                        none_of(",)").ignored(),
+                        one_of(",)").ignored(),
+                    )))
+                    .allow_trailing()
+                    .at_least(1)
+                    .collect()
                     .map(|vals| box_ast(TupleLiteralAST::new(vals))),
             ))
             .delimited_by(just('('), just(')'))
             .map_with_span(|ast, span| box_ast(ParenAST::new(span.into_range().into(), ast)))
-            .recover_with(via_parser(nested_delimiters('(', ')', [('[', ']'), ('{', '}')], |span: SimpleSpan| box_ast(ErrorAST::new(span.into_range().into()))))),
+            .recover_with(via_parser(nested_delimiters(
+                '(',
+                ')',
+                [('[', ']'), ('{', '}')],
+                |span: SimpleSpan| box_ast(ErrorAST::new(span.into_range().into())),
+            ))),
             // array
             expr.clone()
                 .recover_with(skip_then_retry_until(none_of(",;)}").ignored(), end()))
                 .padded_by(ignored())
-                .separated_by(just(',').recover_with(skip_then_retry_until(none_of(",]").ignored(), one_of(",]").ignored()))).allow_trailing().collect()
+                .separated_by(just(',').recover_with(skip_then_retry_until(
+                    none_of(",]").ignored(),
+                    one_of(",]").ignored(),
+                )))
+                .allow_trailing()
+                .collect()
                 .delimited_by(just('['), just(']'))
-                .map_with_span(|vals, span| box_ast(ArrayLiteralAST::new((span.start, 1).into(), (span.end - 1, 1).into(), vals)))
-                .recover_with(via_parser(nested_delimiters('[', ']', [('(', ')'), ('{', '}')], |span: SimpleSpan| box_ast(ErrorAST::new(span.into_range().into()))))),
+                .map_with_span(|vals, span| {
+                    box_ast(ArrayLiteralAST::new(
+                        (span.start, 1).into(),
+                        (span.end - 1, 1).into(),
+                        vals,
+                    ))
+                })
+                .recover_with(via_parser(nested_delimiters(
+                    '[',
+                    ']',
+                    [('(', ')'), ('{', '}')],
+                    |span: SimpleSpan| box_ast(ErrorAST::new(span.into_range().into())),
+                ))),
             // block
-            def_stmt(raw_expr.or_not().map_with_span(|ast, span: SimpleSpan| ast.unwrap_or_else(|| box_ast(NullAST::new(span.into_iter().into())))).boxed())
-                .recover_with(skip_then_retry_until(none_of(";)}").ignored(), end()))
-                .padded_by(ignored())
-                .separated_by(just(';').recover_with(skip_then_retry_until(none_of(";}").ignored(), one_of(";}").ignored()))).collect()
-                .delimited_by(just('{'), just('}'))
-                .map_with_span(|vals, span| box_ast(BlockAST::new(span.into_range().into(), vals)))
-                .recover_with(via_parser(nested_delimiters('{', '}', [('[', ']'), ('(', ')')], |span: SimpleSpan| box_ast(ErrorAST::new(span.into_range().into()))))),
-        )).labelled("an atom").boxed();
+            def_stmt(
+                raw_expr
+                    .or_not()
+                    .map_with_span(|ast, span: SimpleSpan| {
+                        ast.unwrap_or_else(|| box_ast(NullAST::new(span.into_iter().into())))
+                    })
+                    .boxed(),
+            )
+            .recover_with(skip_then_retry_until(none_of(";)}").ignored(), end()))
+            .padded_by(ignored())
+            .separated_by(just(';').recover_with(skip_then_retry_until(
+                none_of(";}").ignored(),
+                one_of(";}").ignored(),
+            )))
+            .collect()
+            .delimited_by(just('{'), just('}'))
+            .map_with_span(|vals, span| box_ast(BlockAST::new(span.into_range().into(), vals)))
+            .recover_with(via_parser(nested_delimiters(
+                '{',
+                '}',
+                [('[', ']'), ('(', ')')],
+                |span: SimpleSpan| box_ast(ErrorAST::new(span.into_range().into())),
+            ))),
+        ))
+        .labelled("an atom")
+        .boxed();
         #[derive(Debug, Clone)]
         enum PostfixType {
             Op(String, SourceSpan),
@@ -426,63 +979,128 @@ fn expr_impl<'a: 'b, 'b>() -> BoxedASTParser<'a, 'b> {
             Sub(Box<dyn AST>, SourceSpan),
             Call(Vec<Box<dyn AST>>, SourceSpan),
         }
-        let postfix = atom.foldl(choice((
-            // postfix operator
-            one_of("?!").map_with_span(|c: char, span: SimpleSpan| PostfixType::Op(c.to_string(), span.into_range().into())),
-            // attribute
-            just('.').ignore_then(ignored()).ignore_then(ident()).map_with_span(|attr, span| PostfixType::Attr(attr.to_string(), span.into_range().into())),
-            // subscript
-            maybe_expr
+        let postfix = atom
+            .foldl(
+                choice((
+                    // postfix operator
+                    one_of("?!").map_with_span(|c: char, span: SimpleSpan| {
+                        PostfixType::Op(c.to_string(), span.into_range().into())
+                    }),
+                    // attribute
+                    just('.')
+                        .ignore_then(ignored())
+                        .ignore_then(ident())
+                        .map_with_span(|attr, span| {
+                            PostfixType::Attr(attr.to_string(), span.into_range().into())
+                        }),
+                    // subscript
+                    maybe_expr
+                        .padded_by(ignored())
+                        .delimited_by(just('['), just(']'))
+                        .map_with_span(|ast, loc| PostfixType::Sub(ast, loc.into_range().into())),
+                    expr.padded_by(ignored())
+                        .separated_by(just(',').recover_with(skip_then_retry_until(
+                            none_of(",)").ignored(),
+                            one_of(",)").ignored(),
+                        )))
+                        .allow_trailing()
+                        .collect()
+                        .delimited_by(just('('), just(')'))
+                        .map_with_span(|ast, loc| PostfixType::Call(ast, (loc.end - 1, 1).into())),
+                ))
+                .labelled("an operator")
                 .padded_by(ignored())
-                .delimited_by(just('['), just(']'))
-                .map_with_span(|ast, loc| PostfixType::Sub(ast, loc.into_range().into())),
-            expr
-                .padded_by(ignored())
-                .separated_by(just(',').recover_with(skip_then_retry_until(none_of(",)").ignored(), one_of(",)").ignored()))).allow_trailing().collect()
-                .delimited_by(just('('), just(')'))
-                .map_with_span(|ast, loc| PostfixType::Call(ast, (loc.end - 1, 1).into()))
-        )).labelled("an operator").padded_by(ignored()).repeated(), |ast, op| match op {
-            PostfixType::Op(op, loc) => box_ast(PostfixAST::new(loc, op, ast)),
-            PostfixType::Attr(attr, loc) => box_ast(DotAST::new(ast, (attr, loc))),
-            PostfixType::Sub(idx, loc) => box_ast(SubAST::new(loc, ast, idx)),
-            PostfixType::Call(args, loc) => box_ast(CallAST::new(loc, ast, args))
-        }).labelled("an expression").boxed();
-        let prefix = choice((just("++"), just("--"), text::keyword("mut"))).map(String::from)
-            .or(one_of("+-*&~!").map(String::from)).labelled("an operator")
-            .map_with_span(add_loc).padded_by(ignored()).repeated()
-            .foldr(postfix, |(op, loc), ast| box_ast(PrefixAST::new(loc, op, ast)))
-            .labelled("an expression").boxed();
+                .repeated(),
+                |ast, op| match op {
+                    PostfixType::Op(op, loc) => box_ast(PostfixAST::new(loc, op, ast)),
+                    PostfixType::Attr(attr, loc) => box_ast(DotAST::new(ast, (attr, loc))),
+                    PostfixType::Sub(idx, loc) => box_ast(SubAST::new(loc, ast, idx)),
+                    PostfixType::Call(args, loc) => box_ast(CallAST::new(loc, ast, args)),
+                },
+            )
+            .labelled("an expression")
+            .boxed();
+        let prefix = choice((just("++"), just("--"), text::keyword("mut")))
+            .map(String::from)
+            .or(one_of("+-*&~!").map(String::from))
+            .labelled("an operator")
+            .map_with_span(add_loc)
+            .padded_by(ignored())
+            .repeated()
+            .foldr(postfix, |(op, loc), ast| {
+                box_ast(PrefixAST::new(loc, op, ast))
+            })
+            .labelled("an expression")
+            .boxed();
         #[inline(always)]
-        fn impl_ltr<'a, const N: usize>(prev: BoxedASTParser<'a, 'a>, ops: [&'static str; N]) -> BoxedASTParser<'a, 'a> {
-            prev.clone().foldl(
-                choice(ops.map(just))
-                    .labelled("an operator")
-                    .map_with_span(|op, span: SimpleSpan| (op.to_string(), span.into_range().into()))
-                    .padded_by(ignored()).then(prev).repeated(),
-                |lhs, ((op, loc), rhs)| box_ast(BinOpAST::new(loc, op, lhs, rhs))).labelled("an expression").boxed()
+        fn impl_ltr<'a, const N: usize>(
+            prev: BoxedASTParser<'a, 'a>,
+            ops: [&'static str; N],
+        ) -> BoxedASTParser<'a, 'a> {
+            prev.clone()
+                .foldl(
+                    choice(ops.map(just))
+                        .labelled("an operator")
+                        .map_with_span(|op, span: SimpleSpan| {
+                            (op.to_string(), span.into_range().into())
+                        })
+                        .padded_by(ignored())
+                        .then(prev)
+                        .repeated(),
+                    |lhs, ((op, loc), rhs)| box_ast(BinOpAST::new(loc, op, lhs, rhs)),
+                )
+                .labelled("an expression")
+                .boxed()
         }
         let mul_div = impl_ltr(prefix, ["*", "/", "%"]);
         let add_sub = impl_ltr(mul_div, ["+", "-"]);
         let shifts = impl_ltr(add_sub, ["<<", ">>"]);
         let cmps = impl_ltr(shifts, ["<=", ">=", "<", ">"]);
         let eqs = impl_ltr(cmps, ["==", "!="]);
-        let log_or = ["&", "^", "|", "&?", "|?"].into_iter().fold(eqs, |parser, op| impl_ltr(parser, [op]));
+        let log_or = ["&", "^", "|", "&?", "|?"]
+            .into_iter()
+            .fold(eqs, |parser, op| impl_ltr(parser, [op]));
         // casts
-        log_or.clone()
-            .foldl(just(':').ignore_then(just('?').or_not()).map(|o| o.is_some()).labelled("an operator")
-                .map_with_span(add_loc)
-                .padded_by(ignored()).then(log_or).repeated(),
-          |lhs, ((bit, loc), rhs)|
-                if bit {box_ast(BitCastAST::new(loc, lhs, rhs))}
-                else {box_ast(CastAST::new(loc, lhs, rhs))})
-            .labelled("an expression").boxed()
-    }).boxed()
+        log_or
+            .clone()
+            .foldl(
+                just(':')
+                    .ignore_then(just('?').or_not())
+                    .map(|o| o.is_some())
+                    .labelled("an operator")
+                    .map_with_span(add_loc)
+                    .padded_by(ignored())
+                    .then(log_or)
+                    .repeated(),
+                |lhs, ((bit, loc), rhs)| {
+                    if bit {
+                        box_ast(BitCastAST::new(loc, lhs, rhs))
+                    } else {
+                        box_ast(CastAST::new(loc, lhs, rhs))
+                    }
+                },
+            )
+            .labelled("an expression")
+            .boxed()
+    })
+    .boxed()
 }
 /// create a parser for expressions
 #[inline(always)]
-pub fn parse_expr<'a: 'b, 'b>() -> BoxedASTParser<'a, 'b> {add_assigns(expr_impl())}
+pub fn parse_expr<'a: 'b, 'b>() -> BoxedASTParser<'a, 'b> {
+    add_assigns(expr_impl())
+}
 /// create a parser for statements
 #[inline(always)]
-pub fn parse_stmt<'a: 'b, 'b>() -> BoxedASTParser<'a, 'b> {def_stmt(expr_impl())}
+pub fn parse_stmt<'a: 'b, 'b>() -> BoxedASTParser<'a, 'b> {
+    def_stmt(expr_impl())
+}
 /// create a parser for the top-level scope
-pub fn parse_tl<'a: 'b, 'b>() -> BoxedParser<'a, 'b, TopLevelAST> {top_level().repeated().collect().map(TopLevelAST::new).then_ignore(ignored().then(end())).boxed()}
+pub fn parse_tl<'a: 'b, 'b>() -> BoxedParser<'a, 'b, TopLevelAST> {
+    top_level()
+        .repeated()
+        .collect()
+        .map(TopLevelAST::new)
+        .then_ignore(ignored().then(end()))
+        .boxed()
+}

--- a/cobalt-parser/src/utils.rs
+++ b/cobalt-parser/src/utils.rs
@@ -4,15 +4,25 @@
 pub struct CharBytesIterator(u32, u8);
 impl CharBytesIterator {
     #[inline]
-    pub fn from_char(c: char) -> Self {Self(c as u32, 0)}
+    pub fn from_char(c: char) -> Self {
+        Self(c as u32, 0)
+    }
     #[inline]
-    pub fn from_u8(c: u8) -> Self {Self(c as u32, 0)}
+    pub fn from_u8(c: u8) -> Self {
+        Self(c as u32, 0)
+    }
     #[inline]
-    pub fn from_u32(c: u32) -> Option<Self> {(c < 0x200000).then_some(Self(c, 0))}
+    pub fn from_u32(c: u32) -> Option<Self> {
+        (c < 0x200000).then_some(Self(c, 0))
+    }
     #[inline]
-    pub fn raw(c: u8) -> Self {Self(c as u32, 254)}
+    pub fn raw(c: u8) -> Self {
+        Self(c as u32, 254)
+    }
     #[inline]
-    pub fn explode(self) -> (u32, u8) {(self.0, self.1)}
+    pub fn explode(self) -> (u32, u8) {
+        (self.0, self.1)
+    }
 }
 impl Iterator for CharBytesIterator {
     type Item = u8;
@@ -20,31 +30,35 @@ impl Iterator for CharBytesIterator {
         let res = match self.explode() {
             (c, 254) => Some(c as u8),
             (c @ 0..=0x7f, 0) => Some(c as u8),
-            (c @ 0x80..=0x7ff, 0)       => Some(0xc0 | ((c >>  6) as u8 & 0x1F)),
-            (c @ 0x80..=0x7ff, 1)       => Some(0x80 | ((c      ) as u8 & 0x3F)),
-            (c @ 0x800..=0xffff, 0)     => Some(0xe0 | ((c >> 12) as u8 & 0x0F)),
-            (c @ 0x800..=0xffff, 1)     => Some(0x80 | ((c >>  6) as u8 & 0x3F)),
-            (c @ 0x800..=0xffff, 2)     => Some(0x80 | ((c      ) as u8 & 0x3F)),
+            (c @ 0x80..=0x7ff, 0) => Some(0xc0 | ((c >> 6) as u8 & 0x1F)),
+            (c @ 0x80..=0x7ff, 1) => Some(0x80 | ((c) as u8 & 0x3F)),
+            (c @ 0x800..=0xffff, 0) => Some(0xe0 | ((c >> 12) as u8 & 0x0F)),
+            (c @ 0x800..=0xffff, 1) => Some(0x80 | ((c >> 6) as u8 & 0x3F)),
+            (c @ 0x800..=0xffff, 2) => Some(0x80 | ((c) as u8 & 0x3F)),
             (c @ 0x10000..=0x1fffff, 0) => Some(0xf0 | ((c >> 18) as u8 & 0x07)),
             (c @ 0x10000..=0x1fffff, 1) => Some(0x80 | ((c >> 12) as u8 & 0x3F)),
-            (c @ 0x10000..=0x1fffff, 2) => Some(0x80 | ((c >>  6) as u8 & 0x3F)),
-            (c @ 0x10000..=0x1fffff, 3) => Some(0x80 | ((c      ) as u8 & 0x3F)),
-            _ => None
+            (c @ 0x10000..=0x1fffff, 2) => Some(0x80 | ((c >> 6) as u8 & 0x3F)),
+            (c @ 0x10000..=0x1fffff, 3) => Some(0x80 | ((c) as u8 & 0x3F)),
+            _ => None,
         };
         self.1 += res.is_some() as u8;
         res
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let mut val = if self.1 == 254 {1} else {
+        let mut val = if self.1 == 254 {
+            1
+        } else {
             match self.0 {
                 0..=0x7f => 1,
                 0x80..=0x7ff => 2,
                 0x800..=0xffff => 3,
                 0x10000..=0x1fffff => 4,
-                _ => 0
+                _ => 0,
             }
         };
-        if val > self.1 {val -= self.1}
+        if val > self.1 {
+            val -= self.1
+        }
         (val as _, Some(val as _))
     }
 }

--- a/cobalt-utils/src/lib.rs
+++ b/cobalt-utils/src/lib.rs
@@ -6,7 +6,7 @@ pub struct Flags {
     pub prepass: bool,
     pub dbg_mangle: bool,
     pub up: bool,
-    pub all_move_metadata: bool
+    pub all_move_metadata: bool,
 }
 impl Default for Flags {
     fn default() -> Self {
@@ -16,18 +16,30 @@ impl Default for Flags {
             prepass: true,
             dbg_mangle: false,
             up: true,
-            all_move_metadata: false
+            all_move_metadata: false,
         }
     }
 }
 #[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub struct Counter<T: Copy + std::ops::Add<T, Output = T> + std::ops::Sub<T, Output = T> + From<u8>>(Cell<T>);
+pub struct Counter<T: Copy + std::ops::Add<T, Output = T> + std::ops::Sub<T, Output = T> + From<u8>>(
+    Cell<T>,
+);
 impl<T: Copy + std::ops::Add<T, Output = T> + std::ops::Sub<T, Output = T> + From<u8>> Counter<T> {
-    pub fn get(&self) -> T {self.0.get()}
-    pub fn incr(&self) -> &Self {self.0.set(self.0.get() + 1.into()); self}
-    pub fn decr(&self) -> &Self {self.0.set(self.0.get() - 1.into()); self}
+    pub fn get(&self) -> T {
+        self.0.get()
+    }
+    pub fn incr(&self) -> &Self {
+        self.0.set(self.0.get() + 1.into());
+        self
+    }
+    pub fn decr(&self) -> &Self {
+        self.0.set(self.0.get() - 1.into());
+        self
+    }
 }
-impl<T: Copy + std::ops::Add<T, Output = T> + std::ops::Sub<T, Output = T> + From<u8>> From<T> for Counter<T> {
+impl<T: Copy + std::ops::Add<T, Output = T> + std::ops::Sub<T, Output = T> + From<u8>> From<T>
+    for Counter<T>
+{
     #[inline]
     fn from(value: T) -> Self {
         Self(Cell::new(value))
@@ -35,7 +47,9 @@ impl<T: Copy + std::ops::Add<T, Output = T> + std::ops::Sub<T, Output = T> + Fro
 }
 pub struct CellExt<T>(Cell<Option<T>>);
 impl<T> CellExt<T> {
-    pub fn new(val: T) -> Self {CellExt(Cell::new(Some(val)))}
+    pub fn new(val: T) -> Self {
+        CellExt(Cell::new(Some(val)))
+    }
     pub fn map<F: FnOnce(T) -> T>(&self, f: F) -> &Self {
         let val = self.0.take();
         self.0.set(Some(f(val.unwrap())));
@@ -58,9 +72,15 @@ impl<T> CellExt<T> {
         self.0.set(Some(val));
         out
     }
-    pub fn replace(&self, val: T) -> T {self.0.replace(Some(val)).unwrap()}
-    pub fn set(&self, val: T) {self.0.set(Some(val))}
-    pub fn into_inner(self) -> T {self.0.into_inner().unwrap()}
+    pub fn replace(&self, val: T) -> T {
+        self.0.replace(Some(val)).unwrap()
+    }
+    pub fn set(&self, val: T) {
+        self.0.set(Some(val))
+    }
+    pub fn into_inner(self) -> T {
+        self.0.into_inner().unwrap()
+    }
 }
 impl<T: Clone> Clone for CellExt<T> {
     fn clone(&self) -> Self {


### PR DESCRIPTION
Until now, the code's style has been inconsistent and messy. Hopefully, by running Cargo's auto-format, it will fix some of this.