### PR TITLE
Add structs

### DIFF
--- a/cobalt-ast/src/ast.rs
+++ b/cobalt-ast/src/ast.rs
@@ -59,6 +59,8 @@ pub trait AST: ASTClone + std::fmt::Debug {
         ctx.is_const.set(old_is_const);
         res
     }
+
+    /// Just calls `codegen()` and appends the errors to `errs`.
     fn codegen_errs<'ctx>(&self, ctx: &CompCtx<'ctx>, errs: &mut Vec<CobaltError>) -> Value<'ctx> {
         let (val, mut es) = self.codegen(ctx);
         errs.append(&mut es);

--- a/cobalt-ast/src/ast.rs
+++ b/cobalt-ast/src/ast.rs
@@ -101,7 +101,7 @@ pub fn print_ast_child(
             let slice = ast.loc();
             let (sl, sc) = file.source_loc(slice.offset()).ok()?;
             let (el, ec) = file.source_loc(slice.offset() + slice.len()).ok()?;
-            Some(write!(f, "({}:{}..{}:{}) ", sl, sc, el, ec))
+            Some(write!(f, "({sl}:{sc}..{el}:{ec}) "))
         })() {
             return Err(e);
         };

--- a/cobalt-ast/src/ast.rs
+++ b/cobalt-ast/src/ast.rs
@@ -94,7 +94,7 @@ pub fn print_ast_child(
     last: bool,
     file: Option<CobaltFile>,
 ) -> Result {
-    write!(f, "{}{}", pre, if last { "└── " } else { "├── " })?;
+    write!(f, "{pre}{} ", if last { "└──" } else { "├──" })?;
     if f.alternate() {
         if let Some(Err(e)) = (|| -> Option<Result> {
             let file = file?;

--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -600,7 +600,9 @@ impl AST for StructLiteralAST {
         file: Option<CobaltFile>,
     ) -> std::fmt::Result {
         writeln!(f, "struct")?;
-        for (n, (name, val)) in self.vals.iter().enumerate() {
+        let mut v = self.vals.iter().collect::<Vec<_>>();
+        v.sort_by_key(|x| x.0);
+        for (n, (name, val)) in v.into_iter().enumerate() {
             let last = n == self.vals.len() - 1;
             write!(f, "{pre}{} {name}: ", if last { "└──" } else { "├──" })?;
             if f.alternate() {

--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -91,7 +91,7 @@ impl AST for IntLiteralAST {
     ) -> std::fmt::Result {
         write!(f, "int: {}", self.val)?;
         if let Some((ref s, _)) = self.suffix {
-            writeln!(f, ", suffix: {}", s)
+            writeln!(f, ", suffix: {s}")
         } else {
             writeln!(f)
         }
@@ -167,7 +167,7 @@ impl AST for FloatLiteralAST {
     ) -> std::fmt::Result {
         write!(f, "float: {}", self.val)?;
         if let Some((ref s, _)) = self.suffix {
-            writeln!(f, ", suffix: {}", s)
+            writeln!(f, ", suffix: {s}")
         } else {
             writeln!(f)
         }
@@ -269,7 +269,7 @@ impl AST for CharLiteralAST {
             write!(f, "char: \\u{{{:0>X}}}", self.val)
         }?;
         if let Some((ref s, _)) = self.suffix {
-            writeln!(f, ", suffix: {}", s)
+            writeln!(f, ", suffix: {s}")
         } else {
             writeln!(f)
         }
@@ -338,7 +338,7 @@ impl AST for StringLiteralAST {
     ) -> std::fmt::Result {
         write!(f, "string: {:?}", self.val.as_bstr())?;
         if let Some((ref s, _)) = self.suffix {
-            writeln!(f, ", suffix: {}", s)
+            writeln!(f, ", suffix: {s}")
         } else {
             writeln!(f)
         }
@@ -611,7 +611,7 @@ impl AST for StructLiteralAST {
                     let slice = val.loc();
                     let (sl, sc) = file.source_loc(slice.offset()).ok()?;
                     let (el, ec) = file.source_loc(slice.offset() + slice.len()).ok()?;
-                    Some(write!(f, "({}:{}..{}:{}) ", sl, sc, el, ec))
+                    Some(write!(f, "({sl}:{sc}..{el}:{ec}) "))
                 })() {
                     return Err(e);
                 };

--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -2,6 +2,7 @@ use crate::*;
 use bstr::ByteSlice;
 use inkwell::types::BasicType;
 use inkwell::values::BasicValueEnum::*;
+use std::collections::HashMap;
 #[derive(Debug, Clone)]
 pub struct IntLiteralAST {
     loc: SourceSpan,
@@ -520,6 +521,102 @@ impl AST for TupleLiteralAST {
         for val in self.vals.iter() {
             print_ast_child(f, pre, &**val, len == 1, file)?;
             len -= 1;
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, Clone)]
+pub struct StructLiteralAST {
+    loc: SourceSpan,
+    vals: HashMap<String, Box<dyn AST>>,
+}
+impl StructLiteralAST {
+    pub fn new(loc: SourceSpan, vals: HashMap<String, Box<dyn AST>>) -> Self {
+        StructLiteralAST { loc, vals }
+    }
+}
+impl AST for StructLiteralAST {
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn nodes(&self) -> usize {
+        self.vals.values().map(|t| t.nodes()).sum::<usize>() + 1
+    }
+    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+        let mut errs = vec![];
+        let mut vec = self
+            .vals
+            .iter()
+            .map(|(n, v)| (n, v.codegen_errs(ctx, &mut errs)))
+            .collect::<Vec<_>>();
+        vec.sort_by(|(ln, lhs), (rn, rhs)| {
+            types::struct_order(&lhs.data_type, &rhs.data_type, Some((ln, rn)), ctx)
+        });
+        let mut lookup = HashMap::with_capacity(vec.len());
+        for (n, (name, _)) in vec.iter().enumerate() {
+            lookup.insert(name.to_string(), n);
+        }
+        let comp_val = if !ctx.is_const.get() {
+            let v = vec
+                .iter()
+                .map(|x| x.1.value(ctx))
+                .collect::<Option<Vec<_>>>();
+            if let Some(vals) = v {
+                let llt = ctx.context.struct_type(
+                    &vals.iter().map(|v| v.get_type()).collect::<Vec<_>>(),
+                    false,
+                );
+                Some(
+                    vals.into_iter()
+                        .enumerate()
+                        .fold(llt.get_undef(), |val, (n, elem)| {
+                            ctx.builder
+                                .build_insert_value(val, elem, n as _, "")
+                                .unwrap()
+                                .into_struct_value()
+                        }),
+                )
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        let inter_val = vec
+            .iter()
+            .map(|v| v.1.inter_val.clone())
+            .collect::<Option<_>>()
+            .map(InterData::Array);
+        let data_type = Type::Struct(vec.into_iter().map(|v| v.1.data_type).collect(), lookup);
+        (
+            Value::new(comp_val.map(From::from), inter_val, data_type),
+            errs,
+        )
+    }
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        pre: &mut TreePrefix,
+        file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
+        writeln!(f, "struct")?;
+        for (n, (name, val)) in self.vals.iter().enumerate() {
+            let last = n == self.vals.len() - 1;
+            write!(f, "{pre}{} {name}: ", if last { "└──" } else { "├──" })?;
+            if f.alternate() {
+                if let Some(Err(e)) = (|| -> Option<std::fmt::Result> {
+                    let file = file?;
+                    let slice = val.loc();
+                    let (sl, sc) = file.source_loc(slice.offset()).ok()?;
+                    let (el, ec) = file.source_loc(slice.offset() + slice.len()).ok()?;
+                    Some(write!(f, "({}:{}..{}:{}) ", sl, sc, el, ec))
+                })() {
+                    return Err(e);
+                };
+            }
+            pre.push(last);
+            val.print_impl(f, pre, file)?;
+            pre.pop();
         }
         Ok(())
     }

--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -565,7 +565,6 @@ impl AST for StructLiteralAST {
         for (n, (name, _)) in vec.iter().enumerate() {
             lookup.insert(name.to_string(), n);
         }
-        let data_type = Type::Struct(vec.into_iter().map(|v| v.1.data_type).collect(), lookup);
 
         // Compute the value, if possible, of the fields.
         let comp_val = if !ctx.is_const.get() {
@@ -599,6 +598,7 @@ impl AST for StructLiteralAST {
             .map(|v| v.1.inter_val.clone())
             .collect::<Option<_>>()
             .map(InterData::Array);
+        let data_type = Type::Struct(vec.into_iter().map(|v| v.1.data_type).collect(), lookup);
 
         (
             Value::new(comp_val.map(From::from), inter_val, data_type),

--- a/cobalt-ast/src/ops.rs
+++ b/cobalt-ast/src/ops.rs
@@ -85,7 +85,8 @@ pub fn impl_convertible(base: &Type, target: &Type, ctx: &CompCtx) -> bool {
             }
             Type::Mut(b) => impl_convertible(b, target, ctx),
             Type::Tuple(v) | Type::Struct(v, _) => {
-                v.iter().all(|v| impl_convertible(v, &Type::TypeData, ctx))
+                target == &Type::TypeData
+                    && v.iter().all(|v| impl_convertible(v, &Type::TypeData, ctx))
             }
             Type::Null => *target == Type::TypeData,
             Type::Error => true,
@@ -130,7 +131,8 @@ pub fn expl_convertible(base: &Type, target: &Type, ctx: &CompCtx) -> bool {
             }
             Type::Mut(b) => expl_convertible(b, target, ctx),
             Type::Tuple(v) | Type::Struct(v, _) => {
-                v.iter().all(|v| impl_convertible(v, &Type::TypeData, ctx))
+                target == &Type::TypeData
+                    && v.iter().all(|v| impl_convertible(v, &Type::TypeData, ctx))
             }
             Type::Null => matches!(
                 target,

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -6,6 +6,7 @@ use inkwell::types::{
 };
 use inkwell::values::BasicValueEnum;
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::fmt::*;
 use std::io::{self, BufRead, Read, Write};
 use SizeType::*;
@@ -81,6 +82,8 @@ pub enum Type {
     BoundMethod(Box<Type>, Vec<(Type, bool)>),
     Nominal(String),
     Tuple(Vec<Type>),
+    /// IMPORTANT: this *must* be in the correct order- it must be sorted according to `struct_order`
+    Struct(Vec<Type>, HashMap<String, usize>),
     Error,
 }
 impl Display for Type {
@@ -161,9 +164,42 @@ impl Display for Type {
                 }
                 write!(f, ")")
             }
+            Struct(fields, lookup) => write!(
+                f,
+                "{{{}}}",
+                lookup
+                    .iter()
+                    .map(|(name, idx)| format!("{name}: {}", fields[*idx]))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
             Error => write!(f, "<error>"),
         }
     }
+}
+/// determine the most efficient layout for struct fields
+pub fn struct_order(
+    lhs: &Type,
+    rhs: &Type,
+    names: Option<(&str, &str)>,
+    ctx: &CompCtx,
+) -> std::cmp::Ordering {
+    use std::cmp::Ordering::*;
+    let mut ord = rhs.align(ctx).cmp(&lhs.align(ctx));
+    if ord != Equal {
+        return ord;
+    }
+    ord = match (lhs.size(ctx), rhs.size(ctx)) {
+        (Meta, _) | (_, Meta) => Equal,
+        (Dynamic, Dynamic) => Equal,
+        (_, Dynamic) => Less,
+        (Dynamic, _) => Greater,
+        (Static(l), Static(r)) => r.cmp(&l),
+    };
+    if ord != Equal {
+        return ord;
+    }
+    names.map_or(Equal, |(l, r)| l.cmp(r))
 }
 impl Type {
     pub fn size(&self, ctx: &CompCtx) -> SizeType {
@@ -201,6 +237,23 @@ impl Type {
                     v
                 }
             }),
+            Struct(fields, _) => fields.iter().fold(Static(0), |v, t| {
+                if let Static(bs) = v {
+                    let n = t.size(ctx);
+                    if let Static(ns) = n {
+                        let a = t.align(ctx) as u32;
+                        if a == 0 || a == 1 {
+                            Static(bs + ns)
+                        } else {
+                            Static(((bs + a - 1) / a) * a + ns)
+                        }
+                    } else {
+                        n
+                    }
+                } else {
+                    v
+                }
+            }),
             Nominal(n) => ctx.nominals.borrow()[n].0.size(ctx),
         }
     }
@@ -221,7 +274,7 @@ impl Type {
             Function(..) | Module | TypeData | InlineAsm(_) | Intrinsic(_) | Error => 0,
             Pointer(_) | Reference(_) | BoundMethod(..) => ctx.flags.word_size,
             Mut(b) => b.align(ctx),
-            Tuple(v) => v.iter().map(|x| x.align(ctx)).max().unwrap_or(1),
+            Tuple(v) | Type::Struct(v, _) => v.iter().map(|x| x.align(ctx)).max().unwrap_or(1),
             Nominal(n) => ctx.nominals.borrow()[n].0.align(ctx),
         }
     }
@@ -294,12 +347,12 @@ impl Type {
             Mut(b) => b
                 .llvm_type(ctx)
                 .map(|t| t.ptr_type(Default::default()).into()),
-            Tuple(v) => {
-                let mut vec = Vec::with_capacity(v.len());
-                for t in v {
-                    vec.push(t.llvm_type(ctx)?);
-                }
-                Some(ctx.context.struct_type(&vec, false).into())
+            Tuple(v) | Struct(v, _) => {
+                let fields = v
+                    .iter()
+                    .map(|t| t.llvm_type(ctx))
+                    .collect::<Option<Vec<_>>>()?;
+                Some(ctx.context.struct_type(&fields, false).into())
             }
             Nominal(n) => ctx.nominals.borrow()[n].0.llvm_type(ctx),
         }
@@ -312,7 +365,7 @@ impl Type {
                 info.3.dtor.is_some() || (!info.3.no_auto_drop && info.0.has_dtor(ctx))
             }
             Type::Array(b, _) | Type::Mut(b) => b.has_dtor(ctx),
-            Type::Tuple(v) => v.iter().any(|t| t.has_dtor(ctx)),
+            Type::Tuple(v) | Type::Struct(v, _) => v.iter().any(|t| t.has_dtor(ctx)),
             Type::BoundMethod(_, a) => a.get(0).map_or(false, |t| t.0.has_dtor(ctx)),
             _ => false,
         }
@@ -330,7 +383,7 @@ impl Type {
                     false
                 }
             }
-            Type::Tuple(vs) => {
+            Type::Tuple(vs) | Type::Struct(vs, _) => {
                 if let InterData::Array(is) = v {
                     vs.len() == is.len()
                         && vs.iter().zip(is).all(|(t, v)| t.can_be_compiled(v, ctx))
@@ -417,7 +470,7 @@ impl Type {
                     None
                 }
             }
-            Type::Tuple(vs) => {
+            Type::Tuple(vs) | Type::Struct(vs, _) => {
                 self.can_be_compiled(v, ctx).then_some(())?;
                 if let InterData::Array(is) = v {
                     let (vals, types): (Vec<_>, Vec<_>) = vs
@@ -454,7 +507,7 @@ impl Type {
             | Type::Mut(b)
             | Type::Array(b, _)
             | Type::InlineAsm(b) => b.contains_nominal(),
-            Type::Tuple(v) => v.iter().any(|t| t.contains_nominal()),
+            Type::Tuple(v) | Type::Struct(v, _) => v.iter().any(|t| t.contains_nominal()),
             Type::Function(r, a) => {
                 r.contains_nominal() || a.iter().any(|t| t.0.contains_nominal())
             }
@@ -499,6 +552,16 @@ impl Type {
                 if v.iter().any(|t| t.contains_nominal()) {
                     Cow::Owned(Type::Tuple(
                         v.iter().map(|t| t.unwrapped(ctx).into_owned()).collect(),
+                    ))
+                } else {
+                    Cow::Borrowed(self)
+                }
+            }
+            Type::Struct(v, l) => {
+                if v.iter().any(|t| t.contains_nominal()) {
+                    Cow::Owned(Type::Struct(
+                        v.iter().map(|t| t.unwrapped(ctx).into_owned()).collect(),
+                        l.clone(),
                     ))
                 } else {
                     Cow::Borrowed(self)
@@ -602,6 +665,19 @@ impl Type {
                 out.write_all(&buf)?;
                 v.iter().try_for_each(|t| t.save(out))
             }
+            Struct(fields, l) => {
+                out.write_all(&[22])?;
+                let mut rev_lookup = [None].repeat(fields.len());
+                for (k, &v) in l {
+                    rev_lookup[v] = Some(k);
+                }
+                for (n, ty) in fields.iter().enumerate() {
+                    out.write_all(rev_lookup[n].unwrap().as_bytes())?;
+                    out.write_all(&[0])?;
+                    ty.save(out)?;
+                }
+                out.write_all(&[0])
+            }
             BoundMethod(r, p) => {
                 out.write_all(&[21])?;
                 out.write_all(&(p.len() as u16).to_be_bytes())?; // # of params
@@ -697,7 +773,24 @@ impl Type {
                 }
                 Type::BoundMethod(Box::new(ret), vec)
             }
-            x => panic!("read type value expecting value in 1..=21, got {x}"),
+            22 => {
+                let mut fields = vec![];
+                let mut lookup = HashMap::new();
+                loop {
+                    let mut vec = vec![];
+                    buf.read_until(0, &mut vec)?;
+                    if vec.last() == Some(&0) {
+                        vec.pop();
+                    }
+                    if vec.is_empty() {
+                        break;
+                    }
+                    lookup.insert(String::from_utf8(vec).unwrap(), fields.len());
+                    fields.push(Type::load(buf)?);
+                }
+                Type::Struct(fields, lookup)
+            }
+            x => panic!("read type value expecting value in 1..=22, got {x}"),
         })
     }
     /// Ensure that any symbols reachable from this type are exported
@@ -709,7 +802,7 @@ impl Type {
             | Type::Mut(b)
             | Type::Array(b, _)
             | Type::InlineAsm(b) => b.export(ctx),
-            Type::Tuple(v) => v.iter().for_each(|t| t.export(ctx)),
+            Type::Tuple(v) | Type::Struct(v, _) => v.iter().for_each(|t| t.export(ctx)),
             Type::Function(r, a) => {
                 r.export(ctx);
                 a.iter().for_each(|t| t.0.export(ctx));

--- a/cobalt-ast/src/value.rs
+++ b/cobalt-ast/src/value.rs
@@ -17,12 +17,16 @@ pub struct FnData<'ctx> {
     pub cconv: u32,
     pub mt: MethodType,
 }
+
+/// Used for compile-time constants.
 #[derive(Debug, Clone)]
 pub enum InterData<'ctx> {
     Null,
     Int(i128),
     Float(f64),
+    /// Used for tuples, structs, arrays, and bound methods.
     Array(Vec<InterData<'ctx>>),
+    /// Used for default values of function parameters.
     Function(FnData<'ctx>),
     InlineAsm(String, String),
     Type(Box<Type>),

--- a/cobalt-parser/src/lib.rs
+++ b/cobalt-parser/src/lib.rs
@@ -46,12 +46,18 @@ type BoxedASTParser<'a, 'b> = BoxedParser<'a, 'b, Box<dyn AST>>;
 static KEYWORDS: &[&str] = &[
     "let", "mut", "const", "fn", "if", "else", "while", "for", "null", "type",
 ];
+
 /// parse an identifier. unicode-aware
 fn ident<'a>() -> impl Parser<'a, &'a str, &'a str, Extras<'a>> + Copy {
+    // First parse it, then check if it's a keyword.
+    //
+    // - 1: Accept any character which is an '_' or xid start.
+    // - 2: Then accept any number of xid_continue, storing them in a `Vec`.
+    // - 3: We want the output of this parser to be a slice.
     any()
-        .filter(|&c| c == '_' || is_xid_start(c))
-        .then(any().filter(|&c| is_xid_continue(c)).repeated())
-        .slice()
+        .filter(|&c| c == '_' || is_xid_start(c)) // 1
+        .then(any().filter(|&c| is_xid_continue(c)).repeated()) // 2
+        .slice() // 3
         .try_map(|val, span| {
             if KEYWORDS.contains(&val) {
                 Err(Rich::custom(
@@ -64,6 +70,7 @@ fn ident<'a>() -> impl Parser<'a, &'a str, &'a str, Extras<'a>> + Copy {
         })
         .labelled("an identifier")
 }
+
 fn local_id<'a>() -> impl Parser<'a, &'a str, DottedName, Extras<'a>> + Copy {
     ident()
         .map_with_span(|id, loc| DottedName::local((id.to_string(), loc.into_range().into())))
@@ -83,7 +90,13 @@ fn global_id<'a>() -> impl Parser<'a, &'a str, DottedName, Extras<'a>> + Copy {
         .map(|(global, ids)| DottedName::new(ids, global))
         .labelled("a global identifier")
 }
+
+/// Parses (well, ignores) patterns that Cobalt should ignore, such as whitespace and comments.
 fn ignored<'a>() -> impl Parser<'a, &'a str, (), Extras<'a>> + Copy {
+    // Consume any number of either
+    // - whitespace
+    // - multiline comments
+    // - single-line comments
     choice((
         // whitespace
         any().filter(|c: &char| c.is_whitespace()).ignored(),
@@ -102,6 +115,7 @@ fn ignored<'a>() -> impl Parser<'a, &'a str, (), Extras<'a>> + Copy {
     .ignored()
     .labelled("whitespace")
 }
+
 /// where a declaration is being parsed
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DeclLoc {
@@ -112,20 +126,30 @@ enum DeclLoc {
     /// global scope- do I need to explain this?
     Global,
 }
+
+/// Parser for an annotation, e.g. `@C(extern)`.
+///
+/// The output is (annotation name, annotation argument, source span), e.g. for
+/// `@C(extern)` the annotation name is "C" and the annotation argument is "extern".
 fn annotation<'a>(
 ) -> impl Parser<'a, &'a str, (String, Option<String>, SourceSpan), Extras<'a>> + Copy {
+    // - 1: Accept an `@` (but don't store it), then an identifier (so no keywords).
+    // - 2: The argument can be any sequence of characters that does not include ')' and is
+    // surrounded by parentheses.
+    // - 3: Since not every annotation has an argument, don't fail if there isn't one.
     just('@')
-        .ignore_then(ident())
+        .ignore_then(ident()) // 1
         .then(
             none_of(')')
                 .repeated()
                 .collect()
-                .delimited_by(just('('), just(')'))
-                .or_not(),
+                .delimited_by(just('('), just(')')) // 2
+                .or_not(), // 3
         )
         .map_with_span(|(name, arg), loc| (name.to_string(), arg, loc.into_range().into()))
         .labelled("an annotation")
 }
+
 fn cdn<'a>() -> impl Parser<'a, &'a str, CompoundDottedName, Extras<'a>> + Clone {
     use CompoundDottedNameSegment::*;
     let cdns = recursive(|cdns| {
@@ -164,6 +188,7 @@ fn import<'a>() -> impl Parser<'a, &'a str, ImportAST, Extras<'a>> + Clone {
         .map(|((anns, loc), cdn)| ImportAST::new(loc.into_range().into(), cdn, anns))
         .labelled("an import")
 }
+
 /// parse declarations. these are:
 /// - functions
 /// - variables
@@ -508,6 +533,7 @@ fn declarations<'a>(
     ])
     .labelled("a declaration")
 }
+
 /// create a parser for a statement.
 /// it requires an expression parser to passed, otherwise it would require infinite recursion
 fn def_stmt<'a>(expr: BoxedASTParser<'a, 'a>) -> BoxedASTParser<'a, 'a> {
@@ -581,13 +607,25 @@ fn top_level<'a>() -> impl Parser<'a, &'a str, Box<dyn AST>, Extras<'a>> + Clone
     })
     .labelled("a top-level declaration")
 }
+
 /// add assignments and control flow to parser
 fn add_assigns<'a: 'b, 'b>(
     expr: impl Parser<'a, &'a str, Box<dyn AST>, Extras<'a>> + Clone + 'a,
 ) -> BoxedASTParser<'a, 'b> {
+    // - 1: After the initial parser is done, the input can be followed up by any of these options.
+    // The order in which they are listed indicates their precedence. After this `then()`, the
+    // output will be (output of `expr`, operator).
+    //
+    // - 2: Right associative folding. Consider this input:
+    // ```
+    // x = y+=z<<=a
+    // ```
+    // This will parse as (x, =, (y, +=, (z, <<=, a))). Note this is the opposite direction of
+    // associativity to math operations.
     let prev = expr
         .clone()
         .then(
+            // 1
             choice(
                 [
                     "=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=",
@@ -600,20 +638,51 @@ fn add_assigns<'a: 'b, 'b>(
         )
         .repeated()
         .foldr(expr, |(lhs, (op, loc)), rhs| {
+            // 2
             box_ast(BinOpAST::new(loc, op, lhs, rhs))
         })
         .labelled("an expression")
         .boxed();
+
+    // - 1: Parse an if/else section, e.g.
+    // ```
+    // if (x == 3i32) {
+    //   x += 1;
+    // };
+    // ```
+    // -- 1a: The conditional will begin with `(` or `{`...
+    // -- 1b: ...but don't immediately fail if not. In any case we have were expecting an
+    // expression (something accepted by `expr`) and just consumed one character of it.
+    // Rewind one character and parse it using `expr`.
+    // -- 1c: The reason for having (1a) and (1b) in the first place is just for better error
+    // messaging; we want to know if the user just forgot to wrap their condition in
+    // parentheses/braces.
+    // -- 1d: This parses the body of the section, e.g. `{ x += 1; }`.
+    // -- 1e: There may or may not be an else clause.
+    // -- 1f: If there was an "else" clause, then unwrap it, or just put a dummy ast node in
+    // it's place.
+    //
+    // - 2: Parse a while section, e.g.
+    // ```
+    // while (x > 0i32) {
+    //  x -= 1;
+    // };
+    // ```
+    // This is functionally very similar to the if/else parsing.
+    //
+    // - 3: Error recovery strategy: maybe we're just seeing an else clause for some reason.
+    // If that's the consume it. In any case, an error is thrown.
     recursive(|expr| {
         choice([
-            text::keyword("if")
+            text::keyword("if") // 1
                 .ignore_then(ignored())
                 .ignore_then(
                     one_of("({")
-                        .or_not()
-                        .rewind()
+                        .or_not() // 1a
+                        .rewind() // 1b
                         .then(expr.clone())
                         .validate(|(o, ast), loc, e| {
+                            // 1c
                             if o.is_none() {
                                 e.emit(Rich::custom(
                                     loc,
@@ -624,12 +693,13 @@ fn add_assigns<'a: 'b, 'b>(
                         })
                         .labelled("a condition"),
                 )
-                .then(expr.clone().padded_by(ignored()))
+                .then(expr.clone().padded_by(ignored())) // 1d
                 .then(
                     text::keyword("else")
                         .ignore_then(expr.clone().padded_by(ignored()))
-                        .or_not()
+                        .or_not() // 1e
                         .map_with_span(|expr, loc| {
+                            // 1f
                             expr.unwrap_or_else(|| box_ast(NullAST::new(loc.into_range().into())))
                         }),
                 )
@@ -642,12 +712,12 @@ fn add_assigns<'a: 'b, 'b>(
                     ))
                 })
                 .boxed(),
-            text::keyword("while")
+            text::keyword("while") // 2
                 .ignore_then(ignored())
                 .ignore_then(
                     one_of("({")
                         .or_not()
-                        .rewind()
+                        .rewind() // 2a
                         .then(expr.clone())
                         .validate(|(o, ast), loc, e| {
                             if o.is_none() {
@@ -667,11 +737,12 @@ fn add_assigns<'a: 'b, 'b>(
                 .boxed(),
             prev,
         ])
-        .recover_with(via_parser(text::keyword("else").ignore_then(expr)))
+        .recover_with(via_parser(text::keyword("else").ignore_then(expr))) // 3
     })
     .labelled("an expression")
     .boxed()
 }
+
 /// create a parser for expressions, without assignment
 fn expr_impl<'a: 'b, 'b>() -> BoxedASTParser<'a, 'b> {
     type Cbi = utils::CharBytesIterator;

--- a/cobalt-parser/src/lib.rs
+++ b/cobalt-parser/src/lib.rs
@@ -1,9 +1,8 @@
-use std::collections::HashMap;
-
 use chumsky::{error::RichReason, prelude::*};
 use cobalt_ast::{ast::*, *};
 use cobalt_errors::miette::{LabeledSpan, MietteDiagnostic, SourceSpan};
 use cobalt_errors::*;
+use std::collections::HashMap;
 use unicode_ident::*;
 mod utils;
 pub mod prelude {

--- a/cobalt-parser/src/lib.rs
+++ b/cobalt-parser/src/lib.rs
@@ -964,6 +964,7 @@ fn expr_impl<'a: 'b, 'b>() -> BoxedASTParser<'a, 'b> {
                             })
                             .then_ignore(just(':').padded_by(ignored()))
                             .then(expr.clone()) // parse `name: type`
+                            .padded_by(ignored())
                             .separated_by(just(',').padded_by(ignored()))
                             .allow_trailing()
                             .at_least(1)


### PR DESCRIPTION
Structs are a type that has fields, which is more convenient than a tuple type with `@getter` annotations. There's also the `@transparent` annotation, which allows transparent access to the underlying type of a user-defined type