### PR TITLE
Add file-level module declarations

### DIFF
--- a/cobalt-ast/src/ast/scope.rs
+++ b/cobalt-ast/src/ast/scope.rs
@@ -14,6 +14,224 @@ impl AST for ModuleAST {
     fn nodes(&self) -> usize {
         self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1
     }
+    fn varfwd_prepass(&self, ctx: &CompCtx) {
+        let mut target_match = 2u8;
+        let mut vis_spec = None;
+        for (ann, arg, _) in self.annotations.iter() {
+            match ann.as_str() {
+                "target" => {
+                    if let Some(arg) = arg {
+                        let mut arg = arg.as_str();
+                        let negate = if arg.as_bytes().first() == Some(&0x21) {
+                            arg = &arg[1..];
+                            true
+                        } else {
+                            false
+                        };
+                        if let Ok(pat) = Pattern::new(arg) {
+                            if target_match != 1 {
+                                target_match = u8::from(
+                                    negate
+                                        ^ pat.matches(
+                                            &ctx.module.get_triple().as_str().to_string_lossy(),
+                                        ),
+                                )
+                            }
+                        }
+                    }
+                }
+                "export" => {
+                    if vis_spec.is_none() {
+                        match arg.as_deref() {
+                            None | Some("true") | Some("1") | Some("") => vis_spec = Some(true),
+                            Some("false") | Some("0") => vis_spec = Some(false),
+                            Some(_) => {}
+                        }
+                    }
+                }
+                "private" => {
+                    if vis_spec.is_none() {
+                        match arg.as_deref() {
+                            None | Some("true") | Some("1") | Some("") => vis_spec = Some(false),
+                            Some("false") | Some("0") => vis_spec = Some(true),
+                            Some(_) => {}
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if target_match == 0 {
+            return;
+        }
+        ctx.map_vars(|mut v| match v.lookup_mod(&self.name) {
+            Ok((m, i, _)) => Box::new(VarMap {
+                parent: Some(v),
+                symbols: m,
+                imports: i,
+            }),
+            Err(_) => Box::new(VarMap::new(Some(v))),
+        });
+        let old_scope = ctx.push_scope(&self.name);
+        let old_vis = if let Some(v) = vis_spec {
+            ctx.export.replace(v)
+        } else {
+            false
+        };
+        self.vals.iter().for_each(|val| val.varfwd_prepass(ctx));
+        ctx.restore_scope(old_scope);
+        if vis_spec.is_some() {
+            ctx.export.set(old_vis)
+        }
+        let syms = ctx.map_split_vars(|v| (v.parent.unwrap(), (v.symbols, v.imports)));
+        std::mem::drop(ctx.with_vars(|v| v.insert_mod(&self.name, syms, ctx.mangle(&self.name))));
+    }
+    fn constinit_prepass(&self, ctx: &CompCtx, needs_another: &mut bool) {
+        let mut target_match = 2u8;
+        let mut vis_spec = None;
+        for (ann, arg, _) in self.annotations.iter() {
+            match ann.as_str() {
+                "target" => {
+                    if let Some(arg) = arg {
+                        let mut arg = arg.as_str();
+                        let negate = if arg.as_bytes().first() == Some(&0x21) {
+                            arg = &arg[1..];
+                            true
+                        } else {
+                            false
+                        };
+                        if let Ok(pat) = Pattern::new(arg) {
+                            if target_match != 1 {
+                                target_match = u8::from(
+                                    negate
+                                        ^ pat.matches(
+                                            &ctx.module.get_triple().as_str().to_string_lossy(),
+                                        ),
+                                )
+                            }
+                        }
+                    }
+                }
+                "export" => {
+                    if vis_spec.is_none() {
+                        match arg.as_deref() {
+                            None | Some("true") | Some("1") | Some("") => vis_spec = Some(true),
+                            Some("false") | Some("0") => vis_spec = Some(false),
+                            Some(_) => {}
+                        }
+                    }
+                }
+                "private" => {
+                    if vis_spec.is_none() {
+                        match arg.as_deref() {
+                            None | Some("true") | Some("1") | Some("") => vis_spec = Some(false),
+                            Some("false") | Some("0") => vis_spec = Some(true),
+                            Some(_) => {}
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if target_match == 0 {
+            return;
+        }
+        ctx.map_vars(|mut v| match v.lookup_mod(&self.name) {
+            Ok((m, i, _)) => Box::new(VarMap {
+                parent: Some(v),
+                symbols: m,
+                imports: i,
+            }),
+            Err(_) => Box::new(VarMap::new(Some(v))),
+        });
+        let old_scope = ctx.push_scope(&self.name);
+        let old_vis = if let Some(v) = vis_spec {
+            ctx.export.replace(v)
+        } else {
+            false
+        };
+        self.vals
+            .iter()
+            .for_each(|val| val.constinit_prepass(ctx, needs_another));
+        ctx.restore_scope(old_scope);
+        if vis_spec.is_some() {
+            ctx.export.set(old_vis)
+        }
+        let syms = ctx.map_split_vars(|v| (v.parent.unwrap(), (v.symbols, v.imports)));
+        std::mem::drop(ctx.with_vars(|v| v.insert_mod(&self.name, syms, ctx.mangle(&self.name))));
+    }
+    fn fwddef_prepass(&self, ctx: &CompCtx) {
+        let mut target_match = 2u8;
+        let mut vis_spec = None;
+        for (ann, arg, _) in self.annotations.iter() {
+            match ann.as_str() {
+                "target" => {
+                    if let Some(arg) = arg {
+                        let mut arg = arg.as_str();
+                        let negate = if arg.as_bytes().first() == Some(&0x21) {
+                            arg = &arg[1..];
+                            true
+                        } else {
+                            false
+                        };
+                        if let Ok(pat) = Pattern::new(arg) {
+                            if target_match != 1 {
+                                target_match = u8::from(
+                                    negate
+                                        ^ pat.matches(
+                                            &ctx.module.get_triple().as_str().to_string_lossy(),
+                                        ),
+                                )
+                            }
+                        }
+                    }
+                }
+                "export" => {
+                    if vis_spec.is_none() {
+                        match arg.as_deref() {
+                            None | Some("true") | Some("1") | Some("") => vis_spec = Some(true),
+                            Some("false") | Some("0") => vis_spec = Some(false),
+                            Some(_) => {}
+                        }
+                    }
+                }
+                "private" => {
+                    if vis_spec.is_none() {
+                        match arg.as_deref() {
+                            None | Some("true") | Some("1") | Some("") => vis_spec = Some(false),
+                            Some("false") | Some("0") => vis_spec = Some(true),
+                            Some(_) => {}
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if target_match == 0 {
+            return;
+        }
+        ctx.map_vars(|mut v| match v.lookup_mod(&self.name) {
+            Ok((m, i, _)) => Box::new(VarMap {
+                parent: Some(v),
+                symbols: m,
+                imports: i,
+            }),
+            Err(_) => Box::new(VarMap::new(Some(v))),
+        });
+        let old_scope = ctx.push_scope(&self.name);
+        let old_vis = if let Some(v) = vis_spec {
+            ctx.export.replace(v)
+        } else {
+            false
+        };
+        self.vals.iter().for_each(|val| val.fwddef_prepass(ctx));
+        ctx.restore_scope(old_scope);
+        if vis_spec.is_some() {
+            ctx.export.set(old_vis)
+        }
+        let syms = ctx.map_split_vars(|v| (v.parent.unwrap(), (v.symbols, v.imports)));
+        std::mem::drop(ctx.with_vars(|v| v.insert_mod(&self.name, syms, ctx.mangle(&self.name))));
+    }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let mut errs = Vec::<CobaltError>::new();
         let mut target_match = 2u8;
@@ -138,17 +356,17 @@ impl AST for ModuleAST {
         } else {
             false
         };
-        if ctx.flags.prepass {
-            self.vals.iter().for_each(|val| val.varfwd_prepass(ctx));
-            let mut again = true;
-            while again {
-                again = false;
-                self.vals
-                    .iter()
-                    .for_each(|val| val.constinit_prepass(ctx, &mut again));
-            }
-            self.vals.iter().for_each(|val| val.fwddef_prepass(ctx));
-        }
+        // if ctx.flags.prepass {
+        //     self.vals.iter().for_each(|val| val.varfwd_prepass(ctx));
+        //     let mut again = true;
+        //     while again {
+        //         again = false;
+        //         self.vals
+        //             .iter()
+        //             .for_each(|val| val.constinit_prepass(ctx, &mut again));
+        //     }
+        //     self.vals.iter().for_each(|val| val.fwddef_prepass(ctx));
+        // }
         errs.extend(self.vals.iter().flat_map(|val| val.codegen(ctx).1));
         ctx.restore_scope(old_scope);
         if vis_spec.is_some() {
@@ -210,6 +428,15 @@ impl ImportAST {
 impl AST for ImportAST {
     fn loc(&self) -> SourceSpan {
         self.loc
+    }
+    fn varfwd_prepass(&self, ctx: &CompCtx) {
+        self.codegen(ctx);
+    }
+    fn constinit_prepass(&self, ctx: &CompCtx, _needs_another: &mut bool) {
+        self.codegen(ctx);
+    }
+    fn fwddef_prepass(&self, ctx: &CompCtx) {
+        self.codegen(ctx);
     }
     fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
         let mut errs = vec![];

--- a/cobalt-parser/src/lib.rs
+++ b/cobalt-parser/src/lib.rs
@@ -1111,10 +1111,15 @@ pub fn parse_stmt<'a: 'b, 'b>() -> BoxedASTParser<'a, 'b> {
 }
 /// create a parser for the top-level scope
 pub fn parse_tl<'a: 'b, 'b>() -> BoxedParser<'a, 'b, TopLevelAST> {
-    top_level()
-        .repeated()
-        .collect()
-        .map(|vals| TopLevelAST::new(vals, None))
+    text::keyword("module")
+        .then_ignore(ignored())
+        .ignore_then(global_id())
+        .then_ignore(ignored())
+        .then_ignore(just(';'))
+        .padded_by(ignored())
+        .or_not()
+        .then(top_level().repeated().collect())
+        .map(|(module, vals)| TopLevelAST::new(vals, module))
         .then_ignore(ignored().then(end()))
         .boxed()
 }

--- a/cobalt-parser/src/lib.rs
+++ b/cobalt-parser/src/lib.rs
@@ -1114,7 +1114,7 @@ pub fn parse_tl<'a: 'b, 'b>() -> BoxedParser<'a, 'b, TopLevelAST> {
     top_level()
         .repeated()
         .collect()
-        .map(TopLevelAST::new)
+        .map(|vals| TopLevelAST::new(vals, None))
         .then_ignore(ignored().then(end()))
         .boxed()
 }


### PR DESCRIPTION
Previously, `module name;` defined an empty module. Since this had very limited use, it is no longer allowed. Instead, a module declaration can be added as the first line of a file to cause the file to act as if it was part of that module.