### PR TITLE
Improve support for ZSTs

### DIFF
--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -280,9 +280,14 @@ impl Type {
                         .into(),
                     )
                 }
-                Type::Mut(b) => b
-                    .llvm_type(ctx)
-                    .map(|t| t.ptr_type(Default::default()).into()),
+                Type::Mut(b) => {
+                    if b.size(ctx) == Static(0) {
+                        Some(PointerType(ctx.null_type.ptr_type(Default::default())))
+                    } else {
+                        b.llvm_type(ctx)
+                            .map(|t| t.ptr_type(Default::default()).into())
+                    }
+                }
                 b => {
                     if b.size(ctx) == Static(0) {
                         Some(PointerType(ctx.null_type.ptr_type(Default::default())))
@@ -291,9 +296,14 @@ impl Type {
                     }
                 }
             },
-            Mut(b) => b
-                .llvm_type(ctx)
-                .map(|t| t.ptr_type(Default::default()).into()),
+            Mut(b) => {
+                if b.size(ctx) == Static(0) {
+                    Some(PointerType(ctx.null_type.ptr_type(Default::default())))
+                } else {
+                    b.llvm_type(ctx)
+                        .map(|t| t.ptr_type(Default::default()).into())
+                }
+            }
             Tuple(v) => {
                 let mut vec = Vec::with_capacity(v.len());
                 for t in v {

--- a/cobalt-ast/src/value.rs
+++ b/cobalt-ast/src/value.rs
@@ -328,13 +328,17 @@ impl<'ctx> Value<'ctx> {
     }
 
     pub fn addr(&self, ctx: &CompCtx<'ctx>) -> Option<PointerValue<'ctx>> {
-        self.address.get().or_else(|| {
-            let ctv = self.value(ctx)?;
-            let alloca = ctx.builder.build_alloca(ctv.get_type(), "");
-            ctx.builder.build_store(alloca, ctv);
-            self.address.set(Some(alloca));
-            Some(alloca)
-        })
+        if self.data_type.size(ctx) == SizeType::Static(0) {
+            Some(ctx.null_type.ptr_type(Default::default()).const_null())
+        } else {
+            self.address.get().or_else(|| {
+                let ctv = self.value(ctx)?;
+                let alloca = ctx.builder.build_alloca(ctv.get_type(), "");
+                ctx.builder.build_store(alloca, ctv);
+                self.address.set(Some(alloca));
+                Some(alloca)
+            })
+        }
     }
     pub fn freeze(self, loc: SourceSpan) -> Value<'ctx> {
         Value {


### PR DESCRIPTION
Zero-sized types, or ZSTs, don't map perfectly to LLVM. Despite this, they now have better support and can be used in more places