### PR TITLE
Make ASTs reference data from the input

### DIFF
--- a/cobalt-ast/src/ast/flow.rs
+++ b/cobalt-ast/src/ast/flow.rs
@@ -1,17 +1,17 @@
 use crate::*;
 #[derive(Debug, Clone)]
-pub struct IfAST {
+pub struct IfAST<'src> {
     loc: SourceSpan,
-    pub cond: Box<dyn AST>,
-    pub if_true: Box<dyn AST>,
-    pub if_false: Box<dyn AST>,
+    pub cond: BoxedAST<'src>,
+    pub if_true: BoxedAST<'src>,
+    pub if_false: BoxedAST<'src>,
 }
-impl IfAST {
+impl<'src> IfAST<'src> {
     pub fn new(
         loc: SourceSpan,
-        cond: Box<dyn AST>,
-        if_true: Box<dyn AST>,
-        if_false: Box<dyn AST>,
+        cond: BoxedAST<'src>,
+        if_true: BoxedAST<'src>,
+        if_false: BoxedAST<'src>,
     ) -> Self {
         IfAST {
             loc,
@@ -21,14 +21,17 @@ impl IfAST {
         }
     }
 }
-impl AST for IfAST {
+impl<'src> AST<'src> for IfAST<'src> {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
     fn nodes(&self) -> usize {
         self.cond.nodes() + self.if_true.nodes() + self.if_false.nodes() + 1
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         if ctx.is_const.get() {
             return (Value::null(), vec![]);
         }
@@ -146,24 +149,27 @@ impl AST for IfAST {
     }
 }
 #[derive(Debug, Clone)]
-pub struct WhileAST {
+pub struct WhileAST<'src> {
     loc: SourceSpan,
-    cond: Box<dyn AST>,
-    body: Box<dyn AST>,
+    cond: BoxedAST<'src>,
+    body: BoxedAST<'src>,
 }
-impl WhileAST {
-    pub fn new(loc: SourceSpan, cond: Box<dyn AST>, body: Box<dyn AST>) -> Self {
+impl<'src> WhileAST<'src> {
+    pub fn new(loc: SourceSpan, cond: BoxedAST<'src>, body: BoxedAST<'src>) -> Self {
         WhileAST { loc, cond, body }
     }
 }
-impl AST for WhileAST {
+impl<'src> AST<'src> for WhileAST<'src> {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
     fn nodes(&self) -> usize {
         self.cond.nodes() + self.body.nodes() + 1
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         if ctx.is_const.get() {
             return (Value::null(), vec![]);
         }

--- a/cobalt-ast/src/ast/funcs.rs
+++ b/cobalt-ast/src/ast/funcs.rs
@@ -802,7 +802,7 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                             }
                             Err(err) => errs.push(CobaltError::GlobPatternError {
                                 pos: err.pos,
-                                msg: err.msg.into(),
+                                msg: err.msg,
                                 loc,
                             }),
                         }
@@ -882,7 +882,7 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                             if params.is_empty() {
                                 errs.push(CobaltError::InvalidSelfParam {
                                     loc: self.loc,
-                                    self_t: self_t.to_string().into(),
+                                    self_t: self_t.to_string(),
                                     param: None,
                                 });
                                 params.push((Type::Null, false));
@@ -902,8 +902,8 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                                 {
                                     errs.push(CobaltError::InvalidSelfParam {
                                         loc: self.params[0].2.loc(),
-                                        self_t: s.into(),
-                                        param: Some(params[0].0.to_string().into()),
+                                        self_t: s,
+                                        param: Some(params[0].0.to_string()),
                                     });
                                 } else {
                                     fn_type = Some((MethodType::Normal, loc));
@@ -941,7 +941,7 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                             if params.is_empty() {
                                 errs.push(CobaltError::InvalidSelfParam {
                                     loc: self.loc,
-                                    self_t: self_t.to_string().into(),
+                                    self_t: self_t.to_string(),
                                     param: None,
                                 });
                                 params.push((Type::Null, false));
@@ -961,8 +961,8 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                                 {
                                     errs.push(CobaltError::InvalidSelfParam {
                                         loc: self.params[0].2.loc(),
-                                        self_t: s.into(),
-                                        param: Some(params[0].0.to_string().into()),
+                                        self_t: s,
+                                        param: Some(params[0].0.to_string()),
                                     });
                                 } else {
                                     fn_type = Some((MethodType::Getter, loc));
@@ -1395,14 +1395,14 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                 Err(RedefVariable::NotAModule(x, _)) => {
                     errs.push(CobaltError::NotAModule {
                         loc: self.name.ids[x].1,
-                        name: self.name.start(x).to_string().into()
+                        name: self.name.start(x).to_string()
                     });
                     (Value::error(), errs)
                 },
                 Err(RedefVariable::AlreadyExists(x, d, _)) => {
                     errs.push(CobaltError::RedefVariable {
                         loc: self.name.ids[x].1,
-                        name: self.name.start(x).to_string().into(),
+                        name: self.name.start(x).to_string(),
                         prev: d
                     });
                     (Value::error(), errs)

--- a/cobalt-ast/src/ast/funcs.rs
+++ b/cobalt-ast/src/ast/funcs.rs
@@ -12,25 +12,30 @@ pub enum ParamType {
     Mutable,
     Constant,
 }
-pub type Parameter = (String, ParamType, Box<dyn AST>, Option<Box<dyn AST>>); // parameter, mut/const, type, default
+pub type Parameter<'src> = (
+    Cow<'src, str>,
+    ParamType,
+    BoxedAST<'src>,
+    Option<BoxedAST<'src>>,
+); // parameter, mut/const, type, default
 #[derive(Debug, Clone)]
-pub struct FnDefAST {
+pub struct FnDefAST<'src> {
     loc: SourceSpan,
-    pub name: DottedName,
-    pub ret: Box<dyn AST>,
-    pub params: Vec<Parameter>,
-    pub body: Box<dyn AST>,
-    pub annotations: Vec<(String, Option<String>, SourceSpan)>,
+    pub name: DottedName<'src>,
+    pub ret: BoxedAST<'src>,
+    pub params: Vec<Parameter<'src>>,
+    pub body: BoxedAST<'src>,
+    pub annotations: Vec<(Cow<'src, str>, Option<Cow<'src, str>>, SourceSpan)>,
     pub in_struct: bool,
 }
-impl FnDefAST {
+impl<'src> FnDefAST<'src> {
     pub fn new(
         loc: SourceSpan,
-        name: DottedName,
-        ret: Box<dyn AST>,
-        params: Vec<Parameter>,
-        body: Box<dyn AST>,
-        annotations: Vec<(String, Option<String>, SourceSpan)>,
+        name: DottedName<'src>,
+        ret: BoxedAST<'src>,
+        params: Vec<Parameter<'src>>,
+        body: BoxedAST<'src>,
+        annotations: Vec<(Cow<'src, str>, Option<Cow<'src, str>>, SourceSpan)>,
         in_struct: bool,
     ) -> Self {
         FnDefAST {
@@ -44,7 +49,7 @@ impl FnDefAST {
         }
     }
 }
-impl AST for FnDefAST {
+impl<'src> AST<'src> for FnDefAST<'src> {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
@@ -58,7 +63,7 @@ impl AST for FnDefAST {
                 .sum::<usize>()
             + 1
     }
-    fn fwddef_prepass(&self, ctx: &CompCtx) {
+    fn fwddef_prepass(&self, ctx: &CompCtx<'src, '_>) {
         let oic = ctx.is_const.replace(true);
         let mut ret = ops::impl_convert(
             unreachable_span(),
@@ -107,9 +112,9 @@ impl AST for FnDefAST {
         let mut is_extern = false;
         for (ann, arg, loc) in self.annotations.iter() {
             let loc = *loc;
-            match ann.as_str() {
+            match &**ann {
                 "link" => {
-                    link_type = match arg.as_ref().map(|x| x.as_str()) {
+                    link_type = match arg.as_deref() {
                         Some("extern") | Some("external") => Some(External),
                         Some("extern-weak")
                         | Some("extern_weak")
@@ -136,7 +141,7 @@ impl AST for FnDefAST {
                     }
                 }
                 "cconv" => {
-                    cconv = cconv.or(match arg.as_ref().map(|x| x.as_str()) {
+                    cconv = cconv.or(match arg.as_deref() {
                         Some("c") | Some("C") => Some(0),
                         Some("fast") | Some("Fast") => Some(8),
                         Some("cold") | Some("Cold") => Some(9),
@@ -156,7 +161,7 @@ impl AST for FnDefAST {
                 }
                 "extern" => {
                     is_extern = true;
-                    cconv = cconv.or(match arg.as_ref().map(|x| x.as_str()) {
+                    cconv = cconv.or(match arg.as_deref() {
                         Some("c") | Some("C") => Some(0),
                         Some("fast") | Some("Fast") => Some(8),
                         Some("cold") | Some("Cold") => Some(9),
@@ -176,7 +181,7 @@ impl AST for FnDefAST {
                 }
                 "inline" => {
                     if let Some(arg) = arg {
-                        match arg.as_str() {
+                        match &**arg {
                             "always" | "true" | "1" => inline = Some(true),
                             "never" | "false" | "0" => inline = Some(false),
                             _ => {}
@@ -200,7 +205,7 @@ impl AST for FnDefAST {
                 }
                 "target" => {
                     if let Some(arg) = arg {
-                        let mut arg = arg.as_str();
+                        let mut arg = &**arg;
                         let negate = if arg.as_bytes().first() == Some(&0x21) {
                             arg = &arg[1..];
                             true
@@ -291,18 +296,16 @@ impl AST for FnDefAST {
                 if good && !ctx.is_const.get() {
                     let ft = llt.fn_type(ps.as_slice(), false);
                     let f = ctx.module.add_function(
-                        linkas
-                            .map_or_else(
-                                || {
-                                    if cf {
-                                        self.name.ids.last().unwrap().0.clone()
-                                    } else {
-                                        ctx.mangle(&self.name)
-                                    }
-                                },
-                                |v| v.0,
-                            )
-                            .as_str(),
+                        &linkas.map_or_else(
+                            || {
+                                if cf {
+                                    self.name.ids.last().unwrap().0.clone()
+                                } else {
+                                    ctx.mangle(&self.name).into()
+                                }
+                            },
+                            |v| v.0,
+                        ),
                         ft,
                         None,
                     );
@@ -389,18 +392,16 @@ impl AST for FnDefAST {
                 if good && !ctx.is_const.get() {
                     let ft = ctx.context.void_type().fn_type(ps.as_slice(), false);
                     let f = ctx.module.add_function(
-                        linkas
-                            .map_or_else(
-                                || {
-                                    if cf {
-                                        self.name.ids.last().unwrap().0.clone()
-                                    } else {
-                                        ctx.mangle(&self.name)
-                                    }
-                                },
-                                |v| v.0,
-                            )
-                            .as_str(),
+                        &linkas.map_or_else(
+                            || {
+                                if cf {
+                                    self.name.ids.last().unwrap().0.clone()
+                                } else {
+                                    ctx.mangle(&self.name).into()
+                                }
+                            },
+                            |v| v.0,
+                        ),
                         ft,
                         None,
                     );
@@ -511,7 +512,10 @@ impl AST for FnDefAST {
             unreachable!()
         };
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         let mut errs = vec![];
         let oic = ctx.is_const.replace(true);
         let mut ret = ops::impl_convert(
@@ -580,7 +584,7 @@ impl AST for FnDefAST {
         let mut dtor = None;
         for (ann, arg, loc) in self.annotations.iter() {
             let loc = *loc;
-            match ann.as_str() {
+            match &**ann {
                 "link" => {
                     if let Some((_, prev)) = link_type {
                         errs.push(CobaltError::RedefAnnArgument {
@@ -756,7 +760,7 @@ impl AST for FnDefAST {
                     }
                 }
                 "c" | "C" => {
-                    match arg.as_ref().map(|x| x.as_str()) {
+                    match arg.as_deref() {
                         Some("") | None => {}
                         Some("extern") => is_extern = Some(loc),
                         Some(_) => errs.push(CobaltError::InvalidAnnArgument {
@@ -778,7 +782,7 @@ impl AST for FnDefAST {
                 }
                 "target" => {
                     if let Some(arg) = arg {
-                        let mut arg = arg.as_str();
+                        let mut arg = &**arg;
                         let negate = if arg.as_bytes().first() == Some(&0x21) {
                             arg = &arg[1..];
                             true
@@ -798,7 +802,7 @@ impl AST for FnDefAST {
                             }
                             Err(err) => errs.push(CobaltError::GlobPatternError {
                                 pos: err.pos,
-                                msg: err.msg.to_string(),
+                                msg: err.msg.into(),
                                 loc,
                             }),
                         }
@@ -878,7 +882,7 @@ impl AST for FnDefAST {
                             if params.is_empty() {
                                 errs.push(CobaltError::InvalidSelfParam {
                                     loc: self.loc,
-                                    self_t: self_t.to_string(),
+                                    self_t: self_t.to_string().into(),
                                     param: None,
                                 });
                                 params.push((Type::Null, false));
@@ -898,8 +902,8 @@ impl AST for FnDefAST {
                                 {
                                     errs.push(CobaltError::InvalidSelfParam {
                                         loc: self.params[0].2.loc(),
-                                        self_t: s,
-                                        param: Some(params[0].0.to_string()),
+                                        self_t: s.into(),
+                                        param: Some(params[0].0.to_string().into()),
                                     });
                                 } else {
                                     fn_type = Some((MethodType::Normal, loc));
@@ -908,7 +912,7 @@ impl AST for FnDefAST {
                         }
                     } else {
                         errs.push(CobaltError::UnknownAnnotation {
-                            name: "method".to_string(),
+                            name: "method".into(),
                             def: "non-struct function",
                             loc,
                         })
@@ -937,7 +941,7 @@ impl AST for FnDefAST {
                             if params.is_empty() {
                                 errs.push(CobaltError::InvalidSelfParam {
                                     loc: self.loc,
-                                    self_t: self_t.to_string(),
+                                    self_t: self_t.to_string().into(),
                                     param: None,
                                 });
                                 params.push((Type::Null, false));
@@ -957,8 +961,8 @@ impl AST for FnDefAST {
                                 {
                                     errs.push(CobaltError::InvalidSelfParam {
                                         loc: self.params[0].2.loc(),
-                                        self_t: s,
-                                        param: Some(params[0].0.to_string()),
+                                        self_t: s.into(),
+                                        param: Some(params[0].0.to_string().into()),
                                     });
                                 } else {
                                     fn_type = Some((MethodType::Getter, loc));
@@ -967,7 +971,7 @@ impl AST for FnDefAST {
                         }
                     } else {
                         errs.push(CobaltError::UnknownAnnotation {
-                            name: "getter".to_string(),
+                            name: "getter".into(),
                             def: "non-struct function",
                             loc,
                         })
@@ -1002,7 +1006,10 @@ impl AST for FnDefAST {
                                         loc,
                                         op: "drop",
                                         ex: "(&mut self_t)",
-                                        found: params.iter().map(|t| t.0.to_string()).collect(),
+                                        found: params
+                                            .iter()
+                                            .map(|t| t.0.to_string().into())
+                                            .collect(),
                                     });
                                 }
                             }
@@ -1018,7 +1025,7 @@ impl AST for FnDefAST {
                         }
                     } else {
                         errs.push(CobaltError::UnknownAnnotation {
-                            name: "op".to_string(),
+                            name: "op".into(),
                             def: "non-struct function",
                             loc,
                         })
@@ -1047,7 +1054,7 @@ impl AST for FnDefAST {
                 let ps = params.iter().filter_map(|(x, c)| if *c {None} else {Some(BasicMetadataTypeEnum::from(x.llvm_type(ctx).unwrap_or_else(|| {good = false; IntType(ctx.context.i8_type())})))}).collect::<Vec<_>>();
                 if good && !ctx.is_const.get() {
                     let ft = llt.fn_type(ps.as_slice(), false);
-                    let f = ctx.lookup_full(&self.name).and_then(|x| -> Option<FunctionValue> {Some(unsafe {std::mem::transmute(x.comp_val?.as_value_ref())})}).unwrap_or_else(|| ctx.module.add_function(linkas.map_or_else(|| if cf {self.name.ids.last().unwrap().0.clone()} else {ctx.mangle(&self.name)}, |v| v.0).as_str(), ft, None));
+                    let f = ctx.lookup_full(&self.name).and_then(|x| -> Option<FunctionValue> {Some(unsafe {std::mem::transmute(x.comp_val?.as_value_ref())})}).unwrap_or_else(|| ctx.module.add_function(&linkas.map_or_else(|| if cf {self.name.ids.last().unwrap().0.clone()} else {ctx.mangle(&self.name).into()}, |v| v.0), ft, None));
                     match inline {
                         Some((true, _)) => f.add_attribute(Function, ctx.context.create_enum_attribute(Attribute::get_named_enum_kind_id("alwaysinline"), 0)),
                         Some((false, _)) => f.add_attribute(Function, ctx.context.create_enum_attribute(Attribute::get_named_enum_kind_id("noinline"), 0)),
@@ -1133,11 +1140,11 @@ impl AST for FnDefAST {
                         graph.insert_dtors(ctx, true);
                         unsafe {
                             let seen = errs.iter()
-                                .filter_map(|err| if let CobaltError::DoubleMove {loc, name, ..} = err {Some((*loc, &*(name.as_str() as *const str)))} else {None})
+                                .filter_map(|err| if let CobaltError::DoubleMove {loc, name, ..} = err {Some((*loc, &*(&**name as *const str)))} else {None})
                                 .collect::<std::collections::HashSet<_>>();
                             errs.extend(graph.validate()
                                 .into_iter()
-                                .filter(|cfg::DoubleMove {name, loc, ..}| !seen.contains(&(*loc, name.as_str())))
+                                .filter(|cfg::DoubleMove {name, loc, ..}| !seen.contains(&(*loc, &**name)))
                                 .map(|cfg::DoubleMove {name, loc, prev, guaranteed}| CobaltError::DoubleMove {loc, prev, name, guaranteed}));
                         }
                         std::mem::drop(graph);
@@ -1203,7 +1210,7 @@ impl AST for FnDefAST {
                 let ps = params.iter().filter_map(|(x, c)| if *c {None} else {Some(BasicMetadataTypeEnum::from(x.llvm_type(ctx).unwrap_or_else(|| {good = false; IntType(ctx.context.i8_type())})))}).collect::<Vec<_>>();
                 if good && !ctx.is_const.get() {
                     let ft = ctx.context.void_type().fn_type(ps.as_slice(), false);
-                    let f = ctx.lookup_full(&self.name).and_then(|x| -> Option<FunctionValue> {Some(unsafe {std::mem::transmute(x.comp_val?.as_value_ref())})}).unwrap_or_else(|| ctx.module.add_function(linkas.map_or_else(|| if cf {self.name.ids.last().unwrap().0.clone()} else {ctx.mangle(&self.name)}, |v| v.0).as_str(), ft, None));
+                    let f = ctx.lookup_full(&self.name).and_then(|x| -> Option<FunctionValue> {Some(unsafe {std::mem::transmute(x.comp_val?.as_value_ref())})}).unwrap_or_else(|| ctx.module.add_function(&linkas.map_or_else(|| if cf {self.name.ids.last().unwrap().0.clone()} else {ctx.mangle(&self.name).into()}, |v| v.0), ft, None));
                     match inline {
                         Some((true, _)) => f.add_attribute(Function, ctx.context.create_enum_attribute(Attribute::get_named_enum_kind_id("alwaysinline"), 0)),
                         Some((false, _)) => f.add_attribute(Function, ctx.context.create_enum_attribute(Attribute::get_named_enum_kind_id("noinline"), 0)),
@@ -1289,11 +1296,11 @@ impl AST for FnDefAST {
                         graph.insert_dtors(ctx, true);
                         unsafe {
                             let seen = errs.iter()
-                                .filter_map(|err| if let CobaltError::DoubleMove {loc, name, ..} = err {Some((*loc, &*(name.as_str() as *const str)))} else {None})
+                                .filter_map(|err| if let CobaltError::DoubleMove {loc, name, ..} = err {Some((*loc, &*(&**name as *const str)))} else {None})
                                 .collect::<std::collections::HashSet<_>>();
                             errs.extend(graph.validate()
                                 .into_iter()
-                                .filter(|cfg::DoubleMove {name, loc, ..}| !seen.contains(&(*loc, name.as_str())))
+                                .filter(|cfg::DoubleMove {name, loc, ..}| !seen.contains(&(*loc, name)))
                                 .map(|cfg::DoubleMove {name, loc, prev, guaranteed}| CobaltError::DoubleMove {loc, prev, name, guaranteed}));
                         }
                         std::mem::drop(graph);
@@ -1388,14 +1395,14 @@ impl AST for FnDefAST {
                 Err(RedefVariable::NotAModule(x, _)) => {
                     errs.push(CobaltError::NotAModule {
                         loc: self.name.ids[x].1,
-                        name: self.name.start(x).to_string()
+                        name: self.name.start(x).to_string().into()
                     });
                     (Value::error(), errs)
                 },
                 Err(RedefVariable::AlreadyExists(x, d, _)) => {
                     errs.push(CobaltError::RedefVariable {
                         loc: self.name.ids[x].1,
-                        name: self.name.start(x).to_string(),
+                        name: self.name.start(x).to_string().into(),
                         prev: d
                     });
                     (Value::error(), errs)
@@ -1487,13 +1494,13 @@ impl AST for FnDefAST {
     }
 }
 #[derive(Debug, Clone)]
-pub struct CallAST {
+pub struct CallAST<'src> {
     pub cparen: SourceSpan,
-    pub target: Box<dyn AST>,
-    pub args: Vec<Box<dyn AST>>,
+    pub target: BoxedAST<'src>,
+    pub args: Vec<BoxedAST<'src>>,
 }
-impl CallAST {
-    pub fn new(cparen: SourceSpan, target: Box<dyn AST>, args: Vec<Box<dyn AST>>) -> Self {
+impl<'src> CallAST<'src> {
+    pub fn new(cparen: SourceSpan, target: BoxedAST<'src>, args: Vec<BoxedAST<'src>>) -> Self {
         CallAST {
             cparen,
             target,
@@ -1501,14 +1508,17 @@ impl CallAST {
         }
     }
 }
-impl AST for CallAST {
+impl<'src> AST<'src> for CallAST<'src> {
     fn loc(&self) -> SourceSpan {
         merge_spans(self.target.loc(), self.cparen)
     }
     fn nodes(&self) -> usize {
         self.target.nodes() + self.args.iter().map(|x| x.nodes()).sum::<usize>() + 1
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         let (val, mut errs) = self.target.codegen(ctx);
         (
             ops::call(
@@ -1548,26 +1558,29 @@ impl AST for CallAST {
     }
 }
 #[derive(Debug, Clone)]
-pub struct IntrinsicAST {
+pub struct IntrinsicAST<'src> {
     loc: SourceSpan,
-    pub name: String,
+    pub name: Cow<'src, str>,
 }
-impl IntrinsicAST {
-    pub fn new(loc: SourceSpan, name: String) -> Self {
+impl<'src> IntrinsicAST<'src> {
+    pub fn new(loc: SourceSpan, name: Cow<'src, str>) -> Self {
         IntrinsicAST { loc, name }
     }
 }
-impl AST for IntrinsicAST {
+impl<'src> AST<'src> for IntrinsicAST<'src> {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
-    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        _ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         if matches!(
-            self.name.as_str(),
+            &*self.name,
             "alloca" | "asm" | "sizeof" | "typeof" | "typename"
         ) {
             (
-                Value::new(None, None, Type::Intrinsic(self.name.clone())),
+                Value::new(None, None, Type::Intrinsic(self.name.to_string())),
                 vec![],
             )
         } else {

--- a/cobalt-ast/src/ast/groups.rs
+++ b/cobalt-ast/src/ast/groups.rs
@@ -1,22 +1,25 @@
 use crate::*;
 #[derive(Debug, Clone)]
-pub struct BlockAST {
+pub struct BlockAST<'src> {
     loc: SourceSpan,
-    pub vals: Vec<Box<dyn AST>>,
+    pub vals: Vec<BoxedAST<'src>>,
 }
-impl BlockAST {
-    pub fn new(loc: SourceSpan, vals: Vec<Box<dyn AST>>) -> Self {
+impl<'src> BlockAST<'src> {
+    pub fn new(loc: SourceSpan, vals: Vec<BoxedAST<'src>>) -> Self {
         BlockAST { loc, vals }
     }
 }
-impl AST for BlockAST {
+impl<'src> AST<'src> for BlockAST<'src> {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
     fn nodes(&self) -> usize {
         self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         ctx.map_vars(|v| Box::new(VarMap::new(Some(v))));
         // ctx.lex_scope.incr();
         let mut out = Value::null();
@@ -47,7 +50,7 @@ impl AST for BlockAST {
                     .iter()
                     .filter_map(|err| {
                         if let CobaltError::DoubleMove { loc, name, .. } = err {
-                            Some((*loc, &*(name.as_str() as *const str)))
+                            Some((*loc, &*(&**name as *const str)))
                         } else {
                             None
                         }
@@ -58,7 +61,7 @@ impl AST for BlockAST {
                         .validate()
                         .into_iter()
                         .filter(|cfg::DoubleMove { name, loc, .. }| {
-                            !seen.contains(&(*loc, name.as_str()))
+                            !seen.contains(&(*loc, &**name))
                         })
                         .map(
                             |cfg::DoubleMove {
@@ -98,23 +101,26 @@ impl AST for BlockAST {
     }
 }
 #[derive(Debug, Clone)]
-pub struct GroupAST {
-    pub vals: Vec<Box<dyn AST>>,
+pub struct GroupAST<'src> {
+    pub vals: Vec<BoxedAST<'src>>,
 }
-impl GroupAST {
-    pub fn new(vals: Vec<Box<dyn AST>>) -> Self {
+impl<'src> GroupAST<'src> {
+    pub fn new(vals: Vec<BoxedAST<'src>>) -> Self {
         assert!(!vals.is_empty());
         GroupAST { vals }
     }
 }
-impl AST for GroupAST {
+impl<'src> AST<'src> for GroupAST<'src> {
     fn loc(&self) -> SourceSpan {
         merge_spans(self.vals[0].loc(), self.vals.last().unwrap().loc())
     }
     fn nodes(&self) -> usize {
         self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         let mut out = Value::null();
         let mut errs = vec![];
         self.vals.iter().for_each(|val| {
@@ -147,18 +153,21 @@ impl AST for GroupAST {
     }
 }
 #[derive(Debug, Clone, Default)]
-pub struct TopLevelAST {
+pub struct TopLevelAST<'src> {
     pub file: Option<CobaltFile>,
-    pub vals: Vec<Box<dyn AST>>,
+    pub vals: Vec<BoxedAST<'src>>,
 }
-impl AST for TopLevelAST {
+impl<'src> AST<'src> for TopLevelAST<'src> {
     fn loc(&self) -> SourceSpan {
         unreachable_span()
     }
     fn nodes(&self) -> usize {
         self.vals.iter().map(|x| x.nodes()).sum::<usize>() + 1
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         if ctx.flags.prepass {
             self.vals.iter().for_each(|val| val.varfwd_prepass(ctx));
             let mut again = true;
@@ -195,11 +204,11 @@ impl AST for TopLevelAST {
         Ok(())
     }
 }
-impl TopLevelAST {
-    pub fn new(vals: Vec<Box<dyn AST>>) -> Self {
+impl<'src> TopLevelAST<'src> {
+    pub fn new(vals: Vec<BoxedAST<'src>>) -> Self {
         TopLevelAST { vals, file: None }
     }
-    pub fn run_passes(&self, ctx: &CompCtx) {
+    pub fn run_passes(&self, ctx: &CompCtx<'src, '_>) {
         self.vals.iter().for_each(|val| val.varfwd_prepass(ctx));
         let mut again = true;
         while again {
@@ -211,7 +220,7 @@ impl TopLevelAST {
         self.vals.iter().for_each(|val| val.fwddef_prepass(ctx));
     }
 }
-impl std::fmt::Display for TopLevelAST {
+impl std::fmt::Display for TopLevelAST<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let mut pre = TreePrefix::new();
         self.print_impl(f, &mut pre, self.file)

--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -403,8 +403,8 @@ impl<'src> AST<'src> for ArrayLiteralAST<'src> {
                     errs.push(CobaltError::ArrayElementsDontMatch {
                         loc: val.loc(),
                         prev: elem_loc,
-                        current: ty.to_string().into(),
-                        new: dt.to_string().into(),
+                        current: ty.to_string(),
+                        new: dt.to_string(),
                     });
                 }
             }

--- a/cobalt-ast/src/ast/misc.rs
+++ b/cobalt-ast/src/ast/misc.rs
@@ -2,24 +2,27 @@ use cobalt_llvm::inkwell::values::BasicValue;
 
 use crate::*;
 #[derive(Debug, Clone)]
-pub struct CastAST {
+pub struct CastAST<'src> {
     loc: SourceSpan,
-    pub val: Box<dyn AST>,
-    pub target: Box<dyn AST>,
+    pub val: BoxedAST<'src>,
+    pub target: BoxedAST<'src>,
 }
-impl CastAST {
-    pub fn new(loc: SourceSpan, val: Box<dyn AST>, target: Box<dyn AST>) -> Self {
+impl<'src> CastAST<'src> {
+    pub fn new(loc: SourceSpan, val: BoxedAST<'src>, target: BoxedAST<'src>) -> Self {
         CastAST { loc, val, target }
     }
 }
-impl AST for CastAST {
+impl<'src> AST<'src> for CastAST<'src> {
     fn loc(&self) -> SourceSpan {
         merge_spans(self.val.loc(), self.target.loc())
     }
     fn nodes(&self) -> usize {
         self.val.nodes() + self.target.nodes() + 1
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         let (val, mut errs) = self.val.codegen(ctx);
         if val.data_type == Type::Error {
             return (Value::error(), errs);
@@ -71,24 +74,27 @@ impl AST for CastAST {
     }
 }
 #[derive(Debug, Clone)]
-pub struct BitCastAST {
+pub struct BitCastAST<'src> {
     loc: SourceSpan,
-    pub val: Box<dyn AST>,
-    pub target: Box<dyn AST>,
+    pub val: BoxedAST<'src>,
+    pub target: BoxedAST<'src>,
 }
-impl BitCastAST {
-    pub fn new(loc: SourceSpan, val: Box<dyn AST>, target: Box<dyn AST>) -> Self {
+impl<'src> BitCastAST<'src> {
+    pub fn new(loc: SourceSpan, val: BoxedAST<'src>, target: BoxedAST<'src>) -> Self {
         BitCastAST { loc, val, target }
     }
 }
-impl AST for BitCastAST {
+impl<'src> AST<'src> for BitCastAST<'src> {
     fn loc(&self) -> SourceSpan {
         merge_spans(self.val.loc(), self.target.loc())
     }
     fn nodes(&self) -> usize {
         self.val.nodes() + self.target.nodes() + 1
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         let (mut val, mut errs) = self.val.codegen(ctx);
         if val.data_type == Type::Error {
             return (Value::error(), errs);
@@ -125,10 +131,10 @@ impl AST for BitCastAST {
                 if d != s {
                     errs.push(CobaltError::DifferentBitCastSizes {
                         loc: self.loc,
-                        from_ty: val.data_type.to_string(),
+                        from_ty: val.data_type.to_string().into(),
                         from_sz: s,
                         from_loc: self.val.loc(),
-                        to_ty: t.to_string(),
+                        to_ty: t.to_string().into(),
                         to_sz: d,
                         to_loc: self.target.loc(),
                     });
@@ -139,9 +145,9 @@ impl AST for BitCastAST {
                 if t == Type::Error || val.data_type == Type::Error {
                     errs.push(CobaltError::UnsizedBitCast {
                         loc: self.loc,
-                        from_ty: val.data_type.to_string(),
+                        from_ty: val.data_type.to_string().into(),
                         from_loc: self.val.loc(),
-                        to_ty: t.to_string(),
+                        to_ty: t.to_string().into(),
                         to_loc: self.target.loc(),
                     });
                 }
@@ -194,11 +200,14 @@ impl NullAST {
         NullAST { loc }
     }
 }
-impl AST for NullAST {
+impl<'src> AST<'src> for NullAST {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
-    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        _ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         (Value::null(), vec![])
     }
     fn print_impl(
@@ -219,11 +228,14 @@ impl ErrorAST {
         ErrorAST { loc }
     }
 }
-impl AST for ErrorAST {
+impl<'src> AST<'src> for ErrorAST {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
-    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        _ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         (Value::error(), vec![])
     }
     fn print_impl(
@@ -244,11 +256,14 @@ impl ErrorTypeAST {
         ErrorTypeAST { loc }
     }
 }
-impl AST for ErrorTypeAST {
+impl<'src> AST<'src> for ErrorTypeAST {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
-    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        _ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         (Value::make_type(Type::Error), vec![])
     }
     fn print_impl(
@@ -269,11 +284,14 @@ impl TypeLiteralAST {
         TypeLiteralAST { loc }
     }
 }
-impl AST for TypeLiteralAST {
+impl<'src> AST<'src> for TypeLiteralAST {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
-    fn codegen<'ctx>(&self, _ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        _ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         (Value::make_type(Type::TypeData), vec![])
     }
     fn print_impl(
@@ -286,16 +304,16 @@ impl AST for TypeLiteralAST {
     }
 }
 #[derive(Debug, Clone)]
-pub struct ParenAST {
+pub struct ParenAST<'src> {
     pub loc: SourceSpan,
-    pub base: Box<dyn AST>,
+    pub base: BoxedAST<'src>,
 }
-impl ParenAST {
-    pub fn new(loc: SourceSpan, base: Box<dyn AST>) -> Self {
+impl<'src> ParenAST<'src> {
+    pub fn new(loc: SourceSpan, base: BoxedAST<'src>) -> Self {
         ParenAST { loc, base }
     }
 }
-impl AST for ParenAST {
+impl<'src> AST<'src> for ParenAST<'src> {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
@@ -305,7 +323,10 @@ impl AST for ParenAST {
     fn is_const(&self) -> bool {
         self.base.is_const()
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         self.base.codegen(ctx)
     }
     fn print_impl(

--- a/cobalt-ast/src/ast/misc.rs
+++ b/cobalt-ast/src/ast/misc.rs
@@ -131,10 +131,10 @@ impl<'src> AST<'src> for BitCastAST<'src> {
                 if d != s {
                     errs.push(CobaltError::DifferentBitCastSizes {
                         loc: self.loc,
-                        from_ty: val.data_type.to_string().into(),
+                        from_ty: val.data_type.to_string(),
                         from_sz: s,
                         from_loc: self.val.loc(),
-                        to_ty: t.to_string().into(),
+                        to_ty: t.to_string(),
                         to_sz: d,
                         to_loc: self.target.loc(),
                     });
@@ -145,9 +145,9 @@ impl<'src> AST<'src> for BitCastAST<'src> {
                 if t == Type::Error || val.data_type == Type::Error {
                     errs.push(CobaltError::UnsizedBitCast {
                         loc: self.loc,
-                        from_ty: val.data_type.to_string().into(),
+                        from_ty: val.data_type.to_string(),
                         from_loc: self.val.loc(),
-                        to_ty: t.to_string().into(),
+                        to_ty: t.to_string(),
                         to_loc: self.target.loc(),
                     });
                 }

--- a/cobalt-ast/src/ast/ops.rs
+++ b/cobalt-ast/src/ast/ops.rs
@@ -411,7 +411,7 @@ impl<'src> AST<'src> for DotAST<'src> {
                             (
                                 Some(CobaltError::VariableDoesNotExist {
                                     name: self.name.0.clone(),
-                                    module: n.into(),
+                                    module: n,
                                     container: "module",
                                     loc: self.name.1,
                                 }),
@@ -446,7 +446,7 @@ impl<'src> AST<'src> for DotAST<'src> {
                     } else {
                         errs.push(CobaltError::VariableDoesNotExist {
                             name: self.name.0.clone(),
-                            module: n.clone().into(),
+                            module: n.clone(),
                             container: "type",
                             loc: self.name.1,
                         });
@@ -455,7 +455,7 @@ impl<'src> AST<'src> for DotAST<'src> {
                 } else {
                     errs.push(CobaltError::VariableDoesNotExist {
                         name: self.name.0.clone(),
-                        module: t.to_string().into(),
+                        module: t.to_string(),
                         container: "type",
                         loc: self.name.1,
                     });

--- a/cobalt-ast/src/ast/scope.rs
+++ b/cobalt-ast/src/ast/scope.rs
@@ -46,7 +46,7 @@ impl<'src> AST<'src> for ModuleAST<'src> {
                             }
                             Err(err) => errs.push(CobaltError::GlobPatternError {
                                 pos: err.pos,
-                                msg: err.msg.into(),
+                                msg: err.msg,
                                 loc,
                             }),
                         }
@@ -121,14 +121,14 @@ impl<'src> AST<'src> for ModuleAST<'src> {
             }),
             Err(UndefVariable::NotAModule(x)) => {
                 errs.push(CobaltError::NotAModule {
-                    name: self.name.start(x).to_string().into(),
+                    name: self.name.start(x).to_string(),
                     loc: self.name.ids[x - 1].1,
                 });
                 Box::new(VarMap::new(Some(v)))
             }
             Err(UndefVariable::DoesNotExist(x)) => {
                 errs.push(CobaltError::RedefVariable {
-                    name: self.name.start(x).to_string().into(),
+                    name: self.name.start(x).to_string(),
                     loc: self.name.ids[x - 1].1,
                     prev: None,
                 });
@@ -246,7 +246,7 @@ impl<'src> AST<'src> for ImportAST<'src> {
                             }
                             Err(err) => errs.push(CobaltError::GlobPatternError {
                                 pos: err.pos,
-                                msg: err.msg.into(),
+                                msg: err.msg,
                                 loc,
                             }),
                         }

--- a/cobalt-ast/src/ast/vars.rs
+++ b/cobalt-ast/src/ast/vars.rs
@@ -5,22 +5,22 @@ use inkwell::module::Linkage::*;
 use inkwell::values::{AsValueRef, BasicValueEnum::*, GlobalValue};
 use std::collections::{hash_map::Entry, HashSet};
 #[derive(Debug, Clone)]
-pub struct VarDefAST {
+pub struct VarDefAST<'src> {
     loc: SourceSpan,
-    pub name: DottedName,
-    pub val: Box<dyn AST>,
-    pub type_: Option<Box<dyn AST>>,
-    pub annotations: Vec<(String, Option<String>, SourceSpan)>,
+    pub name: DottedName<'src>,
+    pub val: BoxedAST<'src>,
+    pub type_: Option<BoxedAST<'src>>,
+    pub annotations: Vec<(Cow<'src, str>, Option<Cow<'src, str>>, SourceSpan)>,
     pub global: bool,
     pub is_mut: bool,
 }
-impl VarDefAST {
+impl<'src> VarDefAST<'src> {
     pub fn new(
         loc: SourceSpan,
-        name: DottedName,
-        val: Box<dyn AST>,
-        type_: Option<Box<dyn AST>>,
-        annotations: Vec<(String, Option<String>, SourceSpan)>,
+        name: DottedName<'src>,
+        val: BoxedAST<'src>,
+        type_: Option<BoxedAST<'src>>,
+        annotations: Vec<(Cow<'src, str>, Option<Cow<'src, str>>, SourceSpan)>,
         global: bool,
         is_mut: bool,
     ) -> Self {
@@ -35,14 +35,14 @@ impl VarDefAST {
         }
     }
 }
-impl AST for VarDefAST {
+impl<'src> AST<'src> for VarDefAST<'src> {
     fn loc(&self) -> SourceSpan {
         merge_spans(self.loc, self.val.loc())
     }
     fn nodes(&self) -> usize {
         self.val.nodes() + self.type_.as_ref().map_or(0, |x| x.nodes()) + 1
     }
-    fn fwddef_prepass(&self, ctx: &CompCtx) {
+    fn fwddef_prepass(&self, ctx: &CompCtx<'src, '_>) {
         let mut errs = vec![];
         let mut link_type = None;
         let mut linkas = None;
@@ -51,9 +51,9 @@ impl AST for VarDefAST {
         let mut target_match = 2u8;
         for (ann, arg, loc) in self.annotations.iter() {
             let loc = *loc;
-            match ann.as_str() {
+            match &**ann {
                 "link" => {
-                    link_type = match arg.as_ref().map(|x| x.as_str()) {
+                    link_type = match arg.as_deref() {
                         Some("extern") | Some("external") => Some(External),
                         Some("extern-weak")
                         | Some("extern_weak")
@@ -94,7 +94,7 @@ impl AST for VarDefAST {
                 }
                 "target" => {
                     if let Some(arg) = arg {
-                        let mut arg = arg.as_str();
+                        let mut arg = &**arg;
                         let negate = if arg.as_bytes().first() == Some(&0x21) {
                             arg = &arg[1..];
                             true
@@ -164,7 +164,7 @@ impl AST for VarDefAST {
                             let gv = ctx.module.add_global(
                                 t,
                                 None,
-                                &linkas.unwrap_or_else(|| ctx.mangle(&self.name)),
+                                &linkas.unwrap_or_else(|| ctx.mangle(&self.name).into()),
                             );
                             match link_type {
                                 None => {
@@ -189,7 +189,10 @@ impl AST for VarDefAST {
             )
         });
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         let mut errs = vec![];
         let mut is_static = false;
         let mut link_type = None;
@@ -199,7 +202,7 @@ impl AST for VarDefAST {
         let mut target_match = 2u8;
         for (ann, arg, loc) in self.annotations.iter() {
             let loc = *loc;
-            match ann.as_str() {
+            match &**ann {
                 "static" => {
                     if arg.is_some() {
                         errs.push(CobaltError::InvalidAnnArgument {
@@ -280,7 +283,7 @@ impl AST for VarDefAST {
                     }
                 }
                 "c" | "C" => {
-                    match arg.as_ref().map(|x| x.as_str()) {
+                    match arg.as_deref() {
                         Some("") | None => {}
                         Some("extern") => is_extern = Some(loc),
                         Some(_) => errs.push(CobaltError::InvalidAnnArgument {
@@ -302,7 +305,7 @@ impl AST for VarDefAST {
                 }
                 "target" => {
                     if let Some(arg) = arg {
-                        let mut arg = arg.as_str();
+                        let mut arg = &**arg;
                         let negate = if arg.as_bytes().first() == Some(&0x21) {
                             arg = &arg[1..];
                             true
@@ -322,7 +325,7 @@ impl AST for VarDefAST {
                             }
                             Err(err) => errs.push(CobaltError::GlobPatternError {
                                 pos: err.pos,
-                                msg: err.msg.to_string(),
+                                msg: err.msg.into(),
                                 loc,
                             }),
                         }
@@ -441,7 +444,7 @@ impl AST for VarDefAST {
                                 dt.llvm_type(ctx)
                                     .map(|t| {
                                         let mangled = linkas.map_or_else(
-                                            || ctx.mangle(&self.name),
+                                            || ctx.mangle(&self.name).into(),
                                             |(name, _)| name,
                                         );
                                         let gv = ctx
@@ -465,7 +468,7 @@ impl AST for VarDefAST {
                                     .or_else(|| {
                                         if dt != Type::Error {
                                             errs.push(CobaltError::TypeIsConstOnly {
-                                                ty: dt.to_string(),
+                                                ty: dt.to_string().into(),
                                                 loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
                                             })
                                         };
@@ -482,14 +485,14 @@ impl AST for VarDefAST {
                     Err(RedefVariable::NotAModule(x, _)) => {
                         errs.push(CobaltError::NotAModule {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string(),
+                            name: self.name.start(x).to_string().into(),
                         });
                         (Value::error(), errs)
                     }
                     Err(RedefVariable::AlreadyExists(x, d, _)) => {
                         errs.push(CobaltError::RedefVariable {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string(),
+                            name: self.name.start(x).to_string().into(),
                             prev: d,
                         });
                         (Value::error(), errs)
@@ -538,7 +541,7 @@ impl AST for VarDefAST {
                     } else {
                         let t = dt.llvm_type(ctx).unwrap();
                         let mangled =
-                            linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name);
+                            linkas.map_or_else(|| ctx.mangle(&self.name).into(), |(name, _)| name);
                         let gv = ctx
                             .lookup_full(&self.name)
                             .and_then(|x| -> Option<GlobalValue> {
@@ -570,7 +573,7 @@ impl AST for VarDefAST {
                     val.inter_val = None;
                     if dt != Type::Error {
                         errs.push(CobaltError::TypeIsConstOnly {
-                            ty: dt.to_string(),
+                            ty: dt.to_string().into(),
                             loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
                         })
                     }
@@ -585,14 +588,14 @@ impl AST for VarDefAST {
                     Err(RedefVariable::NotAModule(x, _)) => {
                         errs.push(CobaltError::NotAModule {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string(),
+                            name: self.name.start(x).to_string().into(),
                         });
                         (Value::error(), errs)
                     }
                     Err(RedefVariable::AlreadyExists(x, d, _)) => {
                         errs.push(CobaltError::RedefVariable {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string(),
+                            name: self.name.start(x).to_string().into(),
                             prev: d,
                         });
                         (Value::error(), errs)
@@ -684,7 +687,7 @@ impl AST for VarDefAST {
                             });
                     if let Some(t) = dt.llvm_type(ctx) {
                         let mangled =
-                            linkas.map_or_else(|| ctx.mangle(&self.name), |(name, _)| name);
+                            linkas.map_or_else(|| ctx.mangle(&self.name).into(), |(name, _)| name);
                         let gv = ctx
                             .lookup_full(&self.name)
                             .and_then(|x| -> Option<GlobalValue> {
@@ -763,7 +766,7 @@ impl AST for VarDefAST {
                             }
                             if dt != Type::Error {
                                 errs.push(CobaltError::TypeIsConstOnly {
-                                    ty: dt.to_string(),
+                                    ty: dt.to_string().into(),
                                     loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
                                 })
                             }
@@ -781,7 +784,7 @@ impl AST for VarDefAST {
                         let old_scope = ctx.push_scope(&self.name);
                         if dt != Type::Error {
                             errs.push(CobaltError::TypeIsConstOnly {
-                                ty: dt.to_string(),
+                                ty: dt.to_string().into(),
                                 loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
                             })
                         }
@@ -828,14 +831,14 @@ impl AST for VarDefAST {
                     Err(RedefVariable::NotAModule(x, _)) => {
                         errs.push(CobaltError::NotAModule {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string(),
+                            name: self.name.start(x).to_string().into(),
                         });
                         (Value::error(), errs)
                     }
                     Err(RedefVariable::AlreadyExists(x, d, _)) => {
                         errs.push(CobaltError::RedefVariable {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string(),
+                            name: self.name.start(x).to_string().into(),
                             prev: d,
                         });
                         (Value::error(), errs)
@@ -925,7 +928,7 @@ impl AST for VarDefAST {
                 let a = val.addr(ctx).unwrap_or_else(|| {
                     let a = ctx
                         .builder
-                        .build_alloca(t, self.name.ids.last().map_or("", |(x, _)| x.as_str()));
+                        .build_alloca(t, self.name.ids.last().map_or("", |(x, _)| &**x));
                     ctx.builder.build_store(a, v);
                     a
                 });
@@ -948,7 +951,7 @@ impl AST for VarDefAST {
             } else {
                 if dt != Type::Error {
                     errs.push(CobaltError::TypeIsConstOnly {
-                        ty: dt.to_string(),
+                        ty: dt.to_string().into(),
                         loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
                     })
                 }
@@ -969,14 +972,14 @@ impl AST for VarDefAST {
                 Err(RedefVariable::NotAModule(x, _)) => {
                     errs.push(CobaltError::NotAModule {
                         loc: self.name.ids[x].1,
-                        name: self.name.start(x).to_string(),
+                        name: self.name.start(x).to_string().into(),
                     });
                     (Value::error(), errs)
                 }
                 Err(RedefVariable::AlreadyExists(x, d, _)) => {
                     errs.push(CobaltError::RedefVariable {
                         loc: self.name.ids[x].1,
-                        name: self.name.start(x).to_string(),
+                        name: self.name.start(x).to_string().into(),
                         prev: d,
                     });
                     (Value::error(), errs)
@@ -1018,21 +1021,21 @@ impl AST for VarDefAST {
     }
 }
 #[derive(Debug, Clone)]
-pub struct ConstDefAST {
+pub struct ConstDefAST<'src> {
     loc: SourceSpan,
-    pub name: DottedName,
-    pub val: Box<dyn AST>,
-    pub type_: Option<Box<dyn AST>>,
-    pub annotations: Vec<(String, Option<String>, SourceSpan)>,
-    lastmissing: CellExt<HashSet<String>>,
+    pub name: DottedName<'src>,
+    pub val: BoxedAST<'src>,
+    pub type_: Option<BoxedAST<'src>>,
+    pub annotations: Vec<(Cow<'src, str>, Option<Cow<'src, str>>, SourceSpan)>,
+    lastmissing: CellExt<HashSet<Cow<'src, str>>>,
 }
-impl ConstDefAST {
+impl<'src> ConstDefAST<'src> {
     pub fn new(
         loc: SourceSpan,
-        name: DottedName,
-        val: Box<dyn AST>,
-        type_: Option<Box<dyn AST>>,
-        annotations: Vec<(String, Option<String>, SourceSpan)>,
+        name: DottedName<'src>,
+        val: BoxedAST<'src>,
+        type_: Option<BoxedAST<'src>>,
+        annotations: Vec<(Cow<'src, str>, Option<Cow<'src, str>>, SourceSpan)>,
     ) -> Self {
         ConstDefAST {
             loc,
@@ -1044,19 +1047,19 @@ impl ConstDefAST {
         }
     }
 }
-impl AST for ConstDefAST {
+impl<'src> AST<'src> for ConstDefAST<'src> {
     fn loc(&self) -> SourceSpan {
         merge_spans(self.loc, self.val.loc())
     }
     fn nodes(&self) -> usize {
         self.val.nodes() + self.type_.as_ref().map_or(0, |x| x.nodes()) + 1
     }
-    fn varfwd_prepass(&self, ctx: &CompCtx) {
+    fn varfwd_prepass(&self, ctx: &CompCtx<'src, '_>) {
         let mut target_match = 2u8;
         for (ann, arg, _) in self.annotations.iter() {
-            if ann.as_str() == "target" {
+            if ann == "target" {
                 if let Some(arg) = arg {
-                    let mut arg = arg.as_str();
+                    let mut arg = &**arg;
                     let negate = if arg.as_bytes().first() == Some(&0x21) {
                         arg = &arg[1..];
                         true
@@ -1086,12 +1089,12 @@ impl AST for ConstDefAST {
             )
         });
     }
-    fn constinit_prepass(&self, ctx: &CompCtx, needs_another: &mut bool) {
+    fn constinit_prepass(&self, ctx: &CompCtx<'src, '_>, needs_another: &mut bool) {
         let mut target_match = 2u8;
         for (ann, arg, _) in self.annotations.iter() {
-            if ann.as_str() == "target" {
+            if ann == "target" {
                 if let Some(arg) = arg {
-                    let mut arg = arg.as_str();
+                    let mut arg = &**arg;
                     let negate = if arg.as_bytes().first() == Some(&0x21) {
                         arg = &arg[1..];
                         true
@@ -1127,16 +1130,19 @@ impl AST for ConstDefAST {
         });
         ctx.prepass.set(pp);
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         let mut errs = vec![];
         let mut vis_spec = None;
         let mut target_match = 2u8;
         for (ann, arg, loc) in self.annotations.iter() {
             let loc = *loc;
-            match ann.as_str() {
+            match &**ann {
                 "target" => {
                     if let Some(arg) = arg {
-                        let mut arg = arg.as_str();
+                        let mut arg = &**arg;
                         let negate = if arg.as_bytes().first() == Some(&0x21) {
                             arg = &arg[1..];
                             true
@@ -1156,7 +1162,7 @@ impl AST for ConstDefAST {
                             }
                             Err(err) => errs.push(CobaltError::GlobPatternError {
                                 pos: err.pos,
-                                msg: err.msg.to_string(),
+                                msg: err.msg.into(),
                                 loc,
                             }),
                         }
@@ -1280,14 +1286,14 @@ impl AST for ConstDefAST {
             Err(RedefVariable::NotAModule(x, _)) => {
                 errs.push(CobaltError::NotAModule {
                     loc: self.name.ids[x].1,
-                    name: self.name.start(x).to_string(),
+                    name: self.name.start(x).to_string().into(),
                 });
                 (Value::error(), errs)
             }
             Err(RedefVariable::AlreadyExists(x, d, _)) => {
                 errs.push(CobaltError::RedefVariable {
                     loc: self.name.ids[x].1,
-                    name: self.name.start(x).to_string(),
+                    name: self.name.start(x).to_string().into(),
                     prev: d,
                 });
                 (Value::error(), errs)
@@ -1323,21 +1329,21 @@ impl AST for ConstDefAST {
     }
 }
 #[derive(Debug, Clone)]
-pub struct TypeDefAST {
+pub struct TypeDefAST<'src> {
     loc: SourceSpan,
-    pub name: DottedName,
-    pub val: Box<dyn AST>,
-    pub annotations: Vec<(String, Option<String>, SourceSpan)>,
-    pub methods: Vec<Box<dyn AST>>,
-    lastmissing: CellExt<HashSet<String>>,
+    pub name: DottedName<'src>,
+    pub val: BoxedAST<'src>,
+    pub annotations: Vec<(Cow<'src, str>, Option<Cow<'src, str>>, SourceSpan)>,
+    pub methods: Vec<BoxedAST<'src>>,
+    lastmissing: CellExt<HashSet<Cow<'src, str>>>,
 }
-impl TypeDefAST {
+impl<'src> TypeDefAST<'src> {
     pub fn new(
         loc: SourceSpan,
-        name: DottedName,
-        val: Box<dyn AST>,
-        annotations: Vec<(String, Option<String>, SourceSpan)>,
-        methods: Vec<Box<dyn AST>>,
+        name: DottedName<'src>,
+        val: BoxedAST<'src>,
+        annotations: Vec<(Cow<'src, str>, Option<Cow<'src, str>>, SourceSpan)>,
+        methods: Vec<BoxedAST<'src>>,
     ) -> Self {
         TypeDefAST {
             loc,
@@ -1349,22 +1355,22 @@ impl TypeDefAST {
         }
     }
 }
-impl AST for TypeDefAST {
+impl<'src> AST<'src> for TypeDefAST<'src> {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
     fn nodes(&self) -> usize {
         self.val.nodes() + self.methods.iter().map(|x| x.nodes()).sum::<usize>() + 1
     }
-    fn varfwd_prepass(&self, ctx: &CompCtx) {
+    fn varfwd_prepass(&self, ctx: &CompCtx<'src, '_>) {
         let mut target_match = 2u8;
         let mut no_auto_drop = false;
         let mut transparent = false;
         for (ann, arg, _) in self.annotations.iter() {
-            match ann.as_str() {
+            match &**ann {
                 "target" => {
                     if let Some(arg) = arg {
-                        let mut arg = arg.as_str();
+                        let mut arg = &**arg;
                         let negate = if arg.as_bytes().first() == Some(&0x21) {
                             arg = &arg[1..];
                             true
@@ -1427,11 +1433,11 @@ impl AST for TypeDefAST {
         std::mem::drop(mb);
         ctx.with_vars(|v| {
             v.symbols.insert(
-                "base_t".to_string(),
+                "base_t".into(),
                 Value::make_type(Type::Null).freeze(self.loc).into(),
             );
             v.symbols.insert(
-                "self_t".to_string(),
+                "self_t".into(),
                 Value::make_type(Type::Nominal(mangled.clone()))
                     .freeze(self.loc)
                     .into(),
@@ -1458,15 +1464,15 @@ impl AST for TypeDefAST {
         noms.get_mut(&mangled).unwrap().3 = ctx.nom_info.borrow_mut().pop().unwrap();
         ctx.prepass.set(pp);
     }
-    fn constinit_prepass(&self, ctx: &CompCtx, needs_another: &mut bool) {
+    fn constinit_prepass(&self, ctx: &CompCtx<'src, '_>, needs_another: &mut bool) {
         let mut target_match = 2u8;
         let mut no_auto_drop = false;
         let mut transparent = false;
         for (ann, arg, _) in self.annotations.iter() {
-            match ann.as_str() {
+            match &**ann {
                 "target" => {
                     if let Some(arg) = arg {
-                        let mut arg = arg.as_str();
+                        let mut arg = &**arg;
                         let negate = if arg.as_bytes().first() == Some(&0x21) {
                             arg = &arg[1..];
                             true
@@ -1533,11 +1539,11 @@ impl AST for TypeDefAST {
         std::mem::drop(mb);
         ctx.with_vars(|v| {
             v.symbols.insert(
-                "base_t".to_string(),
+                "base_t".into(),
                 Value::make_type(Type::Null).freeze(self.loc).into(),
             );
             v.symbols.insert(
-                "self_t".to_string(),
+                "self_t".into(),
                 Value::make_type(Type::Nominal(mangled.clone()))
                     .freeze(self.loc)
                     .into(),
@@ -1566,16 +1572,16 @@ impl AST for TypeDefAST {
         noms.get_mut(&mangled).unwrap().3 = ctx.nom_info.borrow_mut().pop().unwrap();
         ctx.prepass.set(pp);
     }
-    fn fwddef_prepass(&self, ctx: &CompCtx) {
+    fn fwddef_prepass(&self, ctx: &CompCtx<'src, '_>) {
         let mut vis_spec = None;
         let mut target_match = 2u8;
         let mut no_auto_drop = false;
         let mut transparent = false;
         for (ann, arg, _) in self.annotations.iter() {
-            match ann.as_str() {
+            match &**ann {
                 "target" => {
                     if let Some(arg) = arg {
-                        let mut arg = arg.as_str();
+                        let mut arg = &**arg;
                         let negate = if arg.as_bytes().first() == Some(&0x21) {
                             arg = &arg[1..];
                             true
@@ -1658,11 +1664,11 @@ impl AST for TypeDefAST {
         .unwrap_or(Type::Error);
         ctx.with_vars(|v| {
             v.symbols.insert(
-                "base_t".to_string(),
+                "base_t".into(),
                 Value::make_type(ty.clone()).freeze(self.loc).into(),
             );
             v.symbols.insert(
-                "self_t".to_string(),
+                "self_t".into(),
                 Value::make_type(Type::Nominal(mangled.clone()))
                     .freeze(self.loc)
                     .into(),
@@ -1685,7 +1691,10 @@ impl AST for TypeDefAST {
         });
         noms.get_mut(&mangled).unwrap().3 = ctx.nom_info.borrow_mut().pop().unwrap();
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         let mut errs = vec![];
         let mut vis_spec = None;
         let mut target_match = 2u8;
@@ -1693,10 +1702,10 @@ impl AST for TypeDefAST {
         let mut transparent = None;
         for (ann, arg, loc) in self.annotations.iter() {
             let loc = *loc;
-            match ann.as_str() {
+            match &**ann {
                 "target" => {
                     if let Some(arg) = arg {
-                        let mut arg = arg.as_str();
+                        let mut arg = &**arg;
                         let negate = if arg.as_bytes().first() == Some(&0x21) {
                             arg = &arg[1..];
                             true
@@ -1716,7 +1725,7 @@ impl AST for TypeDefAST {
                             }
                             Err(err) => errs.push(CobaltError::GlobPatternError {
                                 pos: err.pos,
-                                msg: err.msg.to_string(),
+                                msg: err.msg.into(),
                                 loc,
                             }),
                         }
@@ -1870,11 +1879,11 @@ impl AST for TypeDefAST {
         std::mem::drop(mb);
         ctx.with_vars(|v| {
             v.symbols.insert(
-                "base_t".to_string(),
+                "base_t".into(),
                 Value::make_type(ty.clone()).freeze(self.loc).into(),
             );
             v.symbols.insert(
-                "self_t".to_string(),
+                "self_t".into(),
                 Value::make_type(Type::Nominal(mangled.clone()))
                     .freeze(self.loc)
                     .into(),
@@ -1920,7 +1929,7 @@ impl AST for TypeDefAST {
                 noms.remove(&mangled);
                 errs.push(CobaltError::NotAModule {
                     loc: self.name.ids[x].1,
-                    name: self.name.start(x).to_string(),
+                    name: self.name.start(x).to_string().into(),
                 });
                 (Value::error(), errs)
             }
@@ -1928,7 +1937,7 @@ impl AST for TypeDefAST {
                 noms.remove(&mangled);
                 errs.push(CobaltError::RedefVariable {
                     loc: self.name.ids[x].1,
-                    name: self.name.start(x).to_string(),
+                    name: self.name.start(x).to_string().into(),
                     prev: d,
                 });
                 (Value::error(), errs)
@@ -1972,21 +1981,24 @@ impl AST for TypeDefAST {
     }
 }
 #[derive(Debug, Clone)]
-pub struct VarGetAST {
+pub struct VarGetAST<'src> {
     loc: SourceSpan,
-    pub name: String,
+    pub name: Cow<'src, str>,
     pub global: bool,
 }
-impl VarGetAST {
-    pub fn new(loc: SourceSpan, name: String, global: bool) -> Self {
+impl<'src> VarGetAST<'src> {
+    pub fn new(loc: SourceSpan, name: Cow<'src, str>, global: bool) -> Self {
         VarGetAST { loc, name, global }
     }
 }
-impl AST for VarGetAST {
+impl<'src> AST<'src> for VarGetAST<'src> {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
-    fn codegen<'ctx>(&self, ctx: &CompCtx<'ctx>) -> (Value<'ctx>, Vec<CobaltError>) {
+    fn codegen<'ctx>(
+        &self,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         match ctx.lookup(&self.name, self.global) {
             Some(Symbol(x, d)) if d.scope.map_or(true, |x| x.get() == ctx.var_scope.get()) => (
                 x.clone(),
@@ -2003,7 +2015,7 @@ impl AST for VarGetAST {
                 Value::error(),
                 vec![CobaltError::VariableDoesNotExist {
                     name: self.name.clone(),
-                    module: String::new(),
+                    module: Default::default(),
                     container: "",
                     loc: self.loc,
                 }],

--- a/cobalt-ast/src/ast/vars.rs
+++ b/cobalt-ast/src/ast/vars.rs
@@ -325,7 +325,7 @@ impl<'src> AST<'src> for VarDefAST<'src> {
                             }
                             Err(err) => errs.push(CobaltError::GlobPatternError {
                                 pos: err.pos,
-                                msg: err.msg.into(),
+                                msg: err.msg,
                                 loc,
                             }),
                         }
@@ -468,7 +468,7 @@ impl<'src> AST<'src> for VarDefAST<'src> {
                                     .or_else(|| {
                                         if dt != Type::Error {
                                             errs.push(CobaltError::TypeIsConstOnly {
-                                                ty: dt.to_string().into(),
+                                                ty: dt.to_string(),
                                                 loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
                                             })
                                         };
@@ -485,14 +485,14 @@ impl<'src> AST<'src> for VarDefAST<'src> {
                     Err(RedefVariable::NotAModule(x, _)) => {
                         errs.push(CobaltError::NotAModule {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string().into(),
+                            name: self.name.start(x).to_string(),
                         });
                         (Value::error(), errs)
                     }
                     Err(RedefVariable::AlreadyExists(x, d, _)) => {
                         errs.push(CobaltError::RedefVariable {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string().into(),
+                            name: self.name.start(x).to_string(),
                             prev: d,
                         });
                         (Value::error(), errs)
@@ -573,7 +573,7 @@ impl<'src> AST<'src> for VarDefAST<'src> {
                     val.inter_val = None;
                     if dt != Type::Error {
                         errs.push(CobaltError::TypeIsConstOnly {
-                            ty: dt.to_string().into(),
+                            ty: dt.to_string(),
                             loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
                         })
                     }
@@ -588,14 +588,14 @@ impl<'src> AST<'src> for VarDefAST<'src> {
                     Err(RedefVariable::NotAModule(x, _)) => {
                         errs.push(CobaltError::NotAModule {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string().into(),
+                            name: self.name.start(x).to_string(),
                         });
                         (Value::error(), errs)
                     }
                     Err(RedefVariable::AlreadyExists(x, d, _)) => {
                         errs.push(CobaltError::RedefVariable {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string().into(),
+                            name: self.name.start(x).to_string(),
                             prev: d,
                         });
                         (Value::error(), errs)
@@ -766,7 +766,7 @@ impl<'src> AST<'src> for VarDefAST<'src> {
                             }
                             if dt != Type::Error {
                                 errs.push(CobaltError::TypeIsConstOnly {
-                                    ty: dt.to_string().into(),
+                                    ty: dt.to_string(),
                                     loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
                                 })
                             }
@@ -784,7 +784,7 @@ impl<'src> AST<'src> for VarDefAST<'src> {
                         let old_scope = ctx.push_scope(&self.name);
                         if dt != Type::Error {
                             errs.push(CobaltError::TypeIsConstOnly {
-                                ty: dt.to_string().into(),
+                                ty: dt.to_string(),
                                 loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
                             })
                         }
@@ -831,14 +831,14 @@ impl<'src> AST<'src> for VarDefAST<'src> {
                     Err(RedefVariable::NotAModule(x, _)) => {
                         errs.push(CobaltError::NotAModule {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string().into(),
+                            name: self.name.start(x).to_string(),
                         });
                         (Value::error(), errs)
                     }
                     Err(RedefVariable::AlreadyExists(x, d, _)) => {
                         errs.push(CobaltError::RedefVariable {
                             loc: self.name.ids[x].1,
-                            name: self.name.start(x).to_string().into(),
+                            name: self.name.start(x).to_string(),
                             prev: d,
                         });
                         (Value::error(), errs)
@@ -951,7 +951,7 @@ impl<'src> AST<'src> for VarDefAST<'src> {
             } else {
                 if dt != Type::Error {
                     errs.push(CobaltError::TypeIsConstOnly {
-                        ty: dt.to_string().into(),
+                        ty: dt.to_string(),
                         loc: self.type_.as_ref().unwrap_or(&self.val).loc(),
                     })
                 }
@@ -972,14 +972,14 @@ impl<'src> AST<'src> for VarDefAST<'src> {
                 Err(RedefVariable::NotAModule(x, _)) => {
                     errs.push(CobaltError::NotAModule {
                         loc: self.name.ids[x].1,
-                        name: self.name.start(x).to_string().into(),
+                        name: self.name.start(x).to_string(),
                     });
                     (Value::error(), errs)
                 }
                 Err(RedefVariable::AlreadyExists(x, d, _)) => {
                     errs.push(CobaltError::RedefVariable {
                         loc: self.name.ids[x].1,
-                        name: self.name.start(x).to_string().into(),
+                        name: self.name.start(x).to_string(),
                         prev: d,
                     });
                     (Value::error(), errs)
@@ -1162,7 +1162,7 @@ impl<'src> AST<'src> for ConstDefAST<'src> {
                             }
                             Err(err) => errs.push(CobaltError::GlobPatternError {
                                 pos: err.pos,
-                                msg: err.msg.into(),
+                                msg: err.msg,
                                 loc,
                             }),
                         }
@@ -1286,14 +1286,14 @@ impl<'src> AST<'src> for ConstDefAST<'src> {
             Err(RedefVariable::NotAModule(x, _)) => {
                 errs.push(CobaltError::NotAModule {
                     loc: self.name.ids[x].1,
-                    name: self.name.start(x).to_string().into(),
+                    name: self.name.start(x).to_string(),
                 });
                 (Value::error(), errs)
             }
             Err(RedefVariable::AlreadyExists(x, d, _)) => {
                 errs.push(CobaltError::RedefVariable {
                     loc: self.name.ids[x].1,
-                    name: self.name.start(x).to_string().into(),
+                    name: self.name.start(x).to_string(),
                     prev: d,
                 });
                 (Value::error(), errs)
@@ -1725,7 +1725,7 @@ impl<'src> AST<'src> for TypeDefAST<'src> {
                             }
                             Err(err) => errs.push(CobaltError::GlobPatternError {
                                 pos: err.pos,
-                                msg: err.msg.into(),
+                                msg: err.msg,
                                 loc,
                             }),
                         }
@@ -1929,7 +1929,7 @@ impl<'src> AST<'src> for TypeDefAST<'src> {
                 noms.remove(&mangled);
                 errs.push(CobaltError::NotAModule {
                     loc: self.name.ids[x].1,
-                    name: self.name.start(x).to_string().into(),
+                    name: self.name.start(x).to_string(),
                 });
                 (Value::error(), errs)
             }
@@ -1937,7 +1937,7 @@ impl<'src> AST<'src> for TypeDefAST<'src> {
                 noms.remove(&mangled);
                 errs.push(CobaltError::RedefVariable {
                     loc: self.name.ids[x].1,
-                    name: self.name.start(x).to_string().into(),
+                    name: self.name.start(x).to_string(),
                     prev: d,
                 });
                 (Value::error(), errs)

--- a/cobalt-ast/src/cfg.rs
+++ b/cobalt-ast/src/cfg.rs
@@ -21,7 +21,7 @@ impl<'ctx> Location<'ctx> {
             Self::Inst(i, _) | Self::AfterInst(i) => i.get_parent().unwrap(),
         }
     }
-    pub fn current(ctx: &CompCtx<'ctx>) -> Option<Self> {
+    pub fn current(ctx: &CompCtx<'_, 'ctx>) -> Option<Self> {
         let b = ctx.builder.get_insert_block()?;
         Some(
             b.get_last_instruction()
@@ -111,71 +111,71 @@ enum Terminator<'ctx> {
     CBrLazy(BasicValueEnum<'ctx>, BasicBlock<'ctx>, BasicBlock<'ctx>),
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Use<'ctx> {
+pub struct Use<'src, 'ctx> {
     pub inst: Location<'ctx>,
     pub loc: SourceSpan,
-    pub name: (String, usize),
+    pub name: (Cow<'src, str>, usize),
     pub is_move: bool,
     /// whether this is tracked or just for debugging
     pub real: bool,
 }
 /// compare the order in which moves (or their underlying instructions) occur.
-impl PartialOrd for Use<'_> {
+impl PartialOrd for Use<'_, '_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.inst.partial_cmp(&other.inst)
     }
 }
-impl<'ctx> PartialEq<InstructionValue<'ctx>> for Use<'ctx> {
+impl<'ctx> PartialEq<InstructionValue<'ctx>> for Use<'_, 'ctx> {
     fn eq(&self, other: &InstructionValue<'ctx>) -> bool {
         self.inst == *other
     }
 }
 /// compare the order in which moves (or their underlying instructions) occur.
-impl<'ctx> PartialOrd<InstructionValue<'ctx>> for Use<'ctx> {
+impl<'ctx> PartialOrd<InstructionValue<'ctx>> for Use<'_, 'ctx> {
     fn partial_cmp(&self, other: &InstructionValue<'ctx>) -> Option<std::cmp::Ordering> {
         self.inst.partial_cmp(other)
     }
 }
-impl<'ctx> PartialOrd<Store<'ctx>> for Use<'ctx> {
-    fn partial_cmp(&self, other: &Store<'ctx>) -> Option<Ordering> {
+impl<'ctx> PartialOrd<Store<'_, 'ctx>> for Use<'_, 'ctx> {
+    fn partial_cmp(&self, other: &Store<'_, 'ctx>) -> Option<Ordering> {
         self.inst.partial_cmp(&other.inst)
     }
 }
-impl<'ctx> PartialEq<Store<'ctx>> for Use<'ctx> {
-    fn eq(&self, _other: &Store<'ctx>) -> bool {
+impl<'ctx> PartialEq<Store<'_, 'ctx>> for Use<'_, 'ctx> {
+    fn eq(&self, _other: &Store<'_, 'ctx>) -> bool {
         false
     }
 }
-impl Hash for Use<'_> {
+impl Hash for Use<'_, '_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.inst.hash(state);
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Store<'ctx> {
+pub struct Store<'src, 'ctx> {
     pub inst: Location<'ctx>,
-    pub name: (String, usize),
+    pub name: (Cow<'src, str>, usize),
     pub real: bool,
 }
 /// compare the order in which moves (or their underlying instructions) occur.
-impl PartialOrd for Store<'_> {
+impl PartialOrd for Store<'_, '_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.inst.partial_cmp(&other.inst)
     }
 }
-impl<'ctx> PartialEq<InstructionValue<'ctx>> for Store<'ctx> {
+impl<'ctx> PartialEq<InstructionValue<'ctx>> for Store<'_, 'ctx> {
     fn eq(&self, other: &InstructionValue<'ctx>) -> bool {
         self.inst == *other
     }
 }
 /// compare the order in which moves (or their underlying instructions) occur.
-impl<'ctx> PartialOrd<InstructionValue<'ctx>> for Store<'ctx> {
+impl<'ctx> PartialOrd<InstructionValue<'ctx>> for Store<'_, 'ctx> {
     fn partial_cmp(&self, other: &InstructionValue<'ctx>) -> Option<Ordering> {
         self.inst.partial_cmp(other)
     }
 }
-impl<'ctx> PartialOrd<Use<'ctx>> for Store<'ctx> {
-    fn partial_cmp(&self, other: &Use<'ctx>) -> Option<Ordering> {
+impl<'ctx> PartialOrd<Use<'_, 'ctx>> for Store<'_, 'ctx> {
+    fn partial_cmp(&self, other: &Use<'_, 'ctx>) -> Option<Ordering> {
         use Ordering::*;
         other.partial_cmp(self).map(|v| match v {
             Less => Greater,
@@ -184,12 +184,12 @@ impl<'ctx> PartialOrd<Use<'ctx>> for Store<'ctx> {
         })
     }
 }
-impl<'ctx> PartialEq<Use<'ctx>> for Store<'ctx> {
-    fn eq(&self, _other: &Use<'ctx>) -> bool {
+impl<'ctx> PartialEq<Use<'_, 'ctx>> for Store<'_, 'ctx> {
+    fn eq(&self, _other: &Use<'_, 'ctx>) -> bool {
         false
     }
 }
-impl Hash for Store<'_> {
+impl Hash for Store<'_, '_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.inst.hash(state);
     }
@@ -199,10 +199,10 @@ fn cmp_ops(l: &Either<*const Use, *const Store>, r: &Either<*const Use, *const S
         .unwrap_or(Ordering::Equal)
 }
 /// structure of a block
-struct Block<'a, 'ctx> {
+struct Block<'a, 'src, 'ctx> {
     block: BasicBlock<'ctx>,
     // these pointers are safe because they're borrowed from a container in a RefCell, which cannot be mutated because of the Ref
-    moves: Vec<Either<*const Use<'ctx>, *const Store<'ctx>>>,
+    moves: Vec<Either<*const Use<'src, 'ctx>, *const Store<'src, 'ctx>>>,
     term: Terminator<'ctx>,
     // these are used to prevent extra allocations
     input: Cell<bool>,
@@ -211,7 +211,7 @@ struct Block<'a, 'ctx> {
     // marker to for safety
     _ref: Ref<'a, ()>,
 }
-impl std::fmt::Debug for Block<'_, '_> {
+impl std::fmt::Debug for Block<'_, '_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         unsafe {
             f.debug_struct("Block")
@@ -236,13 +236,13 @@ impl std::fmt::Debug for Block<'_, '_> {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DoubleMove {
-    pub name: String,
+pub struct DoubleMove<'src> {
+    pub name: Cow<'src, str>,
     pub loc: SourceSpan,
     pub prev: Option<SourceSpan>,
     pub guaranteed: bool,
 }
-impl PartialOrd for DoubleMove {
+impl PartialOrd for DoubleMove<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         if self.loc.offset() == other.loc.offset() {
             if self.loc.len() == other.loc.len() {
@@ -261,7 +261,7 @@ impl PartialOrd for DoubleMove {
         }
     }
 }
-impl Ord for DoubleMove {
+impl Ord for DoubleMove<'_> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         if self.loc.offset() == other.loc.offset() {
             if self.loc.len() == other.loc.len() {
@@ -282,15 +282,15 @@ impl Ord for DoubleMove {
 }
 /// control flow graph
 #[derive(Debug)]
-pub struct Cfg<'a, 'ctx: 'a> {
-    blocks: Vec<Block<'a, 'ctx>>,
+pub struct Cfg<'a, 'src, 'ctx: 'a> {
+    blocks: Vec<Block<'a, 'src, 'ctx>>,
     last: Location<'ctx>,
     preds: Vec<HashSet<usize>>,
 }
-impl<'a, 'ctx> Cfg<'a, 'ctx> {
+impl<'a, 'src, 'ctx> Cfg<'a, 'src, 'ctx> {
     /// create a CFG tracking the moves between `start` and `end`
     /// `start` and `end` are inclusive
-    pub fn new(start: Location<'ctx>, end: Location<'ctx>, ctx: &'a CompCtx<'ctx>) -> Self {
+    pub fn new(start: Location<'ctx>, end: Location<'ctx>, ctx: &'a CompCtx<'src, 'ctx>) -> Self {
         let start_block = start.block();
         let end_block = end.block();
         let false_ = ctx.context.bool_type().const_zero();
@@ -607,7 +607,7 @@ impl<'a, 'ctx> Cfg<'a, 'ctx> {
         }
     }
     /// Search CFG for double moves
-    pub fn validate(&self) -> Vec<DoubleMove> {
+    pub fn validate(&self) -> Vec<DoubleMove<'src>> {
         let mut errs = vec![];
         unsafe {
             let vars = self
@@ -714,7 +714,7 @@ impl<'a, 'ctx> Cfg<'a, 'ctx> {
         name: &str,
         lex_scope: Option<usize>,
         inst: Option<Location<'ctx>>,
-        ctx: &CompCtx<'ctx>,
+        ctx: &CompCtx<'src, 'ctx>,
     ) -> IntValue<'ctx> {
         let inst = inst.unwrap_or(self.last);
         let mut blk = None;
@@ -792,7 +792,7 @@ impl<'a, 'ctx> Cfg<'a, 'ctx> {
     }
     /// Insert destructor calls before stores if necessary.
     /// If `at_end` is true, insert the destructors for all values in the top VarMap layer as well
-    pub fn insert_dtors(&self, ctx: &CompCtx<'ctx>, at_end: bool) {
+    pub fn insert_dtors(&self, ctx: &CompCtx<'src, 'ctx>, at_end: bool) {
         let f = ctx
             .builder
             .get_insert_block()

--- a/cobalt-ast/src/lib.rs
+++ b/cobalt-ast/src/lib.rs
@@ -8,13 +8,14 @@ pub mod types;
 pub mod value;
 pub mod varmap;
 
-pub use ast::AST;
 use ast::{print_ast_child, TreePrefix};
+pub use ast::{BoxedAST, DynAST, AST};
 use cobalt_errors::*;
 use cobalt_llvm::*;
 use cobalt_utils::*;
 pub use context::*;
 pub use dottedname::*;
+use std::borrow::Cow;
 pub use types::*;
 pub use value::*;
 pub use varmap::*;

--- a/cobalt-ast/src/ops.rs
+++ b/cobalt-ast/src/ops.rs
@@ -159,8 +159,8 @@ pub fn bin_op<'src, 'ctx>(
     right_move: bool,
 ) -> Result<Value<'src, 'ctx>, CobaltError<'src>> {
     let err = CobaltError::BinOpNotDefined {
-        lhs: lhs.data_type.to_string().into(),
-        rhs: rhs.data_type.to_string().into(),
+        lhs: lhs.data_type.to_string(),
+        rhs: rhs.data_type.to_string(),
         op,
         lloc,
         rloc,
@@ -943,7 +943,7 @@ pub fn bin_op<'src, 'ctx>(
                         } else {
                             Err(CobaltError::CantMoveFromReference {
                                 loc: lloc,
-                                ty: lhs.data_type.to_string().into(),
+                                ty: lhs.data_type.to_string(),
                             })
                         }
                     }
@@ -968,7 +968,7 @@ pub fn bin_op<'src, 'ctx>(
             } else {
                 Err(CobaltError::CantMoveFromReference {
                     loc: rloc,
-                    ty: rhs.data_type.to_string().into(),
+                    ty: rhs.data_type.to_string(),
                 })
             }
         }
@@ -1985,9 +1985,9 @@ pub fn bin_op<'src, 'ctx>(
         if non_mut {
             CobaltError::CantMutateImmut {
                 vloc: lloc,
-                ty: tyname.into(),
+                ty: tyname,
                 oloc: Some(loc),
-                op: op.to_string().into(),
+                op,
                 floc: lf.unwrap(),
             }
         } else {
@@ -1998,13 +1998,13 @@ pub fn bin_op<'src, 'ctx>(
 pub fn pre_op<'src, 'ctx>(
     loc: SourceSpan,
     (mut val, vloc): (Value<'src, 'ctx>, SourceSpan),
-    op: &str,
+    op: &'static str,
     ctx: &CompCtx<'src, 'ctx>,
     can_move: bool,
 ) -> Result<Value<'src, 'ctx>, CobaltError<'src>> {
     let err = CobaltError::PreOpNotDefined {
-        val: val.data_type.to_string().into(),
-        op: op.to_string().into(),
+        val: val.data_type.to_string(),
+        op,
         vloc,
         oloc: loc,
     };
@@ -2173,7 +2173,7 @@ pub fn pre_op<'src, 'ctx>(
                 } else {
                     Err(CobaltError::CantMoveFromReference {
                         loc,
-                        ty: val.data_type.to_string().into(),
+                        ty: val.data_type.to_string(),
                     })
                 }
             }
@@ -2355,9 +2355,9 @@ pub fn pre_op<'src, 'ctx>(
         if non_mut {
             CobaltError::CantMutateImmut {
                 vloc,
-                ty: tyname.into(),
+                ty: tyname,
                 oloc: Some(loc),
-                op: op.to_string().into(),
+                op,
                 floc: vf.unwrap(),
             }
         } else {
@@ -2368,14 +2368,14 @@ pub fn pre_op<'src, 'ctx>(
 pub fn post_op<'src, 'ctx>(
     loc: SourceSpan,
     (val, vloc): (Value<'src, 'ctx>, SourceSpan),
-    op: &str,
+    op: &'static str,
     ctx: &CompCtx<'src, 'ctx>,
     can_move: bool,
 ) -> Result<Value<'src, 'ctx>, CobaltError<'src>> {
     #![allow(clippy::redundant_clone, clippy::only_used_in_recursion)]
     let err = CobaltError::PostOpNotDefined {
-        val: val.data_type.to_string().into(),
-        op: op.to_string().into(),
+        val: val.data_type.to_string(),
+        op,
         vloc,
         oloc: loc,
     };
@@ -2398,9 +2398,9 @@ pub fn post_op<'src, 'ctx>(
         if non_mut {
             CobaltError::CantMutateImmut {
                 vloc,
-                ty: tyname.into(),
+                ty: tyname,
                 oloc: Some(loc),
-                op: op.to_string().into(),
+                op,
                 floc: vf.unwrap(),
             }
         } else {
@@ -2414,8 +2414,8 @@ pub fn subscript<'src, 'ctx>(
     ctx: &CompCtx<'src, 'ctx>,
 ) -> Result<Value<'src, 'ctx>, CobaltError<'src>> {
     let err = CobaltError::SubscriptNotDefined {
-        val: val.data_type.to_string().into(),
-        sub: idx.data_type.to_string().into(),
+        val: val.data_type.to_string(),
+        sub: idx.data_type.to_string(),
         vloc,
         sloc: iloc,
     };
@@ -3389,8 +3389,8 @@ pub fn impl_convert<'src, 'ctx>(
 ) -> Result<Value<'src, 'ctx>, CobaltError<'src>> {
     let err = CobaltError::InvalidConversion {
         is_expl: false,
-        val: val.data_type.to_string().into(),
-        ty: target.to_string().into(),
+        val: val.data_type.to_string(),
+        ty: target.to_string(),
         vloc,
         tloc,
         oloc: loc,
@@ -3426,9 +3426,9 @@ pub fn impl_convert<'src, 'ctx>(
                 return if let Some(floc) = val.frozen {
                     Err(CobaltError::CantMutateImmut {
                         vloc: vloc.unwrap_or(loc),
-                        ty: val.data_type.to_string().into(),
+                        ty: val.data_type.to_string(),
                         oloc: None,
-                        op: "".to_string().into(),
+                        op: "",
                         floc,
                     })
                 } else {
@@ -3545,7 +3545,7 @@ pub fn impl_convert<'src, 'ctx>(
                         if b.has_dtor(ctx) {
                             Err(CobaltError::CantMoveFromReference {
                                 loc,
-                                ty: val.data_type.to_string().into(),
+                                ty: val.data_type.to_string(),
                             })
                         } else {
                             if !(ctx.is_const.get() && matches!(b, Type::Mut(_))) {
@@ -3616,7 +3616,7 @@ pub fn impl_convert<'src, 'ctx>(
                     if b.has_dtor(ctx) {
                         Err(CobaltError::CantMoveFromReference {
                             loc,
-                            ty: val.data_type.to_string().into(),
+                            ty: val.data_type.to_string(),
                         })
                     } else {
                         if !(ctx.is_const.get() && matches!(b, Type::Mut(_))) {
@@ -3909,8 +3909,8 @@ pub fn expl_convert<'src, 'ctx>(
 ) -> Result<Value<'src, 'ctx>, CobaltError<'src>> {
     let err = CobaltError::InvalidConversion {
         is_expl: true,
-        val: val.data_type.to_string().into(),
-        ty: target.to_string().into(),
+        val: val.data_type.to_string(),
+        ty: target.to_string(),
         vloc,
         tloc,
         oloc: loc,
@@ -3946,9 +3946,9 @@ pub fn expl_convert<'src, 'ctx>(
                 return if let Some(floc) = val.frozen {
                     Err(CobaltError::CantMutateImmut {
                         vloc: vloc.unwrap_or(loc),
-                        ty: val.data_type.to_string().into(),
+                        ty: val.data_type.to_string(),
                         oloc: None,
-                        op: "".to_string().into(),
+                        op: "",
                         floc,
                     })
                 } else {
@@ -4065,7 +4065,7 @@ pub fn expl_convert<'src, 'ctx>(
                         if b.has_dtor(ctx) {
                             Err(CobaltError::CantMoveFromReference {
                                 loc,
-                                ty: b.to_string().into(),
+                                ty: b.to_string(),
                             })
                         } else {
                             if !(ctx.is_const.get() && matches!(b, Type::Mut(_))) {
@@ -4136,7 +4136,7 @@ pub fn expl_convert<'src, 'ctx>(
                     if b.has_dtor(ctx) {
                         Err(CobaltError::CantMoveFromReference {
                             loc,
-                            ty: b.to_string().into(),
+                            ty: b.to_string(),
                         })
                     } else {
                         if !(ctx.is_const.get() && matches!(b, Type::Mut(_))) {
@@ -4595,7 +4595,7 @@ pub fn attr<'src, 'ctx>(
     ctx: &CompCtx<'src, 'ctx>,
 ) -> Result<Value<'src, 'ctx>, CobaltError<'src>> {
     let err = CobaltError::AttrNotDefined {
-        val: val.data_type.to_string().into(),
+        val: val.data_type.to_string(),
         attr: id.to_string().into(),
         vloc,
         aloc: iloc,
@@ -5169,12 +5169,11 @@ pub fn call<'src, 'ctx>(
                         val: format!(
                             "&({})",
                             v.iter().map(Type::to_string).collect::<Vec<_>>().join(", ")
-                        )
-                        .into(),
+                        ),
                         loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
                         args: args
                             .iter()
-                            .map(|(v, _)| v.data_type.to_string().into())
+                            .map(|(v, _)| v.data_type.to_string())
                             .collect(),
                         aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
                         nargs: vec![],
@@ -5241,12 +5240,11 @@ pub fn call<'src, 'ctx>(
                     val: format!(
                         "&({})",
                         v.iter().map(Type::to_string).collect::<Vec<_>>().join(", ")
-                    )
-                    .into(),
+                    ),
                     loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
                     args: args
                         .iter()
-                        .map(|(v, _)| v.data_type.to_string().into())
+                        .map(|(v, _)| v.data_type.to_string())
                         .collect(),
                     aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
                     nargs: vec![],
@@ -5321,12 +5319,11 @@ pub fn call<'src, 'ctx>(
                         .map(|(t, _)| t.to_string())
                         .collect::<Vec<_>>()
                         .join(", ")
-                )
-                .into(),
+                ),
                 loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
                 args: args
                     .iter()
-                    .map(|(v, _)| v.data_type.to_string().into())
+                    .map(|(v, _)| v.data_type.to_string())
                     .collect(),
                 aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
                 nargs: vec![],
@@ -5519,12 +5516,11 @@ pub fn call<'src, 'ctx>(
                 val: format!(
                     "({})",
                     v.iter().map(Type::to_string).collect::<Vec<_>>().join(", ")
-                )
-                .into(),
+                ),
                 loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
                 args: args
                     .iter()
-                    .map(|(v, _)| v.data_type.to_string().into())
+                    .map(|(v, _)| v.data_type.to_string())
                     .collect(),
                 aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
                 nargs: vec![],
@@ -5641,20 +5637,20 @@ pub fn call<'src, 'ctx>(
                                 }
                                 (a0, a1) => Err(CobaltError::InvalidInlineAsm2 {
                                     loc1: loc0,
-                                    type1: a0.data_type.to_string().into(),
+                                    type1: a0.data_type.to_string(),
                                     const1: a0.inter_val.is_some(),
                                     loc2: loc1,
-                                    type2: a1.data_type.to_string().into(),
+                                    type2: a1.data_type.to_string(),
                                     const2: a1.inter_val.is_some(),
                                 }),
                             }
                         } else {
                             Err(CobaltError::InvalidInlineAsm2 {
                                 loc1: loc0,
-                                type1: a0.data_type.to_string().into(),
+                                type1: a0.data_type.to_string(),
                                 const1: a0.inter_val.is_some(),
                                 loc2: loc1,
-                                type2: a1.data_type.to_string().into(),
+                                type2: a1.data_type.to_string(),
                                 const2: a1.inter_val.is_some(),
                             })
                         }
@@ -5735,10 +5731,10 @@ pub fn call<'src, 'ctx>(
                                         type1: "type".into(),
                                         const1: true,
                                         loc2: loc1,
-                                        type2: a1.data_type.to_string().into(),
+                                        type2: a1.data_type.to_string(),
                                         const2: a1.inter_val.is_some(),
                                         loc3: loc2,
-                                        type3: a2.data_type.to_string().into(),
+                                        type3: a2.data_type.to_string(),
                                         const3: a2.inter_val.is_some(),
                                     }),
                                 }
@@ -5748,23 +5744,23 @@ pub fn call<'src, 'ctx>(
                                     type1: "type".into(),
                                     const1: true,
                                     loc2: loc1,
-                                    type2: a1.data_type.to_string().into(),
+                                    type2: a1.data_type.to_string(),
                                     const2: a1.inter_val.is_some(),
                                     loc3: loc2,
-                                    type3: a2.data_type.to_string().into(),
+                                    type3: a2.data_type.to_string(),
                                     const3: a2.inter_val.is_some(),
                                 })
                             }
                         } else {
                             Err(CobaltError::InvalidInlineAsm3 {
                                 loc1: loc0,
-                                type1: a0.data_type.to_string().into(),
+                                type1: a0.data_type.to_string(),
                                 const1: a0.inter_val.is_some(),
                                 loc2: loc1,
-                                type2: a1.data_type.to_string().into(),
+                                type2: a1.data_type.to_string(),
                                 const2: a1.inter_val.is_some(),
                                 loc3: loc2,
-                                type3: a2.data_type.to_string().into(),
+                                type3: a2.data_type.to_string(),
                                 const3: a2.inter_val.is_some(),
                             })
                         }
@@ -5790,7 +5786,7 @@ pub fn call<'src, 'ctx>(
                             ))
                         } else {
                             Err(CobaltError::NonRuntimeAllocaType {
-                                ty: ty.to_string().into(),
+                                ty: ty.to_string(),
                                 loc: loc0,
                             })
                         }
@@ -5830,7 +5826,7 @@ pub fn call<'src, 'ctx>(
                                 }
                                 x => {
                                     errs.push(CobaltError::NonIntegralAllocaArg {
-                                        ty: x.to_string().into(),
+                                        ty: x.to_string(),
                                         loc,
                                     });
                                     break;
@@ -5853,7 +5849,7 @@ pub fn call<'src, 'ctx>(
                             ))
                         } else {
                             errs.push(CobaltError::NonRuntimeAllocaType {
-                                ty: ty.to_string().into(),
+                                ty: ty.to_string(),
                                 loc: loc0,
                             });
                             Err(CobaltError::InvalidIntrinsicCall {
@@ -5889,7 +5885,7 @@ pub fn call<'src, 'ctx>(
                                     .ok_or_else(|| CobaltError::ExpectedType {
                                         loc,
                                         aloc,
-                                        ty: v.data_type.to_string().into(),
+                                        ty: v.data_type.to_string(),
                                     })
                             })
                             .collect::<Result<_, _>>()?,
@@ -5910,7 +5906,7 @@ pub fn call<'src, 'ctx>(
                         .ok_or_else(|| CobaltError::ExpectedType {
                             loc,
                             aloc: args[0].1,
-                            ty: args[0].0.data_type.to_string().into(),
+                            ty: args[0].0.data_type.to_string(),
                         })?
                         .to_string(),
                     _ => Type::Tuple(
@@ -5921,7 +5917,7 @@ pub fn call<'src, 'ctx>(
                                     .ok_or_else(|| CobaltError::ExpectedType {
                                         loc,
                                         aloc,
-                                        ty: v.data_type.to_string().into(),
+                                        ty: v.data_type.to_string(),
                                     })
                             })
                             .collect::<Result<_, _>>()?,
@@ -5953,11 +5949,11 @@ pub fn call<'src, 'ctx>(
             }),
         },
         t => Err(CobaltError::CannotCallWithArgs {
-            val: t.to_string().into(),
+            val: t.to_string(),
             loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
             args: args
                 .iter()
-                .map(|(v, _)| v.data_type.to_string().into())
+                .map(|(v, _)| v.data_type.to_string())
                 .collect(),
             aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
             nargs: vec![],

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -279,7 +279,7 @@ impl Type {
             Nominal(n) => ctx.nominals.borrow()[n].0.align(ctx),
         }
     }
-    pub fn llvm_type<'ctx>(&self, ctx: &CompCtx<'ctx>) -> Option<BasicTypeEnum<'ctx>> {
+    pub fn llvm_type<'ctx>(&self, ctx: &CompCtx<'_, 'ctx>) -> Option<BasicTypeEnum<'ctx>> {
         match self {
             IntLiteral => Some(IntType(ctx.context.i64_type())),
             Int(size, _) => Some(IntType(ctx.context.custom_width_int_type(*size as u32))),
@@ -371,7 +371,7 @@ impl Type {
             _ => false,
         }
     }
-    fn can_be_compiled<'ctx>(&self, v: &InterData<'ctx>, ctx: &CompCtx<'ctx>) -> bool {
+    fn can_be_compiled<'ctx>(&self, v: &InterData<'_, 'ctx>, ctx: &CompCtx<'_, 'ctx>) -> bool {
         match self {
             Type::IntLiteral | Type::Int(..) => matches!(v, InterData::Int(..)),
             Type::Float16 | Type::Float32 | Type::Float64 | Type::Float128 => {
@@ -399,8 +399,8 @@ impl Type {
     }
     pub fn into_compiled<'ctx>(
         &self,
-        v: &InterData<'ctx>,
-        ctx: &CompCtx<'ctx>,
+        v: &InterData<'_, 'ctx>,
+        ctx: &CompCtx<'_, 'ctx>,
     ) -> Option<BasicValueEnum<'ctx>> {
         if ctx.is_const.get() {
             return None;
@@ -816,7 +816,7 @@ impl Type {
         }
     }
 }
-pub fn tuple_type<'ctx>(v: &[Type], ctx: &CompCtx<'ctx>) -> Option<BasicTypeEnum<'ctx>> {
+pub fn tuple_type<'ctx>(v: &[Type], ctx: &CompCtx<'_, 'ctx>) -> Option<BasicTypeEnum<'ctx>> {
     let mut vec = Vec::with_capacity(v.len());
     for t in v {
         vec.push(t.llvm_type(ctx)?);
@@ -837,7 +837,7 @@ impl<'ctx> NominalInfo<'ctx> {
         out.write_all(&[0])?;
         out.write_all(&[u8::from(self.no_auto_drop) << 1 | u8::from(self.transparent)])
     }
-    pub fn load<R: Read + BufRead>(buf: &mut R, ctx: &CompCtx<'ctx>) -> io::Result<Self> {
+    pub fn load<R: Read + BufRead>(buf: &mut R, ctx: &CompCtx<'_, 'ctx>) -> io::Result<Self> {
         let mut vec = vec![];
         buf.read_until(0, &mut vec)?;
         if vec.last() == Some(&0) {

--- a/cobalt-ast/src/value.rs
+++ b/cobalt-ast/src/value.rs
@@ -12,31 +12,31 @@ pub enum MethodType {
     Getter,
 }
 #[derive(Debug, Clone)]
-pub struct FnData<'ctx> {
-    pub defaults: Vec<InterData<'ctx>>,
+pub struct FnData<'src, 'ctx> {
+    pub defaults: Vec<InterData<'src, 'ctx>>,
     pub cconv: u32,
     pub mt: MethodType,
 }
 
 /// Used for compile-time constants.
 #[derive(Debug, Clone)]
-pub enum InterData<'ctx> {
+pub enum InterData<'src, 'ctx> {
     Null,
     Int(i128),
     Float(f64),
     /// Used for tuples, structs, arrays, and bound methods.
-    Array(Vec<InterData<'ctx>>),
+    Array(Vec<Self>),
     /// Used for default values of function parameters.
-    Function(FnData<'ctx>),
+    Function(FnData<'src, 'ctx>),
     InlineAsm(String, String),
     Type(Box<Type>),
     Module(
-        HashMap<String, Symbol<'ctx>>,
-        Vec<(CompoundDottedName, bool)>,
+        HashMap<Cow<'src, str>, Symbol<'src, 'ctx>>,
+        Vec<(CompoundDottedName<'src>, bool)>,
         String,
     ),
 }
-impl<'ctx> InterData<'ctx> {
+impl<'src, 'ctx> InterData<'src, 'ctx> {
     pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {
         match self {
             InterData::Null => out.write_all(&[1]),
@@ -101,7 +101,10 @@ impl<'ctx> InterData<'ctx> {
             }
         }
     }
-    pub fn load<R: Read + BufRead>(buf: &mut R, ctx: &CompCtx<'ctx>) -> io::Result<Option<Self>> {
+    pub fn load<R: Read + BufRead>(
+        buf: &mut R,
+        ctx: &CompCtx<'src, 'ctx>,
+    ) -> io::Result<Option<Self>> {
         let mut c = 0u8;
         buf.read_exact(std::slice::from_mut(&mut c))?;
         Ok(match c {
@@ -186,7 +189,9 @@ impl<'ctx> InterData<'ctx> {
                         break;
                     }
                     out.insert(
-                        String::from_utf8(name).expect("Cobalt symbols should be valid UTF-8"),
+                        String::from_utf8(name)
+                            .expect("Cobalt symbols should be valid UTF-8")
+                            .into(),
                         Symbol::load(buf, ctx)?,
                     );
                 }
@@ -204,15 +209,15 @@ impl<'ctx> InterData<'ctx> {
     }
 }
 #[derive(Debug, Clone)]
-pub struct Value<'ctx> {
+pub struct Value<'src, 'ctx> {
     pub comp_val: Option<BasicValueEnum<'ctx>>,
-    pub inter_val: Option<InterData<'ctx>>,
+    pub inter_val: Option<InterData<'src, 'ctx>>,
     pub data_type: Type,
     pub address: Rc<Cell<Option<PointerValue<'ctx>>>>,
-    pub name: Option<(String, usize)>,
+    pub name: Option<(Cow<'src, str>, usize)>,
     pub frozen: Option<SourceSpan>,
 }
-impl<'ctx> Value<'ctx> {
+impl<'src, 'ctx> Value<'src, 'ctx> {
     pub fn error() -> Self {
         Value {
             comp_val: None,
@@ -235,7 +240,7 @@ impl<'ctx> Value<'ctx> {
     }
     pub fn new(
         comp_val: Option<BasicValueEnum<'ctx>>,
-        inter_val: Option<InterData<'ctx>>,
+        inter_val: Option<InterData<'src, 'ctx>>,
         data_type: Type,
     ) -> Self {
         Value {
@@ -249,7 +254,7 @@ impl<'ctx> Value<'ctx> {
     }
     pub fn with_addr(
         comp_val: Option<BasicValueEnum<'ctx>>,
-        inter_val: Option<InterData<'ctx>>,
+        inter_val: Option<InterData<'src, 'ctx>>,
         data_type: Type,
         addr: PointerValue<'ctx>,
     ) -> Self {
@@ -274,7 +279,7 @@ impl<'ctx> Value<'ctx> {
     }
     pub fn interpreted(
         comp_val: BasicValueEnum<'ctx>,
-        inter_val: InterData<'ctx>,
+        inter_val: InterData<'src, 'ctx>,
         data_type: Type,
     ) -> Self {
         Value {
@@ -286,7 +291,7 @@ impl<'ctx> Value<'ctx> {
             frozen: None,
         }
     }
-    pub fn metaval(inter_val: InterData<'ctx>, data_type: Type) -> Self {
+    pub fn metaval(inter_val: InterData<'src, 'ctx>, data_type: Type) -> Self {
         Value {
             comp_val: None,
             inter_val: Some(inter_val),
@@ -317,8 +322,8 @@ impl<'ctx> Value<'ctx> {
         }
     }
     pub fn make_mod(
-        syms: HashMap<String, Symbol<'ctx>>,
-        imps: Vec<(CompoundDottedName, bool)>,
+        syms: HashMap<Cow<'src, str>, Symbol<'src, 'ctx>>,
+        imps: Vec<(CompoundDottedName<'src>, bool)>,
         name: String,
     ) -> Self {
         Value {
@@ -331,7 +336,7 @@ impl<'ctx> Value<'ctx> {
         }
     }
 
-    pub fn addr(&self, ctx: &CompCtx<'ctx>) -> Option<PointerValue<'ctx>> {
+    pub fn addr(&self, ctx: &CompCtx<'src, 'ctx>) -> Option<PointerValue<'ctx>> {
         self.address.get().or_else(|| {
             let ctv = self.value(ctx)?;
             let alloca = ctx.builder.build_alloca(ctv.get_type(), "");
@@ -340,21 +345,21 @@ impl<'ctx> Value<'ctx> {
             Some(alloca)
         })
     }
-    pub fn freeze(self, loc: SourceSpan) -> Value<'ctx> {
+    pub fn freeze(self, loc: SourceSpan) -> Value<'src, 'ctx> {
         Value {
             frozen: Some(loc),
             ..self
         }
     }
 
-    pub fn value(&self, ctx: &CompCtx<'ctx>) -> Option<BasicValueEnum<'ctx>> {
+    pub fn value(&self, ctx: &CompCtx<'src, 'ctx>) -> Option<BasicValueEnum<'ctx>> {
         self.comp_val.or_else(|| {
             self.inter_val
                 .as_ref()
                 .and_then(|v| self.data_type.into_compiled(v, ctx))
         })
     }
-    pub fn into_value(self, ctx: &CompCtx<'ctx>) -> Option<BasicValueEnum<'ctx>> {
+    pub fn into_value(self, ctx: &CompCtx<'src, 'ctx>) -> Option<BasicValueEnum<'ctx>> {
         self.comp_val.or_else(|| {
             self.inter_val
                 .as_ref()
@@ -362,7 +367,7 @@ impl<'ctx> Value<'ctx> {
         })
     }
 
-    pub fn ins_dtor(&self, ctx: &CompCtx<'ctx>) {
+    pub fn ins_dtor(&self, ctx: &CompCtx<'src, 'ctx>) {
         match &self.data_type {
             Type::Nominal(n) => {
                 if let Some(addr) = self.addr(ctx) {
@@ -473,8 +478,8 @@ impl<'ctx> Value<'ctx> {
     pub fn into_mod(
         self,
     ) -> Option<(
-        HashMap<String, Symbol<'ctx>>,
-        Vec<(CompoundDottedName, bool)>,
+        HashMap<Cow<'src, str>, Symbol<'src, 'ctx>>,
+        Vec<(CompoundDottedName<'src>, bool)>,
         String,
     )> {
         if let Value {
@@ -491,8 +496,8 @@ impl<'ctx> Value<'ctx> {
     pub fn as_mod(
         &self,
     ) -> Option<(
-        &HashMap<String, Symbol<'ctx>>,
-        &Vec<(CompoundDottedName, bool)>,
+        &HashMap<Cow<'src, str>, Symbol<'src, 'ctx>>,
+        &Vec<(CompoundDottedName<'src>, bool)>,
         &String,
     )> {
         if let Value {
@@ -509,8 +514,8 @@ impl<'ctx> Value<'ctx> {
     pub fn as_mod_mut(
         &mut self,
     ) -> Option<(
-        &mut HashMap<String, Symbol<'ctx>>,
-        &mut Vec<(CompoundDottedName, bool)>,
+        &mut HashMap<Cow<'src, str>, Symbol<'src, 'ctx>>,
+        &mut Vec<(CompoundDottedName<'src>, bool)>,
         &mut String,
     )> {
         if let Value {
@@ -541,7 +546,7 @@ impl<'ctx> Value<'ctx> {
         } // Interpreted value, self-punctuating
         self.data_type.save(out) // Type
     }
-    pub fn load<R: Read + BufRead>(buf: &mut R, ctx: &CompCtx<'ctx>) -> io::Result<Self> {
+    pub fn load<R: Read + BufRead>(buf: &mut R, ctx: &CompCtx<'src, 'ctx>) -> io::Result<Self> {
         let mut var = Value::error();
         let mut name = vec![];
         buf.read_until(0, &mut name)?;

--- a/cobalt-build/src/build.rs
+++ b/cobalt-build/src/build.rs
@@ -358,7 +358,7 @@ impl<'de> Deserialize<'de> for Dependency {
         deserializer.deserialize_any(DepVisitor)
     }
 }
-pub fn clear_mod(this: &mut HashMap<String, Symbol>) {
+pub fn clear_mod(this: &mut HashMap<std::borrow::Cow<str>, Symbol>) {
     for (_, sym) in this.iter_mut() {
         sym.1.export = false;
         match sym {
@@ -393,10 +393,10 @@ pub fn clear_mod(this: &mut HashMap<String, Symbol>) {
 /// This stops after running the prepasses to allow them to be run on all files before continuing
 fn build_file_1(
     path: &Path,
-    ctx: &CompCtx,
+    ctx: &CompCtx<'static, '_>,
     opts: &BuildOptions,
     force_build: bool,
-) -> anyhow::Result<(([PathBuf; 2], bool), Option<TopLevelAST>)> {
+) -> anyhow::Result<(([PathBuf; 2], bool), Option<TopLevelAST<'static>>)> {
     let mut out_path = opts.build_dir.to_path_buf();
     out_path.push(".artifacts");
     out_path.push("objects");
@@ -430,8 +430,8 @@ fn build_file_1(
     ctx.module.set_source_file_name(name);
     let code = path.as_absolute_path().unwrap().read_to_string_anyhow()?;
     let file = FILES.add_file(0, name.to_string(), code);
-    let lock = file.contents();
-    let (ast, errs) = parse_tl().parse(&lock).into_output_errors();
+    let lock = unsafe { std::mem::transmute(&*file.contents()) }; // TODO: make thread-safe
+    let (ast, errs) = parse_tl().parse(lock).into_output_errors();
     let mut ast = ast.unwrap_or_default();
     let errs = errs.into_iter().flat_map(cvt_err);
     for err in errs {
@@ -448,8 +448,8 @@ fn build_file_1(
 /// Finish building the file
 /// This picks up where `build_file_1` left off
 fn build_file_2(
-    ast: TopLevelAST,
-    ctx: &CompCtx,
+    ast: TopLevelAST<'static>,
+    ctx: &CompCtx<'static, '_>,
     opts: &BuildOptions,
     (out_path, head_path): (&Path, &Path),
     mut fail: bool,

--- a/cobalt-build/src/build.rs
+++ b/cobalt-build/src/build.rs
@@ -429,9 +429,8 @@ fn build_file_1(
     ctx.module.set_name(name);
     ctx.module.set_source_file_name(name);
     let code = path.as_absolute_path().unwrap().read_to_string_anyhow()?;
-    let file = FILES.add_file(0, name.to_string(), code);
-    let lock = unsafe { std::mem::transmute(&*file.contents()) }; // TODO: make thread-safe
-    let (ast, errs) = parse_tl().parse(lock).into_output_errors();
+    let file = FILES.add_file(0, name.to_string(), code.into());
+    let (ast, errs) = parse_tl().parse(file.contents()).into_output_errors();
     let mut ast = ast.unwrap_or_default();
     let errs = errs.into_iter().flat_map(cvt_err);
     for err in errs {

--- a/cobalt-build/src/libs.rs
+++ b/cobalt-build/src/libs.rs
@@ -121,7 +121,7 @@ pub fn load_lib(path: &Path, ctx: &CompCtx) -> anyhow::Result<Vec<String>> {
             .section_by_name(".colib")
             .and_then(|v| v.uncompressed_data().ok())
         {
-            conflicts.append(&mut ctx.load(&mut &*colib)?);
+            conflicts.extend(ctx.load(&mut &*colib)?.into_iter().map(|x| x.into_owned()));
         }
         Ok(conflicts)
     }

--- a/cobalt-cli/src/main.rs
+++ b/cobalt-cli/src/main.rs
@@ -587,9 +587,9 @@ fn driver() -> anyhow::Result<()> {
                 let ink_ctx = inkwell::context::Context::create();
                 let ctx = CompCtx::with_flags(&ink_ctx, &input, flags);
                 let file = FILES.add_file(0, input, code);
-                let lock = file.contents();
+                let lock = unsafe { std::mem::transmute(&*file.contents()) };
                 let ((ast, errs), parse_time) =
-                    timeit(|| parse_tl().parse(&lock).into_output_errors());
+                    timeit(|| parse_tl().parse(lock).into_output_errors());
                 let mut ast = ast.unwrap_or_default();
                 let errs = errs.into_iter().flat_map(cvt_err);
                 reporter.parse_time = Some(parse_time);
@@ -930,8 +930,8 @@ fn driver() -> anyhow::Result<()> {
             let mut fail = false;
             let mut overall_fail = false;
             let file = FILES.add_file(0, input.to_string(), code);
-            let lock = file.contents();
-            let ((ast, errs), parse_time) = timeit(|| parse_tl().parse(&lock).into_output_errors());
+            let lock = unsafe { std::mem::transmute(&*file.contents()) };
+            let ((ast, errs), parse_time) = timeit(|| parse_tl().parse(lock).into_output_errors());
             let mut ast = ast.unwrap_or_default();
             let errs = errs.into_iter().flat_map(cvt_err);
             reporter.parse_time = Some(parse_time);
@@ -1301,8 +1301,8 @@ fn driver() -> anyhow::Result<()> {
             let mut fail = false;
             let mut overall_fail = false;
             let file = FILES.add_file(0, input.to_string(), code);
-            let lock = file.contents();
-            let ((ast, errs), parse_time) = timeit(|| parse_tl().parse(&lock).into_output_errors());
+            let lock = unsafe { std::mem::transmute(&*file.contents()) };
+            let ((ast, errs), parse_time) = timeit(|| parse_tl().parse(lock).into_output_errors());
             let mut ast = ast.unwrap_or_default();
             let errs = errs.into_iter().flat_map(cvt_err);
             reporter.parse_time = Some(parse_time);
@@ -1574,8 +1574,8 @@ fn driver() -> anyhow::Result<()> {
             };
             let mut fail = false;
             let file = FILES.add_file(0, input.to_string(), code);
-            let lock = file.contents();
-            let ((ast, errs), parse_time) = timeit(|| parse_tl().parse(&lock).into_output_errors());
+            let lock = unsafe { std::mem::transmute(&*file.contents()) };
+            let ((ast, errs), parse_time) = timeit(|| parse_tl().parse(lock).into_output_errors());
             let mut ast = ast.unwrap_or_default();
             let errs = errs.into_iter().flat_map(cvt_err);
             reporter.parse_time = Some(parse_time);
@@ -1865,9 +1865,9 @@ fn driver() -> anyhow::Result<()> {
                             anyhow::bail!("cannot pass absolute paths to multi-file input")
                         }
                         let file = FILES.add_file(0, input.clone(), code.clone());
-                        let lock = file.contents();
+                        let lock = unsafe { std::mem::transmute(&*file.contents()) };
                         let ((ast, errs), parse_time) =
-                            timeit(|| parse_tl().parse(&lock).into_output_errors());
+                            timeit(|| parse_tl().parse(lock).into_output_errors());
                         let mut ast = ast.unwrap_or_default();
                         let errs = errs.into_iter().flat_map(cvt_err);
                         *reporter.parse_time.get_or_insert(Duration::ZERO) += parse_time;
@@ -2300,9 +2300,9 @@ fn driver() -> anyhow::Result<()> {
                     .zip(&codes)
                     .map(|(input, code)| {
                         let file = FILES.add_file(0, input.clone(), code.clone());
-                        let lock = file.contents();
+                        let lock = unsafe { std::mem::transmute(&*file.contents()) };
                         let ((ast, errs), parse_time) =
-                            timeit(|| parse_tl().parse(&lock).into_output_errors());
+                            timeit(|| parse_tl().parse(lock).into_output_errors());
                         let mut ast = ast.unwrap_or_default();
                         let errs = errs.into_iter().flat_map(cvt_err);
                         *reporter.parse_time.get_or_insert(Duration::ZERO) += parse_time;
@@ -2628,9 +2628,9 @@ fn driver() -> anyhow::Result<()> {
                     .zip(&codes)
                     .map(|(input, code)| {
                         let file = FILES.add_file(0, input.clone(), code.clone());
-                        let lock = file.contents();
+                        let lock = unsafe { std::mem::transmute(&*file.contents()) };
                         let ((ast, errs), parse_time) =
-                            timeit(|| parse_tl().parse(&lock).into_output_errors());
+                            timeit(|| parse_tl().parse(lock).into_output_errors());
                         let mut ast = ast.unwrap_or_default();
                         let errs = errs.into_iter().flat_map(cvt_err);
                         *reporter.parse_time.get_or_insert(Duration::ZERO) += parse_time;

--- a/cobalt-errors/Cargo.toml
+++ b/cobalt-errors/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 termcolor = "1.2.0"
 miette = "5.9.0"
-parking_lot = "0.12.1"
 once_cell = "1.17.2"
 thiserror = "1.0.40"
 ordinal = "0.3.2"
+aovec = "1.1.0"

--- a/cobalt-errors/src/error.rs
+++ b/cobalt-errors/src/error.rs
@@ -12,9 +12,9 @@ pub enum CobaltError<'src> {
     // Operators
     #[error(r#"binary operator "{op}" is not defined for types `{lhs}` and `{rhs}`"#)]
     BinOpNotDefined {
-        lhs: Cow<'src, str>,
-        rhs: Cow<'src, str>,
-        op: &'src str,
+        lhs: String,
+        rhs: String,
+        op: &'static str,
         #[label("left type is `{lhs}`")]
         lloc: SourceSpan,
         #[label("right type is `{rhs}`")]
@@ -24,8 +24,8 @@ pub enum CobaltError<'src> {
     },
     #[error(r#"prefix operator "{op}" is not defined for type `{val}`"#)]
     PreOpNotDefined {
-        val: Cow<'src, str>,
-        op: Cow<'src, str>,
+        val: String,
+        op: &'static str,
         #[label("value type is `{val}`")]
         vloc: SourceSpan,
         #[label]
@@ -33,8 +33,8 @@ pub enum CobaltError<'src> {
     },
     #[error(r#"postfix operator "{op}" is not defined for type `{val}`"#)]
     PostOpNotDefined {
-        val: Cow<'src, str>,
-        op: Cow<'src, str>,
+        val: String,
+        op: &'static str,
         #[label("value type is `{val}`")]
         vloc: SourceSpan,
         #[label]
@@ -42,8 +42,8 @@ pub enum CobaltError<'src> {
     },
     #[error("cannot subscript value of type `{val}` with `{sub}`")]
     SubscriptNotDefined {
-        val: Cow<'src, str>,
-        sub: Cow<'src, str>,
+        val: String,
+        sub: String,
         #[label("value type is `{val}`")]
         vloc: SourceSpan,
         #[label("subscript type is `{sub}`")]
@@ -51,7 +51,7 @@ pub enum CobaltError<'src> {
     },
     #[error("value of type `{val}` has no attribute `{attr}`")]
     AttrNotDefined {
-        val: Cow<'src, str>,
+        val: String,
         attr: Cow<'src, str>,
         #[label("value type is `{val}`")]
         vloc: SourceSpan,
@@ -61,8 +61,8 @@ pub enum CobaltError<'src> {
     #[error("value of type `{val}` cannot be {}plicitly converted to `{ty}`", if *.is_expl {"ex"} else {"im"})]
     InvalidConversion {
         is_expl: bool,
-        val: Cow<'src, str>,
-        ty: Cow<'src, str>,
+        val: String,
+        ty: String,
         #[label("value type is `{val}`")]
         vloc: Option<SourceSpan>,
         #[label("target type is `{ty}`")]
@@ -72,10 +72,10 @@ pub enum CobaltError<'src> {
     },
     #[error("cannot call value of type `{val}` with arguments ({})", .args.join(", "))]
     CannotCallWithArgs {
-        val: Cow<'src, str>,
+        val: String,
         #[label("function type is `{val}`")]
         loc: SourceSpan,
-        args: Vec<Cow<'src, str>>,
+        args: Vec<String>,
         #[label("argument types are ({})", .args.join(", "))]
         aloc: Option<SourceSpan>,
         #[related]
@@ -100,10 +100,10 @@ pub enum CobaltError<'src> {
     CantMutateImmut {
         #[label("value is of type `{ty}`")]
         vloc: SourceSpan,
-        ty: Cow<'src, str>,
+        ty: String,
         #[label("operator is `{op}`")]
         oloc: Option<SourceSpan>,
-        op: Cow<'src, str>,
+        op: &'static str,
         #[label("defined as immutable here")]
         floc: SourceSpan,
     },
@@ -112,7 +112,7 @@ pub enum CobaltError<'src> {
     #[error("error in glob pattern")]
     GlobPatternError {
         pos: usize,
-        msg: Cow<'src, str>,
+        msg: &'static str,
         #[label("error at byte {pos} of glob: {msg}")]
         loc: SourceSpan,
     },
@@ -128,8 +128,8 @@ pub enum CobaltError<'src> {
     },
     #[error("{}", if let Some(p) = param {format!("cannot convert convert self_t ({self_t}) to {p} for self parameter")} else {"function must have a self parameter".to_string()})]
     InvalidSelfParam {
-        self_t: Cow<'src, str>,
-        param: Option<Cow<'src, str>>,
+        self_t: String,
+        param: Option<String>,
         #[label]
         loc: SourceSpan,
     },
@@ -153,17 +153,17 @@ pub enum CobaltError<'src> {
         loc: SourceSpan,
         #[label("argument type is {ty}")]
         aloc: SourceSpan,
-        ty: Cow<'src, str>,
+        ty: String,
     },
     #[error("bit cast target must be the same size as the source")]
     DifferentBitCastSizes {
         #[label]
         loc: SourceSpan,
-        from_ty: Cow<'src, str>,
+        from_ty: String,
         from_sz: u32,
         #[label("source type is {from_ty}, which has a size of {from_sz} bytes")]
         from_loc: SourceSpan,
-        to_ty: Cow<'src, str>,
+        to_ty: String,
         to_sz: u32,
         #[label("target type is {to_ty}, which has a size of {to_sz} bytes")]
         to_loc: SourceSpan,
@@ -172,10 +172,10 @@ pub enum CobaltError<'src> {
     UnsizedBitCast {
         #[label]
         loc: SourceSpan,
-        from_ty: Cow<'src, str>,
+        from_ty: String,
         #[label("source type is {from_ty}")]
         from_loc: SourceSpan,
-        to_ty: Cow<'src, str>,
+        to_ty: String,
         #[label("source type is {from_ty}")]
         to_loc: SourceSpan,
     },
@@ -194,8 +194,8 @@ pub enum CobaltError<'src> {
     },
     #[error("elements in array aren't the same type")]
     ArrayElementsDontMatch {
-        current: Cow<'src, str>,
-        new: Cow<'src, str>,
+        current: String,
+        new: String,
         #[label("element type is {new}")]
         loc: SourceSpan,
         #[label("element type previously determined to be {current} here")]
@@ -222,7 +222,7 @@ pub enum CobaltError<'src> {
     CantMoveFromReference {
         #[label("`{ty}` has a destructor, so it can't be moved out of references")]
         loc: SourceSpan,
-        ty: Cow<'src, str>,
+        ty: String,
     },
     #[error("cannot move from variable twice")]
     DoubleMove {
@@ -249,11 +249,11 @@ pub enum CobaltError<'src> {
     InvalidInlineAsm2 {
         #[label("first argument type is {type1} ({})", if *.const1 {"constant"} else {"runtime-only"})]
         loc1: SourceSpan,
-        type1: Cow<'src, str>,
+        type1: String,
         const1: bool,
         #[label("second argument type is {type2} ({})", if *.const2 {"constant"} else {"runtime-only"})]
         loc2: SourceSpan,
-        type2: Cow<'src, str>,
+        type2: String,
         const2: bool,
     },
     #[error("invalid creation of inline assembly")]
@@ -261,15 +261,15 @@ pub enum CobaltError<'src> {
     InvalidInlineAsm3 {
         #[label("first argument type is {type1} ({})", if *.const1 {"constant"} else {"runtime-only"})]
         loc1: SourceSpan,
-        type1: Cow<'src, str>,
+        type1: String,
         const1: bool,
         #[label("second argument type is {type2} ({})", if *.const2 {"constant"} else {"runtime-only"})]
         loc2: SourceSpan,
-        type2: Cow<'src, str>,
+        type2: String,
         const2: bool,
         #[label("third argument type is {type3} ({})", if *.const3 {"constant"} else {"runtime-only"})]
         loc3: SourceSpan,
-        type3: Cow<'src, str>,
+        type3: String,
         const3: bool,
     },
     #[error("invalid creation of inline assembly")]
@@ -283,13 +283,13 @@ pub enum CobaltError<'src> {
     // @alloca
     #[error("type for @alloca must be runtime-available")]
     NonRuntimeAllocaType {
-        ty: Cow<'src, str>,
+        ty: String,
         #[label("type is {ty}")]
         loc: SourceSpan,
     },
     #[error("all arguments to @alloca (except for an optional type) must be integral")]
     NonIntegralAllocaArg {
-        ty: Cow<'src, str>,
+        ty: String,
         #[label("argument type is {ty}")]
         loc: SourceSpan,
     },
@@ -340,7 +340,7 @@ pub enum CobaltError<'src> {
     #[error(r#"variable "{name}" cannot be found{}"#, if .container.is_empty() {"".into()} else {format!(r#" in {container} "{module}""#)})]
     VariableDoesNotExist {
         name: Cow<'src, str>,
-        module: Cow<'src, str>,
+        module: String,
         container: &'static str, // "module" or "type"
         #[label]
         loc: SourceSpan,
@@ -353,16 +353,16 @@ pub enum CobaltError<'src> {
     },
     #[error("runtime variable cannot have a const-only type")]
     #[diagnostic(help("consider using `const` instead"))]
-    TypeIsConstOnly { ty: Cow<'src, str>, loc: SourceSpan },
+    TypeIsConstOnly { ty: String, loc: SourceSpan },
     #[error("{name} is not a module")]
     NotAModule {
-        name: Cow<'src, str>,
+        name: String,
         #[label]
         loc: SourceSpan,
     },
     #[error("{name} has already been defined")]
     RedefVariable {
-        name: Cow<'src, str>,
+        name: String,
         #[label]
         loc: SourceSpan,
         #[label("previously defined here")]

--- a/cobalt-errors/src/files.rs
+++ b/cobalt-errors/src/files.rs
@@ -1,25 +1,25 @@
+use aovec::Aovec;
 use miette::{MietteError, SourceCode, SourceSpan, SpanContents};
 use once_cell::sync::Lazy;
-use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
-static UNIT_REF: () = ();
-#[allow(clippy::type_complexity)]
-pub struct FileRegistry(Lazy<RwLock<Vec<(String, Vec<InnerFile>)>>>);
+pub struct FileRegistry(Lazy<Aovec<(Box<str>, Aovec<InnerFile>)>>);
 impl FileRegistry {
     pub(self) const fn new() -> Self {
-        Self(Lazy::new(|| RwLock::new(vec![(String::new(), vec![])])))
+        Self(Lazy::new(|| {
+            let vec = Aovec::new(16);
+            vec.push((Box::default(), Aovec::new(16)));
+            vec
+        }))
     }
-    pub fn add_module(&self, name: String) -> usize {
-        let mut lock = self.0.write();
-        lock.push((name, vec![]));
-        lock.len() - 1
+    pub fn add_module(&self, name: Box<str>) -> usize {
+        self.0.push((name, Aovec::new(16)));
+        self.0.len() - 1
     }
-    pub fn add_file(&self, module: usize, mut name: String, contents: String) -> CobaltFile {
-        let mut lock = self.0.write();
-        let (mname, vec) = &mut lock[module];
+    pub fn add_file(&self, module: usize, mut name: String, contents: Box<str>) -> CobaltFile {
+        let (mname, vec) = &self.0[module];
         if !mname.is_empty() {
             name = format!("{mname}//{name}")
         } // format files in other modules as module//path/to/file
-        vec.push(InnerFile(name, contents));
+        vec.push(InnerFile(name.into_boxed_str(), contents));
         CobaltFile(module, vec.len() - 1)
     }
 }
@@ -45,36 +45,9 @@ impl<'a> SpanContents<'a> for MaybeNamed<'a> {
         self.1
     }
 }
-/// Span carrying a lock guard for thread safety
-/// This has to be implemented like this because the guard requires a reference, and the Box is
-/// owned
-struct LockedSpan<'a>(
-    Box<dyn SpanContents<'a> + 'a>,
-    MappedRwLockReadGuard<'a, ()>,
-);
-impl<'a> SpanContents<'a> for LockedSpan<'a> {
-    fn data(&self) -> &'a [u8] {
-        self.0.data()
-    }
-    fn span(&self) -> &SourceSpan {
-        self.0.span()
-    }
-    fn line(&self) -> usize {
-        self.0.line()
-    }
-    fn column(&self) -> usize {
-        self.0.column()
-    }
-    fn line_count(&self) -> usize {
-        self.0.line_count()
-    }
-    fn name(&self) -> Option<&str> {
-        self.0.name()
-    }
-}
 /// File implementation. It's like `miette::NamedSource`, but returns a `MaybeNamed`, so it is
 /// unnamed if the file name is an empty string
-struct InnerFile(String, String);
+struct InnerFile(Box<str>, Box<str>);
 impl SourceCode for InnerFile {
     fn read_span<'a>(
         &'a self,
@@ -93,12 +66,12 @@ impl SourceCode for InnerFile {
 pub struct CobaltFile(usize, usize);
 impl CobaltFile {
     /// Get the name of the file that this points to.
-    pub fn name(self) -> MappedRwLockReadGuard<'static, str> {
-        RwLockReadGuard::map(FILES.0.read(), |lock| lock[self.0].1[self.1].0.as_str())
+    pub fn name(self) -> &'static str {
+        FILES.0[self.0].1[self.1].0.as_ref()
     }
     /// Get the contents of the file.
-    pub fn contents(self) -> MappedRwLockReadGuard<'static, str> {
-        RwLockReadGuard::map(FILES.0.read(), |lock| lock[self.0].1[self.1].1.as_str())
+    pub fn contents(self) -> &'static str {
+        FILES.0[self.0].1[self.1].1.as_ref()
     }
     /// Extract the module identifier.
     pub fn module_id(self) -> usize {
@@ -106,8 +79,7 @@ impl CobaltFile {
     }
     /// Return the source location of a point
     pub fn source_loc(self, loc: usize) -> Result<(usize, usize), MietteError> {
-        let lock = FILES.0.read();
-        let file = &lock[self.0].1[self.1].1;
+        let file = FILES.0[self.0].1[self.1].1.as_ref();
         let span = file.read_span(&loc.into(), 0, 0)?;
         Ok((span.line(), span.column()))
     }
@@ -119,14 +91,7 @@ impl SourceCode for CobaltFile {
         clb: usize,
         cla: usize,
     ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
-        let mut res: Option<Result<Box<dyn SpanContents<'a> + 'a>, MietteError>> = None;
-        let lock = RwLockReadGuard::map(FILES.0.read(), |lock| {
-            res = Some(unsafe {
-                std::mem::transmute(lock[self.0].1[self.1].read_span(span, clb, cla))
-            }); // transmute to avoid borrowing
-            &UNIT_REF // we need to return a reference to something
-        });
-        Ok(Box::new(LockedSpan(res.unwrap()?, lock)))
+        FILES.0[self.0].1[self.1].read_span(span, clb, cla)
     }
 }
 /// The actual registry. This is where all of the files are stored


### PR DESCRIPTION
Rather than using a ton of `String`s, which lead to unnecessary allocations, AST nodes now use `Cow<str>` for more efficient borrowing from the input