### PR TITLE
Linear relevant types

### DIFF
--- a/cobalt-ast/src/ast/funcs.rs
+++ b/cobalt-ast/src/ast/funcs.rs
@@ -1123,10 +1123,17 @@ impl AST for FnDefAST {
                             let seen = errs.iter()
                                 .filter_map(|err| if let CobaltError::DoubleMove {loc, name, ..} = err {Some((*loc, &*(name.as_str() as *const str)))} else {None})
                                 .collect::<std::collections::HashSet<_>>();
-                            errs.extend(graph.validate()
+                            errs.extend(graph.validate(ctx)
                                 .into_iter()
-                                .filter(|cfg::DoubleMove {name, loc, ..}| !seen.contains(&(*loc, name.as_str())))
-                                .map(|cfg::DoubleMove {name, loc, prev, guaranteed}| CobaltError::DoubleMove {loc, prev, name, guaranteed}));
+                                .filter(|ce| match ce {
+                                    CobaltError::DoubleMove{name, loc, ..} => {
+                                        !seen.contains(&(*loc, name.as_str()))
+                                    } 
+                                    
+                                    CobaltError::LinearTypeNotUsed { .. } => true,
+
+                                    _ => false
+                                }));
                         }
                         std::mem::drop(graph);
                         if let Some((Type::Reference(b), _)) = params.get(0) {
@@ -1276,10 +1283,17 @@ impl AST for FnDefAST {
                             let seen = errs.iter()
                                 .filter_map(|err| if let CobaltError::DoubleMove {loc, name, ..} = err {Some((*loc, &*(name.as_str() as *const str)))} else {None})
                                 .collect::<std::collections::HashSet<_>>();
-                            errs.extend(graph.validate()
+                            errs.extend(graph.validate(ctx)
                                 .into_iter()
-                                .filter(|cfg::DoubleMove {name, loc, ..}| !seen.contains(&(*loc, name.as_str())))
-                                .map(|cfg::DoubleMove {name, loc, prev, guaranteed}| CobaltError::DoubleMove {loc, prev, name, guaranteed}));
+                                .filter(|ce| match ce {
+                                    CobaltError::DoubleMove{name, loc, ..} => {
+                                        !seen.contains(&(*loc, name.as_str()))
+                                    } 
+                                    
+                                    CobaltError::LinearTypeNotUsed { .. } => true,
+
+                                    _ => false
+                                }));
                         }
                         std::mem::drop(graph);
                         if let Some((Type::Reference(b), _)) = params.get(0) {

--- a/cobalt-ast/src/ast/groups.rs
+++ b/cobalt-ast/src/ast/groups.rs
@@ -53,27 +53,15 @@ impl AST for BlockAST {
                         }
                     })
                     .collect::<std::collections::HashSet<_>>();
-                errs.extend(
-                    graph
-                        .validate()
-                        .into_iter()
-                        .filter(|cfg::DoubleMove { name, loc, .. }| {
-                            !seen.contains(&(*loc, name.as_str()))
-                        })
-                        .map(
-                            |cfg::DoubleMove {
-                                 name,
-                                 loc,
-                                 prev,
-                                 guaranteed,
-                             }| CobaltError::DoubleMove {
-                                loc,
-                                prev,
-                                name,
-                                guaranteed,
-                            },
-                        ),
-                );
+                errs.extend(graph.validate(ctx).into_iter().filter(|ce| match ce {
+                    CobaltError::DoubleMove { name, loc, .. } => {
+                        !seen.contains(&(*loc, name.as_str()))
+                    }
+
+                    CobaltError::LinearTypeNotUsed { .. } => true,
+
+                    _ => false,
+                }));
             }
         }
         // let mut b = ctx.moves.borrow_mut();

--- a/cobalt-ast/src/ast/vars.rs
+++ b/cobalt-ast/src/ast/vars.rs
@@ -1375,7 +1375,7 @@ impl AST for TypeDefAST {
                     }
                 }
                 "no_auto_drop" => no_auto_drop = true,
-                "linear" => linear = true,
+                "must_use" => linear = true,
                 _ => {}
             }
         }
@@ -1474,7 +1474,7 @@ impl AST for TypeDefAST {
                     }
                 }
                 "no_auto_drop" => no_auto_drop = true,
-                "linear" => linear = true,
+                "must_use" => linear = true,
                 _ => {}
             }
         }
@@ -1598,7 +1598,7 @@ impl AST for TypeDefAST {
                     }
                 }
                 "no_auto_drop" => no_auto_drop = true,
-                "linear" => linear = true,
+                "must_use" => linear = true,
                 _ => {}
             }
         }
@@ -1774,17 +1774,17 @@ impl AST for TypeDefAST {
                         no_auto_drop = Some(loc);
                     }
                 }
-                "linear" => {
+                "must_use" => {
                     if let Some(prev) = no_auto_drop {
                         errs.push(CobaltError::RedefAnnArgument {
-                            name: "linear",
+                            name: "must_use",
                             loc,
                             prev,
                         });
                     } else {
                         if arg.is_some() {
                             errs.push(CobaltError::InvalidAnnArgument {
-                                name: "linear",
+                                name: "must_use",
                                 found: arg.clone(),
                                 expected: None,
                                 loc,

--- a/cobalt-ast/src/cfg.rs
+++ b/cobalt-ast/src/cfg.rs
@@ -795,10 +795,7 @@ impl<'a, 'src, 'ctx> Cfg<'a, 'src, 'ctx> {
             v.symbols.iter().for_each(|(n, v)| {
                 let is_linear_type = is_linear_type(&v.0.data_type, ctx);
                 if is_linear_type {
-                    let lex_scope = match v.1.scope {
-                        Some(scope) => Some(scope.into()),
-                        None => None,
-                    };
+                    let lex_scope = v.1.scope.map(From::from);
                     let is_moved = self.is_moved(n, lex_scope, None, ctx);
                     match is_moved.get_zero_extended_constant() {
                         Some(1) => {}

--- a/cobalt-ast/src/cfg.rs
+++ b/cobalt-ast/src/cfg.rs
@@ -970,7 +970,11 @@ impl<'a, 'src, 'ctx> Cfg<'a, 'src, 'ctx> {
                 }
                 let c = self.is_moved(&m.name.0, Some(m.name.1), Some(m.inst), ctx);
                 match c.get_zero_extended_constant() {
-                    Some(0) => ctx.lookup(&m.name.0, false).unwrap().0.ins_dtor(ctx),
+                    Some(0) => {
+                        if let Some(val) = ctx.lookup(&m.name.0, false) {
+                            val.0.ins_dtor(ctx)
+                        }
+                    }
                     Some(1) => {}
                     _ => {
                         let db = ctx

--- a/cobalt-ast/src/cfg.rs
+++ b/cobalt-ast/src/cfg.rs
@@ -811,7 +811,7 @@ impl<'a, 'ctx> Cfg<'a, 'ctx> {
 
                             Type::Mut(ref boxed_type) => {
                                 if let Type::Nominal(ref type_name) = **boxed_type {
-                                    to_return = nominal_behavior(&type_name);
+                                    to_return = nominal_behavior(type_name);
                                 } else {
                                     to_return = false;
                                 }

--- a/cobalt-ast/src/ops.rs
+++ b/cobalt-ast/src/ops.rs
@@ -19,7 +19,9 @@ pub fn mark_move<'ctx>(
     if !ctx.is_const.get() {
         if let (Some(name), true) = (
             &val.name,
-            ctx.flags.all_move_metadata || val.data_type.has_dtor(ctx),
+            ctx.flags.all_move_metadata
+                || val.data_type.has_dtor(ctx)
+                || is_linear_type(&val.data_type, ctx),
         ) {
             ctx.moves.borrow_mut().0.insert(cfg::Use {
                 is_move: true,
@@ -40,7 +42,9 @@ pub fn mark_use<'ctx>(
     if !ctx.is_const.get() {
         if let (Some(name), true) = (
             &val.name,
-            ctx.flags.all_move_metadata || val.data_type.has_dtor(ctx),
+            ctx.flags.all_move_metadata
+                || val.data_type.has_dtor(ctx)
+                || is_linear_type(&val.data_type, ctx),
         ) {
             ctx.moves.borrow_mut().0.insert(cfg::Use {
                 is_move: false,
@@ -225,7 +229,9 @@ pub fn bin_op<'ctx>(
                     let inst = ctx.builder.build_store(lv, rv);
                     if let (Some(name), true) = (
                         &lhs.name,
-                        ctx.flags.all_move_metadata || lhs.data_type.has_dtor(ctx),
+                        ctx.flags.all_move_metadata
+                            || lhs.data_type.has_dtor(ctx)
+                            || is_linear_type(&lhs.data_type, ctx),
                     ) {
                         ctx.moves.borrow_mut().1.insert(cfg::Store {
                             inst: inst.into(),

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -729,11 +729,23 @@ pub fn tuple_type<'ctx>(v: &[Type], ctx: &CompCtx<'ctx>) -> Option<BasicTypeEnum
     }
     Some(ctx.context.struct_type(&vec, false).into())
 }
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct NominalInfo<'ctx> {
     pub dtor: Option<FunctionValue<'ctx>>,
     pub no_auto_drop: bool,
+    pub is_linear_type: bool,
 }
+
+impl<'ctx> Default for NominalInfo<'ctx> {
+    fn default() -> Self {
+        Self {
+            is_linear_type: true,
+            dtor: None,
+            no_auto_drop: false,
+        }
+    }
+}
+
 impl<'ctx> NominalInfo<'ctx> {
     pub fn save<W: Write>(&self, out: &mut W) -> io::Result<()> {
         if let Some(fv) = self.dtor {
@@ -766,6 +778,10 @@ impl<'ctx> NominalInfo<'ctx> {
         let mut c = 0u8;
         buf.read_exact(std::slice::from_mut(&mut c))?;
         let no_auto_drop = c != 0;
-        Ok(Self { dtor, no_auto_drop })
+        Ok(Self {
+            dtor,
+            no_auto_drop,
+            is_linear_type: true,
+        })
     }
 }

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -775,3 +775,36 @@ impl<'ctx> NominalInfo<'ctx> {
         })
     }
 }
+
+pub fn is_linear_type(ty: &Type, ctx: &CompCtx) -> bool {
+    let to_return: bool;
+
+    let nominal_behavior = |type_name: &String| {
+        if let Some((_, _, _, nom_info)) = ctx.nominals.borrow().get(type_name) {
+            nom_info.is_linear_type
+        } else {
+            false
+        }
+    };
+
+    // See if it's a nominal type.
+    match ty {
+        Type::Nominal(type_name) => {
+            to_return = nominal_behavior(type_name);
+        }
+
+        Type::Mut(ref boxed_type) => {
+            if let Type::Nominal(ref type_name) = **boxed_type {
+                to_return = nominal_behavior(&type_name);
+            } else {
+                to_return = false;
+            }
+        }
+
+        _ => {
+            to_return = false;
+        }
+    }
+
+    to_return
+}

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -739,7 +739,7 @@ pub struct NominalInfo<'ctx> {
 impl<'ctx> Default for NominalInfo<'ctx> {
     fn default() -> Self {
         Self {
-            is_linear_type: true,
+            is_linear_type: false,
             dtor: None,
             no_auto_drop: false,
         }
@@ -781,7 +781,7 @@ impl<'ctx> NominalInfo<'ctx> {
         Ok(Self {
             dtor,
             no_auto_drop,
-            is_linear_type: true,
+            is_linear_type: false,
         })
     }
 }

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -729,21 +729,11 @@ pub fn tuple_type<'ctx>(v: &[Type], ctx: &CompCtx<'ctx>) -> Option<BasicTypeEnum
     }
     Some(ctx.context.struct_type(&vec, false).into())
 }
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct NominalInfo<'ctx> {
     pub dtor: Option<FunctionValue<'ctx>>,
     pub no_auto_drop: bool,
     pub is_linear_type: bool,
-}
-
-impl<'ctx> Default for NominalInfo<'ctx> {
-    fn default() -> Self {
-        Self {
-            is_linear_type: false,
-            dtor: None,
-            no_auto_drop: false,
-        }
-    }
 }
 
 impl<'ctx> NominalInfo<'ctx> {

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -902,7 +902,7 @@ pub fn is_linear_type(ty: &Type, ctx: &CompCtx) -> bool {
 
         Type::Mut(ref boxed_type) => {
             if let Type::Nominal(ref type_name) = **boxed_type {
-                to_return = nominal_behavior(&type_name);
+                to_return = nominal_behavior(type_name);
             } else {
                 to_return = false;
             }

--- a/cobalt-errors/src/error.rs
+++ b/cobalt-errors/src/error.rs
@@ -231,6 +231,12 @@ pub enum CobaltError {
         name: String,
         guaranteed: bool,
     },
+    #[error("variable of linear type must be used exactly once")]
+    LinearTypeNotUsed {
+        #[label("{name} defined here")]
+        loc: SourceSpan,
+        name: String,
+    },
     #[error("invalid parameters for overloaded operator function")]
     #[help("for `{op}`, the parameters should be ({ex})")]
     InvalidOpParams {


### PR DESCRIPTION
Adds linear types, which can be used by marking a type with the `@must_use` annotation. 