### PR TITLE
Fix some issues involving affine types

### DIFF
--- a/cobalt-ast/src/ast/funcs.rs
+++ b/cobalt-ast/src/ast/funcs.rs
@@ -1097,6 +1097,8 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                         Type::Reference(Box::new(fty.clone()))
                     ), VariableData::with_vis(self.loc, vs)))).clone();
                     if is_extern.is_none() {
+                        let entry = ctx.context.append_basic_block(f, "entry");
+                        ctx.builder.position_at_end(entry);
                         let old_scope = ctx.push_scope(&self.name);
                         ctx.map_vars(|v| Box::new(VarMap::new(Some(v))));
                         ctx.lex_scope.incr();
@@ -1132,8 +1134,6 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                                 }
                             }
                         }
-                        let entry = ctx.context.append_basic_block(f, "entry");
-                        ctx.builder.position_at_end(entry);
                         ctx.to_drop.borrow_mut().push(Vec::new());
                         let body = self.body.codegen_errs(ctx, &mut errs);
                         ctx.to_drop.borrow_mut().pop().unwrap().into_iter().for_each(|v| v.ins_dtor(ctx));
@@ -1260,6 +1260,8 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                         Type::Reference(Box::new(fty.clone()))
                     ), VariableData::with_vis(self.loc, vs)))).clone();
                     if is_extern.is_none() {
+                        let entry = ctx.context.append_basic_block(f, "entry");
+                        ctx.builder.position_at_end(entry);
                         let old_scope = ctx.push_scope(&self.name);
                         ctx.map_vars(|v| Box::new(VarMap::new(Some(v))));
                         ctx.lex_scope.incr();
@@ -1295,8 +1297,6 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                                 }
                             }
                         }
-                        let entry = ctx.context.append_basic_block(f, "entry");
-                        ctx.builder.position_at_end(entry);
                         ctx.to_drop.borrow_mut().push(Vec::new());
                         self.body.codegen_errs(ctx, &mut errs);
                         ctx.to_drop.borrow_mut().pop().unwrap().into_iter().for_each(|v| v.ins_dtor(ctx));

--- a/cobalt-ast/src/ast/groups.rs
+++ b/cobalt-ast/src/ast/groups.rs
@@ -21,7 +21,7 @@ impl<'src> AST<'src> for BlockAST<'src> {
         ctx: &CompCtx<'src, 'ctx>,
     ) -> (Value<'src, 'ctx>, Vec<CobaltError<'src>>) {
         ctx.map_vars(|v| Box::new(VarMap::new(Some(v))));
-        // ctx.lex_scope.incr();
+        ctx.lex_scope.incr();
         let mut out = Value::null();
         let mut errs = vec![];
         let start = cfg::Location::current(ctx);
@@ -65,9 +65,10 @@ impl<'src> AST<'src> for BlockAST<'src> {
                 }));
             }
         }
-        // let mut b = ctx.moves.borrow_mut();
-        // b.0.retain(|v| v.name.1 < ctx.lex_scope.get());
-        // b.1.retain(|v| v.name.1 < ctx.lex_scope.get());
+        let mut b = ctx.moves.borrow_mut();
+        b.0.retain(|v| v.name.1 < ctx.lex_scope.get());
+        b.1.retain(|v| v.name.1 < ctx.lex_scope.get());
+        ctx.lex_scope.decr();
         ctx.map_vars(|v| v.parent.unwrap());
         (out, errs)
     }

--- a/cobalt-ast/src/cfg.rs
+++ b/cobalt-ast/src/cfg.rs
@@ -982,6 +982,7 @@ impl<'a, 'src, 'ctx> Cfg<'a, 'src, 'ctx> {
             .unwrap()
             .get_parent()
             .unwrap();
+        let mut reposition = true;
         self.blocks
             .iter()
             .flat_map(|b| &b.moves)
@@ -989,25 +990,23 @@ impl<'a, 'src, 'ctx> Cfg<'a, 'src, 'ctx> {
             .filter(|s| unsafe { (***s).name.1 } == ctx.lex_scope.get())
             .for_each(|m| unsafe {
                 let m = &**m;
-                match m.inst {
-                    Location::Block(b) => {
-                        if let Some(i) = b.get_first_instruction() {
-                            ctx.builder.position_before(&i)
-                        } else {
-                            ctx.builder.position_at_end(b)
-                        }
-                    }
-                    Location::Inst(i, _) => ctx.builder.position_before(&i),
-                    Location::AfterInst(i) => {
-                        if let Some(i) = i.get_next_instruction() {
-                            ctx.builder.position_before(&i)
-                        } else {
-                            ctx.builder.position_at_end(i.get_parent().unwrap())
-                        }
-                    }
-                }
-                let c = self.is_moved(&m.name.0, Some(m.name.1), Some(dbg!(m.inst)), ctx);
-                match dbg!(c).get_zero_extended_constant() {
+                let i = if let Location::Inst(i, 0) = m.inst {
+                    i
+                } else {
+                    unreachable!("store locations should only be Location::Inst(_, 0)")
+                };
+                assert_eq!(
+                    i.get_next_instruction()
+                        .map(|i| (i.get_opcode(), i.get_num_operands())),
+                    Some((inkwell::values::InstructionOpcode::Br, 1))
+                );
+                let next = i.get_next_instruction().unwrap();
+                let next_block = next.get_operand(0).unwrap().unwrap_right();
+                reposition = false;
+                ctx.builder
+                    .position_before(&i.get_next_instruction().unwrap());
+                let c = self.is_moved(&m.name.0, Some(m.name.1), Some(m.inst), ctx);
+                match c.get_zero_extended_constant() {
                     Some(0) => {
                         if let Some(val) = ctx.lookup(&m.name.0, false) {
                             val.0.ins_dtor(ctx)
@@ -1018,33 +1017,16 @@ impl<'a, 'src, 'ctx> Cfg<'a, 'src, 'ctx> {
                         let db = ctx
                             .context
                             .append_basic_block(f, &format!("dtor.{}.{}", m.name.0, m.name.1));
-                        let mb = ctx.context.append_basic_block(f, "merge");
-                        ctx.builder.build_conditional_branch(c, mb, db);
+                        ctx.builder.build_conditional_branch(c, next_block, db);
+                        next.erase_from_basic_block();
                         ctx.builder.position_at_end(db);
                         ctx.lookup(&m.name.0, false).unwrap().0.ins_dtor(ctx);
-                        ctx.builder.build_unconditional_branch(mb);
-                        ctx.builder.position_at_end(mb);
+                        ctx.builder.build_unconditional_branch(next_block);
+                        ctx.builder.position_at_end(next_block);
                     }
                 }
             });
         if at_end {
-            match self.last {
-                Location::Block(b) => {
-                    if let Some(i) = b.get_first_instruction() {
-                        ctx.builder.position_before(&i)
-                    } else {
-                        ctx.builder.position_at_end(b)
-                    }
-                }
-                Location::Inst(i, _) => ctx.builder.position_before(&i),
-                Location::AfterInst(i) => {
-                    if let Some(i) = i.get_next_instruction() {
-                        ctx.builder.position_before(&i)
-                    } else {
-                        ctx.builder.position_at_end(i.get_parent().unwrap())
-                    }
-                }
-            }
             ctx.with_vars(|v| {
                 v.symbols.iter().for_each(|(n, v)| {
                     let scope =

--- a/cobalt-ast/src/ops.rs
+++ b/cobalt-ast/src/ops.rs
@@ -258,6 +258,16 @@ pub fn bin_op<'src, 'ctx>(
                             name: name.clone(),
                             real: !ctx.flags.all_move_metadata || lhs.data_type.has_dtor(ctx), // don't check for dtor twice if we can avoid it
                         });
+                        let next = ctx.context.append_basic_block(
+                            ctx.builder
+                                .get_insert_block()
+                                .unwrap()
+                                .get_parent()
+                                .unwrap(),
+                            "next",
+                        );
+                        ctx.builder.build_unconditional_branch(next);
+                        ctx.builder.position_at_end(next);
                     }
                 }
                 lhs.inter_val = None;
@@ -5246,10 +5256,7 @@ pub fn call<'src, 'ctx>(
                             v.iter().map(Type::to_string).collect::<Vec<_>>().join(", ")
                         ),
                         loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
-                        args: args
-                            .iter()
-                            .map(|(v, _)| v.data_type.to_string())
-                            .collect(),
+                        args: args.iter().map(|(v, _)| v.data_type.to_string()).collect(),
                         aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
                         nargs: vec![],
                     };
@@ -5317,10 +5324,7 @@ pub fn call<'src, 'ctx>(
                         v.iter().map(Type::to_string).collect::<Vec<_>>().join(", ")
                     ),
                     loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
-                    args: args
-                        .iter()
-                        .map(|(v, _)| v.data_type.to_string())
-                        .collect(),
+                    args: args.iter().map(|(v, _)| v.data_type.to_string()).collect(),
                     aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
                     nargs: vec![],
                 };
@@ -5396,10 +5400,7 @@ pub fn call<'src, 'ctx>(
                         .join(", ")
                 ),
                 loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
-                args: args
-                    .iter()
-                    .map(|(v, _)| v.data_type.to_string())
-                    .collect(),
+                args: args.iter().map(|(v, _)| v.data_type.to_string()).collect(),
                 aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
                 nargs: vec![],
             };
@@ -5593,10 +5594,7 @@ pub fn call<'src, 'ctx>(
                     v.iter().map(Type::to_string).collect::<Vec<_>>().join(", ")
                 ),
                 loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
-                args: args
-                    .iter()
-                    .map(|(v, _)| v.data_type.to_string())
-                    .collect(),
+                args: args.iter().map(|(v, _)| v.data_type.to_string()).collect(),
                 aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
                 nargs: vec![],
             };
@@ -6026,10 +6024,7 @@ pub fn call<'src, 'ctx>(
         t => Err(CobaltError::CannotCallWithArgs {
             val: t.to_string(),
             loc: cparen.map_or(loc, |cp| merge_spans(loc, cp)),
-            args: args
-                .iter()
-                .map(|(v, _)| v.data_type.to_string())
-                .collect(),
+            args: args.iter().map(|(v, _)| v.data_type.to_string()).collect(),
             aloc: args.last().map(|(_, l)| merge_spans(args[0].1, *l)),
             nargs: vec![],
         }),

--- a/cobalt-parser/src/lib.rs
+++ b/cobalt-parser/src/lib.rs
@@ -247,7 +247,7 @@ fn declarations<'a>(
     .then(
         ident()
             .or_not()
-            .map(|v| v.map_or_else(Cow::default, Cow::Borrowed))
+            .map_with_span(|v, l| (v.map_or_else(Cow::default, Cow::Borrowed), l))
             .labelled("parameter name"),
     )
     .then_ignore(ignored())
@@ -295,7 +295,7 @@ fn declarations<'a>(
             .or_not()
             .labelled("default value"),
     )
-    .map(|(((pty, name), ty), default)| (name, pty, ty, default))
+    .map(|(((pty, (name, loc)), ty), default)| (loc.into_range().into(), name, pty, ty, default))
     .and_is(none_of("),").rewind())
     .boxed();
     choice([

--- a/cobalt-parser/src/lib.rs
+++ b/cobalt-parser/src/lib.rs
@@ -50,7 +50,7 @@ static KEYWORDS: &[&str] = &[
 /// operators that can be interned
 static OPS: &[&str] = &[
     "=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=", "+", "-", "*", "/", "%",
-    "&", "|", "^", "<<", ">>", "<", ">", "<=", ">=", "==", "!=",
+    "&", "|", "^", "<<", ">>", "<", ">", "<=", ">=", "==", "!=", "mut",
 ];
 /// take op and make it 'static
 /// assumes op is an operator


### PR DESCRIPTION
- Lexical scopes are now updated in blocks as well as functions. This fixes some issues with shadowed variables overlapping in analysis.
- Function parameters have source locations
- Inserting destructors before stores no longer results in verifier errors