### PR TITLE
Use LLD

### DIFF
--- a/cobalt-build/Cargo.toml
+++ b/cobalt-build/Cargo.toml
@@ -41,4 +41,6 @@ cobalt-llvm = { path = "../cobalt-llvm", optional = true }
 
 [features]
 lld = ["cxx", "cxx-build", "cobalt-llvm"]
+force-lld = ["lld"]
+disable-lld = [] # easy additive command to disable LLD
 default = ["lld"]

--- a/cobalt-build/Cargo.toml
+++ b/cobalt-build/Cargo.toml
@@ -33,3 +33,12 @@ indexmap = "2.0.0"
 os_str_bytes = "6.5.0"
 toml = "0.8.0"
 bstr = "1.5.0"
+cxx = { version = "1.0", optional = true }
+
+[build-dependencies]
+cxx-build = { version = "1.0", optional = true }
+cobalt-llvm = { path = "../cobalt-llvm", optional = true }
+
+[features]
+lld = ["cxx", "cxx-build", "cobalt-llvm"]
+default = ["lld"]

--- a/cobalt-build/build.rs
+++ b/cobalt-build/build.rs
@@ -1,15 +1,23 @@
 #[cfg(feature = "lld")]
 fn main() {
-    println!("carg:rerun-if-changed=cxx");
-    println!("carg:rerun-if-changed=src/lld.rs");
+    println!("cargo:rerun-if-changed=cxx");
+    println!("cargo:rerun-if-changed=src/lld.rs");
+    println!("cargo:rerun-if-changed=src/lld/glue.rs");
     if cxx_build::bridge("src/lld/glue.rs")
         .file("cxx/lld.cpp")
         .include(cobalt_llvm::LLVM_INCLUDE_DIR)
         .flag_if_supported("-std=c++17")
+        .warnings(false)
         .try_compile("lld-rs")
         .is_ok()
     {
         println!("cargo:rustc-cfg=lld_enabled");
+        println!("cargo:rustc-link-search={}", cobalt_llvm::LLVM_LIBS_DIR);
+        println!("cargo:rustc-link-lib=lldCommon");
+        println!("cargo:rustc-link-lib=lldCOFF");
+        println!("cargo:rustc-link-lib=lldELF");
+        println!("cargo:rustc-link-lib=lldMachO");
+        println!("cargo:rustc-link-lib=lldWasm");
     } else {
         println!("cargo:rustc-env=HOST={}", std::env::var("TARGET").unwrap());
     }

--- a/cobalt-build/build.rs
+++ b/cobalt-build/build.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "lld")]
 fn main() {
     println!("cargo:rerun-if-changed=cxx");
-    println!("cargo:rerun-if-changed=src/lld.rs");
     println!("cargo:rerun-if-changed=src/lld/glue.rs");
     if cxx_build::bridge("src/lld/glue.rs")
         .file("cxx/lld.cpp")

--- a/cobalt-build/build.rs
+++ b/cobalt-build/build.rs
@@ -1,4 +1,6 @@
-#[cfg(feature = "lld")]
+#[cfg(all(feature = "disble-lld", feature = "force-lld"))]
+compile_error!("force-lld and disable-lld features are mutually exclusive");
+#[cfg(all(feature = "lld", not(feature = "disable-lld")))]
 fn main() {
     println!("cargo:rerun-if-changed=cxx");
     println!("cargo:rerun-if-changed=src/lld/glue.rs");
@@ -18,10 +20,12 @@ fn main() {
         println!("cargo:rustc-link-lib=lldMachO");
         println!("cargo:rustc-link-lib=lldWasm");
     } else {
+        #[cfg(feature = "force-lld")]
+        panic!("LLD build failed");
         println!("cargo:rustc-env=HOST={}", std::env::var("TARGET").unwrap());
     }
 }
-#[cfg(not(feature = "lld"))]
+#[cfg(any(not(feature = "lld"), feature = "disable-lld"))]
 fn main() {
     println!("cargo:rustc-env=HOST={}", std::env::var("TARGET").unwrap());
 }

--- a/cobalt-build/build.rs
+++ b/cobalt-build/build.rs
@@ -1,3 +1,20 @@
+#[cfg(feature = "lld")]
+fn main() {
+    println!("carg:rerun-if-changed=cxx");
+    println!("carg:rerun-if-changed=src/lld.rs");
+    if cxx_build::bridge("src/lld/glue.rs")
+        .file("cxx/lld.cpp")
+        .include(cobalt_llvm::LLVM_INCLUDE_DIR)
+        .flag_if_supported("-std=c++17")
+        .try_compile("lld-rs")
+        .is_ok()
+    {
+        println!("cargo:rustc-cfg=lld_enabled");
+    } else {
+        println!("cargo:rustc-env=HOST={}", std::env::var("TARGET").unwrap());
+    }
+}
+#[cfg(not(feature = "lld"))]
 fn main() {
     println!("cargo:rustc-env=HOST={}", std::env::var("TARGET").unwrap());
 }

--- a/cobalt-build/cxx/lld.cpp
+++ b/cobalt-build/cxx/lld.cpp
@@ -1,11 +1,19 @@
 #include "cobalt-build/src/lld/glue.rs.h"
 #include <lld/Common/Driver.h>
 namespace llvm {
-void lld_entry(rust::Slice<const *char const> args, llvm::raw_ostream &stdout,
-               llvm::raw_ostream &stderr, LldReturn &ret) {
-  auto res = lld::safeLldMain(args.length(), args.data(), stdout, stderr);
-  set_ret_code(ret, res.ret);
-  set_ret_code(ret, res.canRunAgain);
+int lld_entry(rust::Slice<const char *> rust_args, llvm::raw_ostream &stdout,
+              llvm::raw_ostream &stderr, LldFlavor flavor) {
+  llvm::ArrayRef<const char *> args{rust_args.data(), rust_args.length()};
+  switch (flavor) {
+  case Elf:
+    return lld::elf::link(args, stdout, stderr, false, false);
+  case Coff:
+    return lld::coff::link(args, stdout, stderr, false, false);
+  case MachO:
+    return lld::macho::link(args, stdout, stderr, false, false);
+  case Wasm:
+    return lld::wasm::link(args, stdout, stderr, false, false);
+  }
 }
 std::unique_ptr<llvm::raw_ostream> string_ostream(std::string &buf) {
   return std::make_unique<llvm::raw_string_ostream>(buf);

--- a/cobalt-build/cxx/lld.cpp
+++ b/cobalt-build/cxx/lld.cpp
@@ -1,0 +1,25 @@
+#include "cobalt-build/src/lld/glue.rs.h"
+#include <lld/Common/Driver.h>
+namespace llvm {
+void lld_entry(rust::Slice<const *char const> args, llvm::raw_ostream &stdout,
+               llvm::raw_ostream &stderr, LldReturn &ret) {
+  auto res = lld::safeLldMain(args.length(), args.data(), stdout, stderr);
+  set_ret_code(ret, res.ret);
+  set_ret_code(ret, res.canRunAgain);
+}
+std::unique_ptr<llvm::raw_ostream> string_ostream(std::string &buf) {
+  return std::make_unique<llvm::raw_string_ostream>(buf);
+}
+std::unique_ptr<llvm::raw_ostream>
+file_ostream(rust::Slice<const uint8_t> path) {
+  std::string_view view{reinterpret_cast<const char *>(path.data()),
+                        path.length()};
+  std::error_code ec;
+  auto out = std::make_unique<llvm::raw_fd_ostream>(view, ec);
+  if (ec)
+    throw ec;
+  return out;
+}
+llvm::raw_ostream *outs_ptr() { return &llvm::outs(); }
+llvm::raw_ostream *errs_ptr() { return &llvm::errs(); }
+} // namespace llvm

--- a/cobalt-build/cxx/lld.hpp
+++ b/cobalt-build/cxx/lld.hpp
@@ -1,0 +1,15 @@
+#ifndef COBALT_LLD_HPP
+#define COBALT_LLD_HPP
+#include "rust/cxx.h"
+#include "llvm/Support/raw_ostream.h"
+#include <memory>
+namespace llvm {
+struct LldReturn;
+void lld_entry(rust::Slice<const *char const>, llvm::raw_ostream &,
+               llvm::raw_ostream &, LldReturn &);
+std::unique_ptr<llvm::raw_ostream> string_ostream(std::string &);
+std::unique_ptr<llvm::raw_ostream> file_ostream(rust::Slice<const uint8_t>);
+llvm::raw_ostream *outs_ptr();
+llvm::raw_ostream *errs_ptr();
+} // namespace llvm
+#endif

--- a/cobalt-build/cxx/lld.hpp
+++ b/cobalt-build/cxx/lld.hpp
@@ -4,9 +4,14 @@
 #include "llvm/Support/raw_ostream.h"
 #include <memory>
 namespace llvm {
-struct LldReturn;
-void lld_entry(rust::Slice<const *char const>, llvm::raw_ostream &,
-               llvm::raw_ostream &, LldReturn &);
+enum LldFlavor : int8_t {
+  Elf,
+  Coff,
+  MachO,
+  Wasm,
+};
+int lld_entry(rust::Slice<const char *>, llvm::raw_ostream &,
+              llvm::raw_ostream &, LldFlavor);
 std::unique_ptr<llvm::raw_ostream> string_ostream(std::string &);
 std::unique_ptr<llvm::raw_ostream> file_ostream(rust::Slice<const uint8_t>);
 llvm::raw_ostream *outs_ptr();

--- a/cobalt-build/src/build.rs
+++ b/cobalt-build/src/build.rs
@@ -501,7 +501,7 @@ fn build_file_2(
 /// assumes that all dependencies are already built
 fn resolve_deps_internal(
     ctx: &CompCtx,
-    cmd: &mut cc::CompileCommand,
+    cmd: &mut ccomp::CompileCommand,
     t: &Target,
     pkg: &str,
     v: &Version,
@@ -565,7 +565,7 @@ pub fn build_target_single(
     let ink_ctx = inkwell::context::Context::create();
     let mut ctx = CompCtx::new(&ink_ctx, "");
     ctx.flags.prepass = false;
-    let mut cc = cc::CompileCommand::new();
+    let mut cc = ccomp::CompileCommand::new();
     cc.link_dir("$ORIGIN");
     resolve_deps_internal(&ctx, &mut cc, t, pkg, v, plan, opts)?;
     match t.target_type {
@@ -623,7 +623,7 @@ pub fn build_target_single(
             output.push(name);
             cc.objs(paths.into_iter().map(|([x, _], _)| x));
             cc.output(&output);
-            let code = cc.build_cmd()?.status_anyhow()?.code().unwrap_or(-1);
+            let code = cc.run_command()?()?;
             if code != 0 {
                 anyhow::bail!("C compiler exited with code {code}")
             }
@@ -681,11 +681,11 @@ pub fn build_target_single(
                 })?;
             let mut output = opts.build_dir.to_path_buf();
             output.push(name);
-            let mut cc = cc::CompileCommand::new();
+            let mut cc = ccomp::CompileCommand::new();
             cc.lib(true);
             cc.objs(paths.into_iter().flat_map(|x| x.0));
             cc.output(&output);
-            let code = cc.build_cmd()?.status_anyhow()?.code().unwrap_or(-1);
+            let code = cc.run_command()?()?;
             if code != 0 {
                 anyhow::bail!("C compiler exited with code {code}")
             }
@@ -709,7 +709,7 @@ pub fn build_target_single(
 /// dependency has been rebuilt and a Vec containing the files that need to be linked
 fn resolve_deps(
     ctx: &CompCtx,
-    cmd: &mut cc::CompileCommand,
+    cmd: &mut ccomp::CompileCommand,
     t: &Target,
     targets: &HashMap<String, (Target, Cell<Option<PathBuf>>)>,
     opts: &BuildOptions,
@@ -804,7 +804,7 @@ fn build_target(
     let ink_ctx = inkwell::context::Context::create();
     let mut ctx = CompCtx::new(&ink_ctx, "");
     ctx.flags.prepass = false;
-    let mut cc = cc::CompileCommand::new();
+    let mut cc = ccomp::CompileCommand::new();
     let rebuild = resolve_deps(&ctx, &mut cc, t, targets, opts)?;
     let mut changed = rebuild;
     match t.target_type {
@@ -879,7 +879,7 @@ fn build_target(
             output.push(name);
             cc.objs(paths.into_iter().map(|([x, _], _)| x));
             cc.output(&output);
-            let code = cc.build_cmd()?.status_anyhow()?.code().unwrap_or(-1);
+            let code = cc.run_command()?()?;
             if code != 0 {
                 anyhow::bail!("C compiler exited with code {code}")
             }
@@ -958,7 +958,7 @@ fn build_target(
             cc.lib(true);
             cc.objs(paths.into_iter().flat_map(|x| x.0));
             cc.output(&output);
-            let code = cc.build_cmd()?.status_anyhow()?.code().unwrap_or(-1);
+            let code = cc.run_command()?()?;
             if code != 0 {
                 anyhow::bail!("C compiler exited with code {code}")
             }

--- a/cobalt-build/src/build.rs
+++ b/cobalt-build/src/build.rs
@@ -243,6 +243,7 @@ pub struct BuildOptions<'a> {
     pub continue_build: bool,
     pub continue_comp: bool,
     pub rebuild: bool,
+    pub no_default_link: bool,
     pub triple: &'a inkwell::targets::TargetTriple,
     pub profile: &'a str,
     pub link_dirs: Vec<&'a str>,
@@ -567,6 +568,7 @@ pub fn build_target_single(
     ctx.flags.prepass = false;
     let mut cc = ccomp::CompileCommand::new();
     cc.link_dir("$ORIGIN");
+    cc.no_default_link = opts.no_default_link;
     resolve_deps_internal(&ctx, &mut cc, t, pkg, v, plan, opts)?;
     match t.target_type {
         TargetType::Executable => {
@@ -681,7 +683,6 @@ pub fn build_target_single(
                 })?;
             let mut output = opts.build_dir.to_path_buf();
             output.push(name);
-            let mut cc = ccomp::CompileCommand::new();
             cc.lib(true);
             cc.objs(paths.into_iter().flat_map(|x| x.0));
             cc.output(&output);
@@ -805,6 +806,7 @@ fn build_target(
     let mut ctx = CompCtx::new(&ink_ctx, "");
     ctx.flags.prepass = false;
     let mut cc = ccomp::CompileCommand::new();
+    cc.no_default_link = opts.no_default_link;
     let rebuild = resolve_deps(&ctx, &mut cc, t, targets, opts)?;
     let mut changed = rebuild;
     match t.target_type {

--- a/cobalt-build/src/ccomp.rs
+++ b/cobalt-build/src/ccomp.rs
@@ -366,9 +366,7 @@ impl CompileCommand {
         if let Some(target) = self.target_.as_ref() {
             build.target(target);
         }
-        if self.no_default_link {
-            build.flag_if_supported("-nodefaultlibs");
-        }
+        build.flag_if_supported("-nodefaultlibs");
         self.tool = Some(build.try_get_compiler()?);
         self.modified = false;
         Ok(())

--- a/cobalt-build/src/ccomp.rs
+++ b/cobalt-build/src/ccomp.rs
@@ -11,7 +11,6 @@ mod prelude {
     pub use os_str_bytes::{OsStrBytes, OsStringBytes};
     pub use std::borrow::Cow;
 }
-use os_str_bytes::OsStrBytes;
 #[allow(unused_imports)]
 use prelude::*;
 pub use std::ffi::*;

--- a/cobalt-build/src/lib.rs
+++ b/cobalt-build/src/lib.rs
@@ -1,8 +1,10 @@
 #![allow(clippy::type_complexity)]
 pub mod build;
-pub mod cc;
+pub mod ccomp;
 pub mod graph;
 pub mod libs;
+#[cfg(lld_enabled)]
+pub mod lld;
 pub mod opt;
 pub mod pkg;
 

--- a/cobalt-build/src/lld.rs
+++ b/cobalt-build/src/lld.rs
@@ -28,7 +28,6 @@ pub fn lld_link<I: IntoIterator<Item = T>, T: Into<Vec<u8>>>(
         .map(CString::new)
         .collect::<Result<Vec<_>, NulError>>()
         .expect("Arguments to lld_link cannot contain null!");
-    println!("{args:?}");
     unsafe {
         #[allow(clippy::redundant_closure)] // lifetime error if a closure is not used
         glue::ffi::lld_entry(

--- a/cobalt-build/src/lld.rs
+++ b/cobalt-build/src/lld.rs
@@ -1,0 +1,47 @@
+use cxx::UniquePtr;
+use std::pin::Pin;
+use std::sync::Mutex;
+mod glue;
+pub mod llvm_ostream {
+    use super::*;
+    pub use glue::ffi::string_ostream as from_string;
+    pub fn outs() -> Pin<&'static mut OStream> {
+        unsafe { Pin::new_unchecked(&mut *glue::ffi::outs_ptr()) }
+    }
+    pub fn errs() -> Pin<&'static mut OStream> {
+        unsafe { Pin::new_unchecked(&mut *glue::ffi::errs_ptr()) }
+    }
+    pub fn file_ostream<P: AsRef<[u8]>>(path: P) -> Result<UniquePtr<OStream>, cxx::Exception> {
+        glue::ffi::file_ostream(path.as_ref())
+    }
+}
+pub use glue::ffi::raw_ostream as OStream;
+pub use glue::LldReturn;
+pub static LLD_CAN_RUN: Mutex<bool> = Mutex::new(true);
+pub fn lld_link<'a, I: IntoIterator<Item = &'a str>>(
+    args: I,
+    stdout: Option<Pin<&mut OStream>>,
+    stderr: Option<Pin<&mut OStream>>,
+) -> i32 {
+    let mut lock = LLD_CAN_RUN.lock().unwrap();
+    if !*lock {
+        std::mem::drop(lock);
+        panic!("LLD is in an invalid state and cannot run!")
+    }
+    let mut ret = LldReturn::default();
+    unsafe {
+        use std::ffi::CStr;
+        #[allow(clippy::redundant_closure)]
+        glue::ffi::lld_entry(
+            &args
+                .into_iter()
+                .map(|c| CStr::from_bytes_until_nul(c.as_bytes()).unwrap().as_ptr())
+                .collect::<Vec<_>>(),
+            stdout.unwrap_or_else(|| llvm_ostream::outs()),
+            stderr.unwrap_or_else(|| llvm_ostream::errs()),
+            Pin::new(&mut ret),
+        );
+    }
+    *lock = ret.again;
+    ret.code
+}

--- a/cobalt-build/src/lld/glue.rs
+++ b/cobalt-build/src/lld/glue.rs
@@ -1,34 +1,25 @@
 #[cxx::bridge(namespace = "llvm")]
 pub mod ffi {
-    extern "Rust" {
-        type LldReturn;
-        fn set_ret_code(ret: &mut LldReturn, code: i32);
-        fn set_ret_gain(ret: &mut LldReturn, again: bool);
+    enum LldFlavor {
+        Elf,
+        Coff,
+        MachO,
+        Wasm,
     }
     unsafe extern "C++" {
         include!("llvm/Support/raw_ostream.h");
         include!("cobalt-build/cxx/lld.hpp");
         type raw_ostream;
+        type LldFlavor;
         unsafe fn lld_entry(
-            argv: &[*const c_char],
+            argv: &mut [*const c_char],
             stdout: Pin<&mut raw_ostream>,
             stderr: Pin<&mut raw_ostream>,
-            ret: Pin<&mut LldReturn>,
-        );
+            flavor: LldFlavor,
+        ) -> i32;
         fn outs_ptr() -> *mut raw_ostream;
         fn errs_ptr() -> *mut raw_ostream;
         fn string_ostream(buf: Pin<&mut CxxString>) -> UniquePtr<raw_ostream>;
         fn file_ostream(path: &[u8]) -> Result<UniquePtr<raw_ostream>>;
     }
-}
-#[derive(Default, Debug, Clone, Copy)]
-pub struct LldReturn {
-    pub code: i32,
-    pub again: bool,
-}
-fn set_ret_code(ret: &mut LldReturn, code: i32) {
-    ret.code = code;
-}
-fn set_ret_gain(ret: &mut LldReturn, again: bool) {
-    ret.again = again;
 }

--- a/cobalt-build/src/lld/glue.rs
+++ b/cobalt-build/src/lld/glue.rs
@@ -1,0 +1,34 @@
+#[cxx::bridge(namespace = "llvm")]
+pub mod ffi {
+    extern "Rust" {
+        type LldReturn;
+        fn set_ret_code(ret: &mut LldReturn, code: i32);
+        fn set_ret_gain(ret: &mut LldReturn, again: bool);
+    }
+    unsafe extern "C++" {
+        include!("llvm/Support/raw_ostream.h");
+        include!("cobalt-build/cxx/lld.hpp");
+        type raw_ostream;
+        unsafe fn lld_entry(
+            argv: &[*const c_char],
+            stdout: Pin<&mut raw_ostream>,
+            stderr: Pin<&mut raw_ostream>,
+            ret: Pin<&mut LldReturn>,
+        );
+        fn outs_ptr() -> *mut raw_ostream;
+        fn errs_ptr() -> *mut raw_ostream;
+        fn string_ostream(buf: Pin<&mut CxxString>) -> UniquePtr<raw_ostream>;
+        fn file_ostream(path: &[u8]) -> Result<UniquePtr<raw_ostream>>;
+    }
+}
+#[derive(Default, Debug, Clone, Copy)]
+pub struct LldReturn {
+    pub code: i32,
+    pub again: bool,
+}
+fn set_ret_code(ret: &mut LldReturn, code: i32) {
+    ret.code = code;
+}
+fn set_ret_gain(ret: &mut LldReturn, again: bool) {
+    ret.again = again;
+}

--- a/cobalt-build/src/pkg.rs
+++ b/cobalt-build/src/pkg.rs
@@ -601,6 +601,7 @@ fn install_single(
             continue_comp: false,
             continue_build: false,
             rebuild: true,
+            no_default_link: false,
             profile: "default",
             triple: &inkwell::targets::TargetTriple::create(&opts.target),
             link_dirs: vec![],

--- a/cobalt-cli/src/main.rs
+++ b/cobalt-cli/src/main.rs
@@ -907,7 +907,7 @@ fn driver() -> anyhow::Result<()> {
             }
             let ctx = CompCtx::with_flags(&ink_ctx, &input, flags);
             ctx.module.set_triple(&trip);
-            let mut cc = cc::CompileCommand::new();
+            let mut cc = ccomp::CompileCommand::new();
             cc.target(&triple);
             {
                 reporter.nlibs = linked.len();
@@ -1045,10 +1045,9 @@ fn driver() -> anyhow::Result<()> {
                             let tmp = temp_file::with_contents(mb.as_slice());
                             cc.obj(tmp.path());
                             cc.output(output.unwrap());
-                            let mut cmd = cc.build_cmd()?;
-                            let (res, cmd_time) = try_timeit(|| cmd.status_anyhow())?;
+                            let cmd = cc.run_command()?;
+                            let (code, cmd_time) = try_timeit(cmd)?;
                             reporter.cmd_time = Some(cmd_time);
-                            let code = res.code().unwrap_or(-1);
                             if code != 0 {
                                 Err(Exit(code))?
                             }
@@ -1062,10 +1061,9 @@ fn driver() -> anyhow::Result<()> {
                                 cc.lib(true);
                                 cc.objs([tmp1.path(), tmp2.path()]);
                                 cc.output(&output);
-                                let mut cmd = cc.build_cmd()?;
-                                let (res, cmd_time) = try_timeit(|| cmd.status_anyhow())?;
+                                let cmd = cc.run_command()?;
+                                let (code, cmd_time) = try_timeit(cmd)?;
                                 reporter.cmd_time = Some(cmd_time);
-                                let code = res.code().unwrap_or(-1);
                                 if code != 0 {
                                     Err(Exit(code))?
                                 }
@@ -1279,7 +1277,7 @@ fn driver() -> anyhow::Result<()> {
             let mut ctx = CompCtx::new(&ink_ctx, &input);
             ctx.flags.dbg_mangle = true;
             ctx.module.set_triple(&TargetMachine::get_default_triple());
-            let mut cc = cc::CompileCommand::new();
+            let mut cc = ccomp::CompileCommand::new();
             {
                 reporter.nlibs = linked.len();
                 let start = Instant::now();
@@ -1552,7 +1550,7 @@ fn driver() -> anyhow::Result<()> {
             }
             let ctx = CompCtx::with_flags(&ink_ctx, &input, flags);
             ctx.module.set_triple(&trip);
-            let mut cc = cc::CompileCommand::new();
+            let mut cc = ccomp::CompileCommand::new();
             cc.target(&triple);
             {
                 reporter.nlibs = linked.len();
@@ -1837,7 +1835,7 @@ fn driver() -> anyhow::Result<()> {
                 }
                 let ctx = CompCtx::with_flags(&ink_ctx, "base-module", flags);
                 ctx.module.set_triple(&trip);
-                let mut cc = cc::CompileCommand::new();
+                let mut cc = ccomp::CompileCommand::new();
                 cc.target(&triple);
                 {
                     reporter.nlibs = linked.len();
@@ -2034,10 +2032,9 @@ fn driver() -> anyhow::Result<()> {
                         if is_lib { "lib" } else { "exe" }
                     ))?);
                     cc.lib(is_lib);
-                    let mut cmd = cc.build_cmd()?;
-                    let (res, cmd_time) = try_timeit(|| cmd.status_anyhow())?;
+                    let cmd = cc.run_command()?;
+                    let (code, cmd_time) = try_timeit(cmd)?;
                     reporter.cmd_time = Some(cmd_time);
-                    let code = res.code().unwrap_or(-1);
                     if code != 0 {
                         Err(Exit(code))?
                     }
@@ -2274,7 +2271,7 @@ fn driver() -> anyhow::Result<()> {
                 }
                 let ctx = CompCtx::with_flags(&ink_ctx, "multi-jit", flags);
                 ctx.module.set_triple(&trip);
-                let mut cc = cc::CompileCommand::new();
+                let mut cc = ccomp::CompileCommand::new();
                 cc.target(&triple);
                 {
                     reporter.nlibs = linked.len();
@@ -2591,7 +2588,7 @@ fn driver() -> anyhow::Result<()> {
                 }
                 let ctx = CompCtx::with_flags(&ink_ctx, "multi-check", flags);
                 ctx.module.set_triple(&trip);
-                let mut cc = cc::CompileCommand::new();
+                let mut cc = ccomp::CompileCommand::new();
                 cc.target(&triple);
                 {
                     reporter.nlibs = linked.len();

--- a/cobalt-cli/src/main.rs
+++ b/cobalt-cli/src/main.rs
@@ -7,6 +7,7 @@ use inkwell::execution_engine::FunctionLookupError;
 use inkwell::module::Module;
 use inkwell::targets::*;
 use miette::Severity;
+use std::ffi::OsString;
 use std::fmt;
 use std::io::{prelude::*, BufReader};
 use std::path::{Path, PathBuf};
@@ -128,6 +129,9 @@ enum Cli {
         /// don't search default directories for libraries
         #[arg(long)]
         no_default_link: bool,
+        /// additional arguments to pass to the linker
+        #[arg(short = 'X', long = "linker")]
+        linker_args: Vec<OsString>,
         /// print timings
         #[arg(long)]
         timings: bool,
@@ -257,6 +261,9 @@ enum MultiSubcommand {
         /// don't search default directories for libraries
         #[arg(long)]
         no_default_link: bool,
+        /// additional arguments to pass to the linker
+        #[arg(short = 'X', long = "linker")]
+        linker_args: Vec<OsString>,
         /// print timings
         #[arg(long)]
         timings: bool,
@@ -638,6 +645,7 @@ fn driver() -> anyhow::Result<()> {
             continue_if_err,
             debug_mangle,
             no_default_link,
+            linker_args,
             timings,
         } => {
             struct Reporter {
@@ -877,6 +885,7 @@ fn driver() -> anyhow::Result<()> {
             let mut cc = ccomp::CompileCommand::new();
             cc.target(&triple);
             cc.no_default_link = no_default_link;
+            cc.extra_args(linker_args);
             {
                 reporter.nlibs = linked.len();
                 let start = Instant::now();
@@ -1511,6 +1520,7 @@ fn driver() -> anyhow::Result<()> {
                 profile,
                 debug_mangle,
                 no_default_link,
+                linker_args,
                 timings,
             } => {
                 struct Reporter {
@@ -1709,6 +1719,7 @@ fn driver() -> anyhow::Result<()> {
                 let mut cc = ccomp::CompileCommand::new();
                 cc.target(&triple);
                 cc.no_default_link = no_default_link;
+                cc.extra_args(linker_args);
                 {
                     reporter.nlibs = linked.len();
                     let start = Instant::now();

--- a/cobalt-cli/src/main.rs
+++ b/cobalt-cli/src/main.rs
@@ -67,22 +67,27 @@ const INIT_NEEDED: InitializationConfig = InitializationConfig {
     machine_code: true,
 };
 static LONG_VERSION: &str = formatcp!(
-    "{}\nLLVM version {}{}{}",
+    "{}\nLLVM version {}\nGit {}\nLLD {}\nDebug {}",
     env!("CARGO_PKG_VERSION"),
     cobalt_llvm::LLVM_VERSION,
     if cfg!(has_git) {
         formatcp!(
-            "\nGit commit {} on branch {}",
+            "commit {} on branch {}",
             str_index!(env!("GIT_COMMIT"), ..6),
             env!("GIT_BRANCH")
         )
     } else {
-        ""
+        "not found"
+    },
+    if ccomp::CompileCommand::USING_LLD {
+        "enabled"
+    } else {
+        "disabled"
     },
     if cfg!(debug_assertions) {
-        "\nDebug Build"
+        "enabled"
     } else {
-        ""
+        "disabled"
     }
 );
 #[derive(Debug, Clone, Parser)]

--- a/cobalt-cli/src/main.rs
+++ b/cobalt-cli/src/main.rs
@@ -1294,11 +1294,11 @@ fn driver() -> anyhow::Result<()> {
                 .create_jit_execution_engine(inkwell::OptimizationLevel::None)
                 .expect("Couldn't create execution engine!");
             unsafe {
-                let main_fn = match ee.get_function_value("main") {
+                let main_fn = match ee.get_function_value("_start") {
                     Ok(main_fn) => main_fn,
                     Err(FunctionLookupError::JITNotEnabled) => panic!("JIT not enabled here"),
                     Err(FunctionLookupError::FunctionNotFound) => {
-                        eprintln!("couldn't find symbol 'main'");
+                        eprintln!("couldn't find symbol '_start'");
                         Err(Exit(255))?
                     }
                 };
@@ -2197,11 +2197,11 @@ fn driver() -> anyhow::Result<()> {
                 }
                 reporter.finish();
                 unsafe {
-                    let main_fn = match ee.get_function_value("main") {
+                    let main_fn = match ee.get_function_value("_start") {
                         Ok(main_fn) => main_fn,
                         Err(FunctionLookupError::JITNotEnabled) => panic!("JIT not enabled here"),
                         Err(FunctionLookupError::FunctionNotFound) => {
-                            eprintln!("couldn't find symbol 'main'");
+                            eprintln!("couldn't find symbol '_start'");
                             Err(Exit(255))?
                         }
                     };

--- a/cobalt-cli/src/main.rs
+++ b/cobalt-cli/src/main.rs
@@ -630,7 +630,7 @@ fn driver() -> anyhow::Result<()> {
             input,
             output,
             linked,
-            mut link_dirs,
+            link_dirs,
             headers,
             triple,
             emit,
@@ -778,39 +778,6 @@ fn driver() -> anyhow::Result<()> {
                 }
             }
             let mut reporter = Reporter::new(timings);
-            if !no_default_link {
-                if let Some(pwd) = std::env::current_dir()
-                    .ok()
-                    .and_then(|pwd| pwd.to_str().map(String::from))
-                {
-                    link_dirs.insert(0, pwd);
-                }
-                if let Ok(home) = std::env::var("HOME") {
-                    link_dirs.extend_from_slice(&[
-                        format!("{home}/.cobalt/installed/lib"),
-                        format!("{home}/.local/lib/cobalt"),
-                        "/usr/local/lib/cobalt/installed/lib".to_string(),
-                        "/usr/lib/cobalt/installed/lib".to_string(),
-                        "/lib/cobalt/installed/lib".to_string(),
-                        "/usr/local/lib".to_string(),
-                        "/usr/lib".to_string(),
-                        "/lib".to_string(),
-                    ]);
-                } else {
-                    link_dirs.extend(
-                        [
-                            "/usr/local/lib/cobalt/installed/lib",
-                            "/usr/lib/cobalt/installed/lib",
-                            "/lib/cobalt/installed/lib",
-                            "/usr/local/lib",
-                            "/usr/lib",
-                            "/lib",
-                        ]
-                        .into_iter()
-                        .map(String::from),
-                    );
-                }
-            }
             let code = {
                 let start = Instant::now();
                 let code = if input == "-" {
@@ -909,6 +876,7 @@ fn driver() -> anyhow::Result<()> {
             ctx.module.set_triple(&trip);
             let mut cc = ccomp::CompileCommand::new();
             cc.target(&triple);
+            cc.no_default_link = no_default_link;
             {
                 reporter.nlibs = linked.len();
                 let start = Instant::now();
@@ -1100,7 +1068,7 @@ fn driver() -> anyhow::Result<()> {
         Cli::Jit {
             input,
             linked,
-            mut link_dirs,
+            link_dirs,
             headers,
             profile,
             continue_if_err,
@@ -1218,39 +1186,6 @@ fn driver() -> anyhow::Result<()> {
                 }
             }
             let mut reporter = Reporter::new(timings);
-            if !no_default_link {
-                if let Some(pwd) = std::env::current_dir()
-                    .ok()
-                    .and_then(|pwd| pwd.to_str().map(String::from))
-                {
-                    link_dirs.insert(0, pwd);
-                }
-                if let Ok(home) = std::env::var("HOME") {
-                    link_dirs.extend_from_slice(&[
-                        format!("{home}/.cobalt/installed/lib"),
-                        format!("{home}/.local/lib/cobalt"),
-                        "/usr/local/lib/cobalt/installed/lib".to_string(),
-                        "/usr/lib/cobalt/installed/lib".to_string(),
-                        "/lib/cobalt/installed/lib".to_string(),
-                        "/usr/local/lib".to_string(),
-                        "/usr/lib".to_string(),
-                        "/lib".to_string(),
-                    ]);
-                } else {
-                    link_dirs.extend(
-                        [
-                            "/usr/local/lib/cobalt/installed/lib",
-                            "/usr/lib/cobalt/installed/lib",
-                            "/lib/cobalt/installed/lib",
-                            "/usr/local/lib",
-                            "/usr/lib",
-                            "/lib",
-                        ]
-                        .into_iter()
-                        .map(String::from),
-                    );
-                }
-            }
             let code = {
                 let start = Instant::now();
                 let code = if input == "-" {
@@ -1278,6 +1213,7 @@ fn driver() -> anyhow::Result<()> {
             ctx.flags.dbg_mangle = true;
             ctx.module.set_triple(&TargetMachine::get_default_triple());
             let mut cc = ccomp::CompileCommand::new();
+            cc.no_default_link = no_default_link;
             {
                 reporter.nlibs = linked.len();
                 let start = Instant::now();
@@ -1367,7 +1303,7 @@ fn driver() -> anyhow::Result<()> {
         Cli::Check {
             input,
             linked,
-            mut link_dirs,
+            link_dirs,
             headers,
             no_default_link,
             timings,
@@ -1473,39 +1409,6 @@ fn driver() -> anyhow::Result<()> {
                 }
             }
             let mut reporter = Reporter::new(timings);
-            if !no_default_link {
-                if let Some(pwd) = std::env::current_dir()
-                    .ok()
-                    .and_then(|pwd| pwd.to_str().map(String::from))
-                {
-                    link_dirs.insert(0, pwd);
-                }
-                if let Ok(home) = std::env::var("HOME") {
-                    link_dirs.extend_from_slice(&[
-                        format!("{home}/.cobalt/installed/lib"),
-                        format!("{home}/.local/lib/cobalt"),
-                        "/usr/local/lib/cobalt/installed/lib".to_string(),
-                        "/usr/lib/cobalt/installed/lib".to_string(),
-                        "/lib/cobalt/installed/lib".to_string(),
-                        "/usr/local/lib".to_string(),
-                        "/usr/lib".to_string(),
-                        "/lib".to_string(),
-                    ]);
-                } else {
-                    link_dirs.extend(
-                        [
-                            "/usr/local/lib/cobalt/installed/lib",
-                            "/usr/lib/cobalt/installed/lib",
-                            "/lib/cobalt/installed/lib",
-                            "/usr/local/lib",
-                            "/usr/lib",
-                            "/lib",
-                        ]
-                        .into_iter()
-                        .map(String::from),
-                    );
-                }
-            }
             let code = {
                 let start = Instant::now();
                 let code = if input == "-" {
@@ -1552,6 +1455,7 @@ fn driver() -> anyhow::Result<()> {
             ctx.module.set_triple(&trip);
             let mut cc = ccomp::CompileCommand::new();
             cc.target(&triple);
+            cc.no_default_link = no_default_link;
             {
                 reporter.nlibs = linked.len();
                 let start = Instant::now();
@@ -1600,7 +1504,7 @@ fn driver() -> anyhow::Result<()> {
                 inputs,
                 output,
                 linked,
-                mut link_dirs,
+                link_dirs,
                 headers,
                 triple,
                 emit,
@@ -1747,39 +1651,6 @@ fn driver() -> anyhow::Result<()> {
                     }
                 }
                 let mut reporter = Reporter::new(timings);
-                if !no_default_link {
-                    if let Some(pwd) = std::env::current_dir()
-                        .ok()
-                        .and_then(|pwd| pwd.to_str().map(String::from))
-                    {
-                        link_dirs.insert(0, pwd);
-                    }
-                    if let Ok(home) = std::env::var("HOME") {
-                        link_dirs.extend_from_slice(&[
-                            format!("{home}/.cobalt/installed/lib"),
-                            format!("{home}/.local/lib/cobalt"),
-                            "/usr/local/lib/cobalt/installed/lib".to_string(),
-                            "/usr/lib/cobalt/installed/lib".to_string(),
-                            "/lib/cobalt/installed/lib".to_string(),
-                            "/usr/local/lib".to_string(),
-                            "/usr/lib".to_string(),
-                            "/lib".to_string(),
-                        ]);
-                    } else {
-                        link_dirs.extend(
-                            [
-                                "/usr/local/lib/cobalt/installed/lib",
-                                "/usr/lib/cobalt/installed/lib",
-                                "/lib/cobalt/installed/lib",
-                                "/usr/local/lib",
-                                "/usr/lib",
-                                "/lib",
-                            ]
-                            .into_iter()
-                            .map(String::from),
-                        );
-                    }
-                }
                 let codes = inputs
                     .iter()
                     .map(|input| {
@@ -1837,6 +1708,7 @@ fn driver() -> anyhow::Result<()> {
                 ctx.module.set_triple(&trip);
                 let mut cc = ccomp::CompileCommand::new();
                 cc.target(&triple);
+                cc.no_default_link = no_default_link;
                 {
                     reporter.nlibs = linked.len();
                     let start = Instant::now();
@@ -2044,7 +1916,7 @@ fn driver() -> anyhow::Result<()> {
             MultiSubcommand::Jit {
                 inputs,
                 linked,
-                mut link_dirs,
+                link_dirs,
                 headers,
                 profile,
                 no_default_link,
@@ -2181,39 +2053,6 @@ fn driver() -> anyhow::Result<()> {
                     }
                 }
                 let mut reporter = Reporter::new(timings);
-                if !no_default_link {
-                    if let Some(pwd) = std::env::current_dir()
-                        .ok()
-                        .and_then(|pwd| pwd.to_str().map(String::from))
-                    {
-                        link_dirs.insert(0, pwd);
-                    }
-                    if let Ok(home) = std::env::var("HOME") {
-                        link_dirs.extend_from_slice(&[
-                            format!("{home}/.cobalt/installed/lib"),
-                            format!("{home}/.local/lib/cobalt"),
-                            "/usr/local/lib/cobalt/installed/lib".to_string(),
-                            "/usr/lib/cobalt/installed/lib".to_string(),
-                            "/lib/cobalt/installed/lib".to_string(),
-                            "/usr/local/lib".to_string(),
-                            "/usr/lib".to_string(),
-                            "/lib".to_string(),
-                        ]);
-                    } else {
-                        link_dirs.extend(
-                            [
-                                "/usr/local/lib/cobalt/installed/lib",
-                                "/usr/lib/cobalt/installed/lib",
-                                "/lib/cobalt/installed/lib",
-                                "/usr/local/lib",
-                                "/usr/lib",
-                                "/lib",
-                            ]
-                            .into_iter()
-                            .map(String::from),
-                        );
-                    }
-                }
                 let codes = inputs
                     .iter()
                     .map(|input| {
@@ -2273,6 +2112,7 @@ fn driver() -> anyhow::Result<()> {
                 ctx.module.set_triple(&trip);
                 let mut cc = ccomp::CompileCommand::new();
                 cc.target(&triple);
+                cc.no_default_link = no_default_link;
                 {
                     reporter.nlibs = linked.len();
                     let start = Instant::now();
@@ -2364,7 +2204,7 @@ fn driver() -> anyhow::Result<()> {
             MultiSubcommand::Check {
                 inputs,
                 linked,
-                mut link_dirs,
+                link_dirs,
                 headers,
                 no_default_link,
                 timings,
@@ -2507,39 +2347,6 @@ fn driver() -> anyhow::Result<()> {
                     }
                 }
                 let mut reporter = Reporter::new(timings);
-                if !no_default_link {
-                    if let Some(pwd) = std::env::current_dir()
-                        .ok()
-                        .and_then(|pwd| pwd.to_str().map(String::from))
-                    {
-                        link_dirs.insert(0, pwd);
-                    }
-                    if let Ok(home) = std::env::var("HOME") {
-                        link_dirs.extend_from_slice(&[
-                            format!("{home}/.cobalt/installed/lib"),
-                            format!("{home}/.local/lib/cobalt"),
-                            "/usr/local/lib/cobalt/installed/lib".to_string(),
-                            "/usr/lib/cobalt/installed/lib".to_string(),
-                            "/lib/cobalt/installed/lib".to_string(),
-                            "/usr/local/lib".to_string(),
-                            "/usr/lib".to_string(),
-                            "/lib".to_string(),
-                        ]);
-                    } else {
-                        link_dirs.extend(
-                            [
-                                "/usr/local/lib/cobalt/installed/lib",
-                                "/usr/lib/cobalt/installed/lib",
-                                "/lib/cobalt/installed/lib",
-                                "/usr/local/lib",
-                                "/usr/lib",
-                                "/lib",
-                            ]
-                            .into_iter()
-                            .map(String::from),
-                        );
-                    }
-                }
                 let codes = inputs
                     .iter()
                     .map(|input| {
@@ -2590,6 +2397,7 @@ fn driver() -> anyhow::Result<()> {
                 ctx.module.set_triple(&trip);
                 let mut cc = ccomp::CompileCommand::new();
                 cc.target(&triple);
+                cc.no_default_link = no_default_link;
                 {
                     reporter.nlibs = linked.len();
                     let start = Instant::now();
@@ -2738,7 +2546,7 @@ fn driver() -> anyhow::Result<()> {
                 source_dir,
                 build_dir,
                 profile,
-                mut link_dirs,
+                link_dirs,
                 no_default_link,
                 triple,
                 targets,
@@ -2811,30 +2619,6 @@ fn driver() -> anyhow::Result<()> {
                         )
                     }
                 };
-                if !no_default_link {
-                    if let Ok(home) = std::env::var("HOME") {
-                        link_dirs.extend_from_slice(&[
-                            format!("{home}/.cobalt/installed/lib"),
-                            format!("{home}/.local/lib/cobalt"),
-                            "/usr/local/lib/cobalt/installed/lib".to_string(),
-                            "/usr/lib/cobalt/installed/lib".to_string(),
-                            "/lib/cobalt/installed/lib".to_string(),
-                            "/usr/local/lib".to_string(),
-                            "/usr/lib".to_string(),
-                            "/lib".to_string(),
-                        ]);
-                    } else {
-                        link_dirs.extend(
-                            [
-                                "/usr/local/lib/cobalt/installed/lib",
-                                "/usr/lib/cobalt/installed/lib",
-                                "/lib/cobalt/installed/lib",
-                            ]
-                            .into_iter()
-                            .map(String::from),
-                        );
-                    }
-                }
                 let source_dir: PathBuf = source_dir.map_or(project_dir.clone(), PathBuf::from);
                 let build_dir: PathBuf = build_dir.map_or_else(
                     || {
@@ -2866,6 +2650,7 @@ fn driver() -> anyhow::Result<()> {
                         continue_build: false,
                         continue_comp: false,
                         rebuild,
+                        no_default_link,
                         link_dirs: link_dirs.iter().map(|x| x.as_str()).collect(),
                     },
                 )?;
@@ -2875,7 +2660,7 @@ fn driver() -> anyhow::Result<()> {
                 source_dir,
                 build_dir,
                 profile,
-                mut link_dirs,
+                link_dirs,
                 no_default_link,
                 target,
                 rebuild,
@@ -2948,33 +2733,6 @@ fn driver() -> anyhow::Result<()> {
                         )
                     }
                 };
-                if !no_default_link {
-                    if let Ok(home) = std::env::var("HOME") {
-                        link_dirs.extend_from_slice(&[
-                            format!("{home}/.cobalt/installed/lib"),
-                            format!("{home}/.local/lib/cobalt"),
-                            "/usr/local/lib/cobalt/installed/lib".to_string(),
-                            "/usr/lib/cobalt/installed/lib".to_string(),
-                            "/lib/cobalt/installed/lib".to_string(),
-                            "/usr/local/lib".to_string(),
-                            "/usr/lib".to_string(),
-                            "/lib".to_string(),
-                        ]);
-                    } else {
-                        link_dirs.extend(
-                            [
-                                "/usr/local/lib/cobalt/installed/lib",
-                                "/usr/lib/cobalt/installed/lib",
-                                "/lib/cobalt/installed/lib",
-                                "/usr/local/lib",
-                                "/usr/lib",
-                                "/lib",
-                            ]
-                            .into_iter()
-                            .map(String::from),
-                        );
-                    }
-                }
                 let source_dir: PathBuf = source_dir.map_or(project_dir.clone(), PathBuf::from);
                 let build_dir: PathBuf = build_dir.map_or_else(
                     || {
@@ -3026,6 +2784,7 @@ fn driver() -> anyhow::Result<()> {
                         continue_build: false,
                         continue_comp: false,
                         rebuild,
+                        no_default_link,
                         link_dirs: link_dirs.iter().map(|x| x.as_str()).collect(),
                     },
                 )?;

--- a/cobalt-llvm/build.rs
+++ b/cobalt-llvm/build.rs
@@ -262,6 +262,7 @@ fn main() {
         "cargo:rustc-env=LLVM_INCLUDE_DIR={}",
         llvm_config("--includedir")
     );
+    println!("cargo:rustc-env=LLVM_LIBS_DIR={}", llvm_config("--libdir"));
     if cfg!(feature = "no-llvm-linking") {
         // exit early as we don't need to do anything and llvm-config isn't needed at all
         return;

--- a/cobalt-llvm/build.rs
+++ b/cobalt-llvm/build.rs
@@ -258,7 +258,10 @@ fn main() {
     println!("cargo:rerun-if-env-changed={}", ENV_FORCE_FFI);
 
     println!("cargo:rustc-env=LLVM_VERSION={}", llvm_config("--version"));
-
+    println!(
+        "cargo:rustc-env=LLVM_INCLUDE_DIR={}",
+        llvm_config("--includedir")
+    );
     if cfg!(feature = "no-llvm-linking") {
         // exit early as we don't need to do anything and llvm-config isn't needed at all
         return;

--- a/cobalt-llvm/src/lib.rs
+++ b/cobalt-llvm/src/lib.rs
@@ -7,6 +7,7 @@ pub use llvm_sys_16 as llvm_sys;
 pub use inkwell;
 
 pub const LLVM_VERSION: &str = env!("LLVM_VERSION");
+pub const LLVM_INCLUDE_DIR: &str = env!("LLVM_INCLUDE_DIR");
 
 #[cfg(feature = "llvm-15")]
 #[macro_export]

--- a/cobalt-llvm/src/lib.rs
+++ b/cobalt-llvm/src/lib.rs
@@ -8,6 +8,7 @@ pub use inkwell;
 
 pub const LLVM_VERSION: &str = env!("LLVM_VERSION");
 pub const LLVM_INCLUDE_DIR: &str = env!("LLVM_INCLUDE_DIR");
+pub const LLVM_LIBS_DIR: &str = env!("LLVM_LIBS_DIR");
 
 #[cfg(feature = "llvm-15")]
 #[macro_export]


### PR DESCRIPTION
Right now, linking is done by externally invoking the C compiler. This is very slow in comparison to the rest of the compilation, sometimes taking up to 80% of compilation time. To mitigate this, it's being replaced with LLD, only falling back to an external compiler if it's not available.