### PR TITLE
Fix some more parser stuff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Run Clippy
-      run: cargo clippy --verbose -F no-llvm-linking
+      run: cargo clippy --manifest-path lang/Cargo.toml --verbose -F no-llvm-linking
   test:
     runs-on: ubuntu-latest
     steps:
@@ -22,9 +22,9 @@ jobs:
       with:
         version: "16.0"
     - name: Run Cargo Test
-      run: cargo test --verbose
+      run: cargo test --manifest-path lang/Cargo.toml  --verbose
   fmt:
     runs-on: ubuntu-latest
     steps:
     - name: Run Cargo Formatter
-      run: cargo fmt --verbose --check
+      run: cargo fmt --manifest-path lang/Cargo.toml  --verbose --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,5 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [checkout]
     steps:
+    - name: List files
+      run: ls
     - name: Run Cargo Formatter
       run: cargo fmt --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: Run Clippy, Tests, and Fmt
 
 on:
   workflow_dispatch:
-  
   push:
     branches: [main, pr-lints]
   pull_request:
@@ -12,19 +11,25 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v4
     - name: Run Clippy
-      run: cargo clippy --manifest-path lang/Cargo.toml --verbose -F no-llvm-linking
+      run: cargo clippy --verbose -F no-llvm-linking
   test:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v4
     - name: Install LLVM
       uses: KyleMayes/install-llvm-action@v1
       with:
         version: "16.0"
     - name: Run Cargo Test
-      run: cargo test --manifest-path lang/Cargo.toml  --verbose
+      run: cargo test --verbose
   fmt:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v4
     - name: Run Cargo Formatter
-      run: cargo fmt --manifest-path lang/Cargo.toml  --verbose --check
+      run: cargo fmt --verbose --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
       uses: actions/checkout@v4
     - name: Install LLVM
       uses: KyleMayes/install-llvm-action@v1
+      with:
+        version: "16.0"
     - name: Run Clippy
       run: cargo clippy -F no-llvm-linking
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Install LLVM
+      uses: KyleMayes/install-llvm-action@v1
     - name: Run Clippy
-      run: cargo clippy --verbose -F no-llvm-linking
+      run: cargo clippy -F no-llvm-linking
   test:
     runs-on: ubuntu-latest
     steps:
@@ -25,11 +27,11 @@ jobs:
       with:
         version: "16.0"
     - name: Run Cargo Test
-      run: cargo test --verbose
+      run: cargo test
   fmt:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Run Cargo Formatter
-      run: cargo fmt --verbose --check
+      run: cargo fmt --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,9 @@ jobs:
       with:
         version: "16.0"
     - name: Run Clippy
-      run: cargo clippy -F no-llvm-linking
+      run: cargo clippy
+      env:
+        RUSTFLAGS: "-Dwarnings"
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,12 @@ on:
 
 jobs:
   clippy:
+    runs-on: ubuntu-latest
     steps:
     - name: Run Clippy
       run: cargo clippy --verbose -F no-llvm-linking
   test:
+    runs-on: ubuntu-latest
     steps:
     - name: Install LLVM
       uses: KyleMayes/install-llvm-action@v1
@@ -22,6 +24,7 @@ jobs:
     - name: Run Cargo Test
       run: cargo test --verbose
   fmt:
+    runs-on: ubuntu-latest
     steps:
     - name: Run Cargo Formatter
       run: cargo fmt --verbose --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,12 @@ jobs:
       uses: KyleMayes/install-llvm-action@v1
       with:
         version: "16.0"
+    - name: Cache Build Outputs
+      uses: actions/cache@v3
+      with:
+        path: |
+          Cargo.lock
+          target/
     - name: Run Clippy
       run: cargo clippy
       env:
@@ -33,6 +39,12 @@ jobs:
       uses: KyleMayes/install-llvm-action@v1
       with:
         version: "16.0"
+    - name: Cache Build Outputs
+      uses: actions/cache@v3
+      with:
+        path: |
+          Cargo.lock
+          target/
     - name: Run Cargo Test
       run: cargo test
   fmt:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   
   push:
-    branches: [main]
+    branches: [main, pr-lints]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Cache Build Outputs
       uses: actions/cache@v3
       with:
+        key: test-${{ github.ref_name }}
         path: |
           Cargo.lock
           target/
@@ -42,6 +43,7 @@ jobs:
     - name: Cache Build Outputs
       uses: actions/cache@v3
       with:
+        key: test-${{ github.ref_name }}
         path: |
           Cargo.lock
           target/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Run Clippy, Tests, and Fmt
 on:
   workflow_dispatch:
   push:
-    branches: [main, pr-lints]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,11 @@ env:
  CARGO_TERM_COLOR: always
 
 jobs:
-  checkout:
+  clippy:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-  
-  setup:
-    runs-on: ubuntu-latest
-    steps:
     - name: Install LLVM
       uses: KyleMayes/install-llvm-action@v1
       with:
@@ -31,11 +27,6 @@ jobs:
         path: |
           Cargo.lock
           target/
-  
-  clippy:
-    runs-on: ubuntu-latest
-    needs: [checkout, setup]
-    steps:
     - name: Run Clippy
       run: cargo clippy
       env:
@@ -43,16 +34,27 @@ jobs:
   
   test:
     runs-on: ubuntu-latest
-    needs: [checkout, setup]
     steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install LLVM
+      uses: KyleMayes/install-llvm-action@v1
+      with:
+        version: "16.0"
+    - name: Cache Build Outputs
+      uses: actions/cache@v3
+      with:
+        key: test-${{ github.ref_name }}
+        path: |
+          Cargo.lock
+          target/
     - name: Run Cargo Test
       run: cargo test
   
   fmt:
     runs-on: ubuntu-latest
-    needs: [checkout]
     steps:
-    - name: List files
-      run: ls
+    - name: Checkout
+      uses: actions/checkout@v4
     - name: Run Cargo Formatter
       run: cargo fmt --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Run Clippy, Tests, and Fmt
 
 on:
+  workflow_dispatch:
+  
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Run Clippy, Tests, and Fmt
 on:
   push:
     branches: [main]
-  pull-request:
+  pull_request:
     branches: [main]
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+ CARGO_TERM_COLOR: always
+
 jobs:
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,10 @@ jobs:
     - name: Cache Build Outputs
       uses: actions/cache@v3
       with:
-        key: test-${{ github.ref_name }}
+        key: test-${{ github.ref_name }}-${{ hashFiles('**/src') }}
+        restore-keys: |
+          test-${{ github.ref_name }}-
+          test-
         path: |
           Cargo.lock
           target/
@@ -44,7 +47,10 @@ jobs:
     - name: Cache Build Outputs
       uses: actions/cache@v3
       with:
-        key: test-${{ github.ref_name }}
+        key: test-${{ github.ref_name }}-${{ hashFiles('**/src') }}
+        restore-keys: |
+          test-${{ github.ref_name }}-
+          test-
         path: |
           Cargo.lock
           target/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,15 @@ env:
  CARGO_TERM_COLOR: always
 
 jobs:
-  clippy:
+  checkout:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+  
+  setup:
+    runs-on: ubuntu-latest
+    steps:
     - name: Install LLVM
       uses: KyleMayes/install-llvm-action@v1
       with:
@@ -27,32 +31,26 @@ jobs:
         path: |
           Cargo.lock
           target/
+  
+  clippy:
+    runs-on: ubuntu-latest
+    needs: [checkout, setup]
+    steps:
     - name: Run Clippy
       run: cargo clippy
       env:
         RUSTFLAGS: "-Dwarnings"
+  
   test:
     runs-on: ubuntu-latest
+    needs: [checkout, setup]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Install LLVM
-      uses: KyleMayes/install-llvm-action@v1
-      with:
-        version: "16.0"
-    - name: Cache Build Outputs
-      uses: actions/cache@v3
-      with:
-        key: test-${{ github.ref_name }}
-        path: |
-          Cargo.lock
-          target/
     - name: Run Cargo Test
       run: cargo test
+  
   fmt:
     runs-on: ubuntu-latest
+    needs: [checkout]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
     - name: Run Cargo Formatter
       run: cargo fmt --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Run Clippy, Tests, and Fmt
+
+on:
+  push:
+    branches: [main]
+  pull-request:
+    branches: [main]
+
+jobs:
+  clippy:
+    steps:
+    - name: Run Clippy
+      run: cargo clippy --verbose -F no-llvm-linking
+  test:
+    steps:
+    - name: Install LLVM
+      uses: KyleMayes/install-llvm-action@v1
+      with:
+        version: "16.0"
+    - name: Run Cargo Test
+      run: cargo test --verbose
+  fmt:
+    steps:
+    - name: Run Cargo Formatter
+      run: cargo fmt --verbose --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "cobalt-parser",
   "cobalt-utils"
 ]
+resolver = "2"
 
 [workspace.package]
 version = "0.7.1"

--- a/cobalt-ast/src/ast/funcs.rs
+++ b/cobalt-ast/src/ast/funcs.rs
@@ -1145,7 +1145,7 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                                     });
                                     n += 1;
                                 } else {
-                                    ctx.with_vars(|v| {
+                                    let _ = ctx.with_vars(|v| {
                                         v.insert(
                                             &DottedName::local((name.clone(), unreachable_span())),
                                             Symbol(
@@ -1153,8 +1153,7 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                                                 VariableData::default(),
                                             ),
                                         )
-                                    })
-                                    .map_or((), |_| ());
+                                    });
                                 }
                             }
                         }
@@ -1436,7 +1435,7 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                                     });
                                     n += 1;
                                 } else {
-                                    ctx.with_vars(|v| {
+                                    let _ = ctx.with_vars(|v| {
                                         v.insert(
                                             &DottedName::local((name.clone(), unreachable_span())),
                                             Symbol(
@@ -1444,8 +1443,7 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                                                 VariableData::default(),
                                             ),
                                         )
-                                    })
-                                    .map_or((), |_| ());
+                                    });
                                 }
                             }
                         }

--- a/cobalt-ast/src/cfg.rs
+++ b/cobalt-ast/src/cfg.rs
@@ -286,21 +286,7 @@ pub struct DoubleMove<'src> {
 }
 impl PartialOrd for DoubleMove<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        if self.loc.offset() == other.loc.offset() {
-            if self.loc.len() == other.loc.len() {
-                let lprev = self.prev.unwrap_or(self.loc);
-                let rprev = other.prev.unwrap_or(other.loc);
-                if lprev.offset() == rprev.offset() {
-                    Some(lprev.len().cmp(&rprev.len()))
-                } else {
-                    Some(lprev.offset().cmp(&rprev.offset()))
-                }
-            } else {
-                Some(self.loc.len().cmp(&other.loc.len()))
-            }
-        } else {
-            Some(self.loc.offset().cmp(&other.loc.offset()))
-        }
+        Some(self.cmp(other))
     }
 }
 impl Ord for DoubleMove<'_> {
@@ -1019,7 +1005,9 @@ impl<'a, 'src, 'ctx> Cfg<'a, 'src, 'ctx> {
             .filter(|s| unsafe { (***s).name.1 } == ctx.lex_scope.get())
             .for_each(|m| unsafe {
                 let m = &**m;
-                let Location::Inst(i, _) = m.inst else {unreachable!("store locations should only be Location::Inst(_, 0)")};
+                let Location::Inst(i, _) = m.inst else {
+                    unreachable!("store locations should only be Location::Inst(_, 0)")
+                };
                 assert_eq!(
                     i.get_next_instruction()
                         .map(|i| (i.get_opcode(), i.get_num_operands())),

--- a/cobalt-ast/src/context.rs
+++ b/cobalt-ast/src/context.rs
@@ -289,7 +289,9 @@ impl<'src, 'ctx> CompCtx<'src, 'ctx> {
             let mut bytes = [0u8; 8];
             loop {
                 buf.read_exact(&mut bytes)?;
-                let Some(kind) = std::num::NonZeroU64::new(u64::from_be_bytes(bytes)) else {break};
+                let Some(kind) = std::num::NonZeroU64::new(u64::from_be_bytes(bytes)) else {
+                    break;
+                };
                 let guard = types::TYPE_SERIAL_REGISTRY.guard();
                 let info = types::TYPE_SERIAL_REGISTRY
                     .get(&kind, &guard)

--- a/cobalt-ast/src/types/agg.rs
+++ b/cobalt-ast/src/types/agg.rs
@@ -622,9 +622,11 @@ impl Type for SizedArray {
         self.elem().has_dtor(ctx)
     }
     fn ins_dtor<'src, 'ctx>(&'static self, val: &Value<'src, 'ctx>, ctx: &CompCtx<'src, 'ctx>) {
-        let Some(ib) = ctx.builder.get_insert_block() else {return};
-        let Some(f) = ib.get_parent() else {return};
-        let Some(pv) = val.addr(ctx) else {return};
+        let Some(ib) = ctx.builder.get_insert_block() else {
+            return;
+        };
+        let Some(f) = ib.get_parent() else { return };
+        let Some(pv) = val.addr(ctx) else { return };
         let at = self.llvm_type(ctx).unwrap();
         let bb = ctx.context.append_basic_block(f, "arr.dtor.loop");
         let ex = ctx.context.append_basic_block(f, "arr.dtor.exit");

--- a/cobalt-ast/src/types/custom.rs
+++ b/cobalt-ast/src/types/custom.rs
@@ -195,7 +195,8 @@ impl Type for Custom {
             return if attr.0 == "__base" {
                 Ok(Value {
                     data_type: self.base(),
-                    loc: remove_unreachable(attr.1).map_or(val.loc, |loc| merge_spans(val.loc, loc)),
+                    loc: remove_unreachable(attr.1)
+                        .map_or(val.loc, |loc| merge_spans(val.loc, loc)),
                     ..val
                 })
             } else if self.nom_info(ctx).transparent {
@@ -203,10 +204,10 @@ impl Type for Custom {
                 self.base().attr(val, attr, ctx)
             } else {
                 Err(invalid_attr(&val, attr.0, attr.1))
-            }
+            };
         };
         let Some(InterData::Function(FnData { mt, .. })) = field.inter_val else {
-            return Err(invalid_attr(&val, attr.0, attr.1))
+            return Err(invalid_attr(&val, attr.0, attr.1));
         };
         assert!(field
             .data_type
@@ -242,10 +243,11 @@ impl Type for Custom {
     }
     fn _has_ref_attr(&'static self, attr: &str, ctx: &CompCtx) -> bool {
         let Some(field) = self.static_attr(attr, ctx) else {
-            return attr == "__base"|| (self.nom_info(ctx).transparent && self.base()._has_mut_attr(attr, ctx));
+            return attr == "__base"
+                || (self.nom_info(ctx).transparent && self.base()._has_mut_attr(attr, ctx));
         };
         let Some(InterData::Function(FnData { mt, .. })) = field.inter_val else {
-            return false
+            return false;
         };
         assert!(field
             .data_type
@@ -263,10 +265,11 @@ impl Type for Custom {
     }
     fn _has_refmut_attr(&'static self, attr: &str, ctx: &CompCtx) -> bool {
         let Some(field) = self.static_attr(attr, ctx) else {
-            return attr == "__base" || (self.nom_info(ctx).transparent && self.base()._has_mut_attr(attr, ctx));
+            return attr == "__base"
+                || (self.nom_info(ctx).transparent && self.base()._has_mut_attr(attr, ctx));
         };
         let Some(InterData::Function(FnData { mt, .. })) = field.inter_val else {
-            return false
+            return false;
         };
         assert!(field
             .data_type
@@ -295,7 +298,8 @@ impl Type for Custom {
             return if attr.0 == "__base" {
                 Ok(Value {
                     data_type: self.base().add_ref(false),
-                    loc: remove_unreachable(attr.1).map_or(val.loc, |loc| merge_spans(val.loc, loc)),
+                    loc: remove_unreachable(attr.1)
+                        .map_or(val.loc, |loc| merge_spans(val.loc, loc)),
                     ..val
                 })
             } else if self.nom_info(ctx).transparent {
@@ -303,10 +307,10 @@ impl Type for Custom {
                 self.base().attr(val, attr, ctx)
             } else {
                 Err(invalid_attr(&val, attr.0, attr.1))
-            }
+            };
         };
         let Some(InterData::Function(FnData { mt, .. })) = field.inter_val else {
-            return Err(invalid_attr(&val, attr.0, attr.1))
+            return Err(invalid_attr(&val, attr.0, attr.1));
         };
         assert!(field
             .data_type
@@ -350,7 +354,8 @@ impl Type for Custom {
             return if attr.0 == "__base" {
                 Ok(Value {
                     data_type: self.base().add_ref(true),
-                    loc: remove_unreachable(attr.1).map_or(val.loc, |loc| merge_spans(val.loc, loc)),
+                    loc: remove_unreachable(attr.1)
+                        .map_or(val.loc, |loc| merge_spans(val.loc, loc)),
                     ..val
                 })
             } else if self.nom_info(ctx).transparent {
@@ -358,10 +363,10 @@ impl Type for Custom {
                 self.base().attr(val, attr, ctx)
             } else {
                 Err(invalid_attr(&val, attr.0, attr.1))
-            }
+            };
         };
         let Some(InterData::Function(FnData { mt, .. })) = field.inter_val else {
-            return Err(invalid_attr(&val, attr.0, attr.1))
+            return Err(invalid_attr(&val, attr.0, attr.1));
         };
         assert!(field
             .data_type

--- a/cobalt-ast/src/value.rs
+++ b/cobalt-ast/src/value.rs
@@ -553,7 +553,7 @@ impl<'src, 'ctx> Value<'src, 'ctx> {
             self.comp_val
                 .as_ref()
                 .map(|v| v.into_pointer_value().get_name().to_bytes().to_owned())
-                .unwrap_or_else(Vec::new)
+                .unwrap_or_default()
                 .as_slice(),
         )?; // LLVM symbol name, null-terminated
         out.write_all(&[0])?;

--- a/cobalt-build/Cargo.toml
+++ b/cobalt-build/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = "1.0.40"
 llvm-sys = "160"
 lasso = { version = "0.7.2", features = ["multi-threaded"] }
 indexmap = "2.0.0"
-os_str_bytes = "6.5.0"
+os_str_bytes = { version = "6.6.1", features = ["conversions"] }
 toml = "0.8.0"
 bstr = "1.5.0"
 hashbrown = { version = "0.14.0", features = ["serde"] }

--- a/cobalt-build/src/cc.rs
+++ b/cobalt-build/src/cc.rs
@@ -165,9 +165,11 @@ impl CompileCommand {
             #[cfg(target_os = "linux")]
             'specific: {
                 let mut it = triple.split('-');
-                let Some(arch) = it.next() else {break 'specific};
-                let Some(_)    = it.next() else {break 'specific};
-                let Some(os)   = it.next() else {break 'specific};
+                let Some(arch) = it.next() else {
+                    break 'specific;
+                };
+                let Some(_) = it.next() else { break 'specific };
+                let Some(os) = it.next() else { break 'specific };
                 let trip = it.next().map_or_else(
                     || format!("{arch}-{os}"),
                     |info| format!("{arch}-{os}-{info}"),

--- a/cobalt-build/src/libs.rs
+++ b/cobalt-build/src/libs.rs
@@ -1,5 +1,4 @@
 use cobalt_ast::CompCtx;
-use cobalt_llvm::inkwell;
 use object::{write::Object, SectionKind};
 use os_str_bytes::OsStrBytes;
 use std::fmt;
@@ -17,8 +16,7 @@ impl fmt::Display for ConflictingDefs {
 impl std::error::Error for ConflictingDefs {}
 
 /// Create a new (write) Object for the given triple
-pub fn new_object<'a>(triple: &inkwell::targets::TargetTriple) -> Object<'a> {
-    let triple = triple.as_str().to_str().unwrap();
+pub fn new_object<'a>(triple: &str) -> Object<'a> {
     let components = triple.split('-').collect::<Vec<&str>>();
     use object::Architecture::*;
     use object::BinaryFormat::*;
@@ -73,8 +71,7 @@ pub fn new_object<'a>(triple: &inkwell::targets::TargetTriple) -> Object<'a> {
 /// - Apple formats to libname.dylib
 /// - Windows formats to name.dll
 /// - Anything else formats to libname.so
-pub fn format_lib(base: &str, triple: &inkwell::targets::TargetTriple, shared: bool) -> String {
-    let triple = triple.as_str().to_str().unwrap();
+pub fn format_lib(base: &str, triple: &str, shared: bool) -> String {
     let mut components = triple.split('-');
     if matches!(components.next(), Some("wasm" | "wasm32")) {
         format!("{base}.wasm")

--- a/cobalt-build/src/pkg.rs
+++ b/cobalt-build/src/pkg.rs
@@ -602,8 +602,8 @@ fn install_single(
             continue_build: false,
             rebuild: true,
             profile: "default",
-            triple: &inkwell::targets::TargetTriple::create(&opts.target),
-            link_dirs: vec![],
+            triple: &opts.target,
+            link_dirs: &[],
             no_default_link: false,
         },
     )?;

--- a/cobalt-cli/Cargo.toml
+++ b/cobalt-cli/Cargo.toml
@@ -28,7 +28,7 @@ human-repr = "1.1.0"
 object = { version = "0.32.0", features = ["write"] }
 ar = "0.9.0"
 ambassador = "0.3.5"
-os_str_bytes = "6.5.0"
+os_str_bytes = { version = "6.6.1", features = ["conversions"] }
 
 [[bin]]
 name = "co"

--- a/cobalt-cli/src/lib.rs
+++ b/cobalt-cli/src/lib.rs
@@ -826,13 +826,16 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
             } else {
                 Target::initialize_native(&INIT_NEEDED).map_err(anyhow::Error::msg)?
             }
-            let triple = triple.unwrap_or_else(|| {
-                TargetMachine::get_default_triple()
-                    .as_str()
-                    .to_string_lossy()
-                    .into_owned()
-            });
-            let trip = TargetTriple::create(&triple);
+            let (triple, trip) = triple.map_or_else(
+                || {
+                    let trip = TargetMachine::get_default_triple();
+                    (trip.as_str().to_string_lossy().into_owned(), trip)
+                },
+                |triple| {
+                    let trip = TargetTriple::create(&triple);
+                    (triple, trip)
+                },
+            );
             let target_machine = Target::from_triple(&trip)
                 .unwrap()
                 .create_target_machine(
@@ -857,7 +860,7 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                     ),
                     OutputType::Library | OutputType::Archive => libs::format_lib(
                         input.rfind('.').map_or(input.as_str(), |i| &input[..i]),
-                        &trip,
+                        &triple,
                         emit == OutputType::Library,
                     ),
                     OutputType::RawObject => format!(
@@ -979,7 +982,7 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                     OutputStream::new(output)?.write_all(&buf)?
                 }
                 OutputType::HeaderObj => {
-                    let mut obj = libs::new_object(&trip);
+                    let mut obj = libs::new_object(&triple);
                     let (vec, cg_time) = try_timeit(|| {
                         libs::populate_header(&mut obj, &ctx);
                         obj.write()
@@ -1042,7 +1045,7 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                         }
                         OutputType::Library => {
                             if let Some(output) = output {
-                                let mut obj = libs::new_object(&trip);
+                                let mut obj = libs::new_object(&triple);
                                 libs::populate_header(&mut obj, &ctx);
                                 let tmp1 = temp_file::with_contents(&obj.write()?);
                                 let tmp2 = temp_file::with_contents(mb.as_slice());
@@ -1070,7 +1073,7 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                                 ),
                                 slice,
                             )?;
-                            let mut obj = libs::new_object(&trip);
+                            let mut obj = libs::new_object(&triple);
                             libs::populate_header(&mut obj, &ctx);
                             let out = obj.write()?;
                             builder.append(
@@ -1466,11 +1469,8 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                 code
             };
             Target::initialize_native(&INIT_NEEDED).map_err(anyhow::Error::msg)?;
-            let triple = TargetMachine::get_default_triple()
-                .as_str()
-                .to_string_lossy()
-                .into_owned();
-            let trip = TargetTriple::create(&triple);
+            let trip = TargetMachine::get_default_triple();
+            trip.as_str().to_string_lossy().into_owned();
             let target_machine = Target::from_triple(&trip)
                 .unwrap()
                 .create_target_machine(
@@ -1495,9 +1495,11 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                 flags.word_size = size as u16;
             }
             let ctx = CompCtx::with_flags(&ink_ctx, &input, flags);
+            let trip = TargetMachine::get_default_triple();
+            let triple = trip.as_str().to_string_lossy();
             ctx.module.set_triple(&trip);
             let mut cc = cc::CompileCommand::new();
-            cc.target(&triple);
+            cc.target(&*triple);
             cc.link_dirs(link_dirs);
             cc.no_default_link = no_default_link;
             {
@@ -1717,13 +1719,16 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                 } else {
                     Target::initialize_native(&INIT_NEEDED).map_err(anyhow::Error::msg)?
                 }
-                let triple = triple.unwrap_or_else(|| {
-                    TargetMachine::get_default_triple()
-                        .as_str()
-                        .to_string_lossy()
-                        .into_owned()
-                });
-                let trip = TargetTriple::create(&triple);
+                let (triple, trip) = triple.map_or_else(
+                    || {
+                        let trip = TargetMachine::get_default_triple();
+                        (trip.as_str().to_string_lossy().into_owned(), trip)
+                    },
+                    |triple| {
+                        let trip = TargetTriple::create(&triple);
+                        (triple, trip)
+                    },
+                );
                 let target_machine = Target::from_triple(&trip)
                     .unwrap()
                     .create_target_machine(
@@ -1859,7 +1864,7 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                             }
                             OutputType::HeaderObj => {
                                 out.set_extension("coh.o");
-                                let mut obj = libs::new_object(&trip);
+                                let mut obj = libs::new_object(&triple);
                                 let (vec, cg_time) = try_timeit(|| {
                                     libs::populate_header(&mut obj, &ctx);
                                     obj.write()
@@ -1917,7 +1922,7 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                                         One(tmp)
                                     }
                                     OutputType::Library => {
-                                        let mut obj = libs::new_object(&trip);
+                                        let mut obj = libs::new_object(&triple);
                                         libs::populate_header(&mut obj, &ctx);
                                         let tmp1 = temp_file::with_contents(&obj.write()?);
                                         let tmp2 = temp_file::with_contents(mb.as_slice());
@@ -1962,7 +1967,7 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                     })
                     .collect::<anyhow::Result<Vec<_>>>()?;
                 if emit == OutputType::Archive {
-                    let mut obj = libs::new_object(&trip);
+                    let mut obj = libs::new_object(&triple);
                     libs::populate_header(&mut obj, &ctx);
                     let buf = obj.write()?;
                     archive.as_mut().unwrap().append(
@@ -2147,11 +2152,8 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                     }),
                 );
                 Target::initialize_native(&INIT_NEEDED).map_err(anyhow::Error::msg)?;
-                let triple = TargetMachine::get_default_triple()
-                    .as_str()
-                    .to_string_lossy()
-                    .into_owned();
-                let trip = TargetTriple::create(&triple);
+                let trip = TargetMachine::get_default_triple();
+                let triple = trip.as_str().to_string_lossy().into_owned();
                 let target_machine = Target::from_triple(&trip)
                     .unwrap()
                     .create_target_machine(
@@ -2434,11 +2436,8 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                     })
                     .collect::<anyhow::Result<Vec<String>>>()?;
                 Target::initialize_native(&INIT_NEEDED).map_err(anyhow::Error::msg)?;
-                let triple = TargetMachine::get_default_triple()
-                    .as_str()
-                    .to_string_lossy()
-                    .into_owned();
-                let trip = TargetTriple::create(&triple);
+                let trip = TargetMachine::get_default_triple();
+                let triple = trip.as_str().to_string_lossy().into_owned();
                 let target_machine = Target::from_triple(&trip)
                     .unwrap()
                     .create_target_machine(
@@ -2705,6 +2704,12 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                 } else {
                     Target::initialize_native(&INIT_NEEDED).map_err(anyhow::Error::msg)?
                 }
+                let triple = triple.unwrap_or_else(|| {
+                    TargetMachine::get_default_triple()
+                        .as_str()
+                        .to_string_lossy()
+                        .into_owned()
+                });
                 build::build(
                     project_data,
                     if targets.is_empty() {
@@ -2716,14 +2721,12 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                         source_dir: &source_dir,
                         build_dir: &build_dir,
                         profile: profile.as_deref().unwrap_or("default"),
-                        triple: &triple.map_or_else(TargetMachine::get_default_triple, |x| {
-                            TargetTriple::create(&x)
-                        }),
+                        triple: &triple,
                         continue_build: false,
                         continue_comp: false,
                         rebuild,
                         no_default_link,
-                        link_dirs: link_dirs.iter().map(|x| x.as_str()).collect(),
+                        link_dirs: &link_dirs.iter().map(Path::new).collect::<Vec<_>>(),
                     },
                 )?;
             }
@@ -2844,7 +2847,10 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                         Ok(t)
                     },
                 )?;
-                let triple = TargetMachine::get_default_triple();
+                let triple = TargetMachine::get_default_triple()
+                    .as_str()
+                    .to_string_lossy()
+                    .into_owned();
                 build::build(
                     project_data,
                     Some(vec![target.clone()]),
@@ -2857,16 +2863,11 @@ pub fn driver(cli: Cli) -> anyhow::Result<()> {
                         continue_comp: false,
                         rebuild,
                         no_default_link,
-                        link_dirs: link_dirs.iter().map(|x| x.as_str()).collect(),
+                        link_dirs: &link_dirs.iter().map(Path::new).collect::<Vec<_>>(),
                     },
                 )?;
                 let mut exe_path = build_dir;
-                if triple
-                    .as_str()
-                    .to_str()
-                    .ok()
-                    .map_or(false, |t| t.contains("windows"))
-                {
+                if triple.contains("windows") {
                     target.push_str(".exe");
                 }
                 exe_path.push(target);

--- a/cobalt-llvm/build.rs
+++ b/cobalt-llvm/build.rs
@@ -58,7 +58,7 @@ fn target_os_is(name: &str) -> bool {
 fn locate_llvm_config() -> Option<PathBuf> {
     let prefix = env::var_os(ENV_LLVM_PREFIX)
         .map(|p| PathBuf::from(p).join("bin"))
-        .unwrap_or_else(PathBuf::new);
+        .unwrap_or_default();
     for binary_name in llvm_config_binary_names() {
         let binary_name = prefix.join(binary_name);
         match llvm_version(&binary_name) {

--- a/cobalt-llvm/src/lib.rs
+++ b/cobalt-llvm/src/lib.rs
@@ -1,4 +1,4 @@
-pub use llvm_sys;
 pub use inkwell;
+pub use llvm_sys;
 
 pub const LLVM_VERSION: &str = env!("LLVM_VERSION");

--- a/cobalt-parser/Cargo.toml
+++ b/cobalt-parser/Cargo.toml
@@ -14,4 +14,4 @@ cobalt-utils = { path = "../cobalt-utils" }
 cobalt-ast = { path = "../cobalt-ast" }
 unicode-ident = "1.0.9"
 either = "1.8.1"
-chumsky = { version = "1.0.0-alpha.4", features = ["label"] }
+chumsky = { version = "=1.0.0-alpha.4", features = ["label"] }

--- a/cobalt-parser/src/lexer/tokenizer.rs
+++ b/cobalt-parser/src/lexer/tokenizer.rs
@@ -58,7 +58,7 @@ impl<'src> SourceReader<'src> {
         let mut tokens = Vec::new();
         let mut errors = Vec::new();
 
-        while let Some(c) = self.peek().map(|c| c.clone()) {
+        while let Some(&c) = self.peek() {
             match c {
                 ' ' | '\n' | '\t' => {
                     self.next_char();
@@ -563,8 +563,7 @@ impl<'src> SourceReader<'src> {
     fn eat_ident(&mut self) -> Result<Token<'src>, CobaltError<'src>> {
         let start_idx = self.index;
 
-        let option_c = self.peek().map(|c| c.clone());
-        if let Some(c) = option_c {
+        if let Some(&c) = self.peek() {
             if !(is_xid_start(c) || c == '_') {
                 self.next_char();
                 let err = CobaltError::ExpectedFound {
@@ -609,13 +608,8 @@ impl<'src> SourceReader<'src> {
         assert!(self.next_char() == Some('#'));
 
         let mut multiline_level = 0;
-        loop {
-            match self.next_char() {
-                Some('=') => {
-                    multiline_level += 1;
-                }
-                _ => break,
-            }
+        while let Some('=') = self.next_char() {
+            multiline_level += 1;
         }
 
         if multiline_level == 0 {

--- a/cobalt-parser/src/lib.rs
+++ b/cobalt-parser/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 use cobalt_ast::ast::TopLevelAST;
 use cobalt_errors::CobaltError;
 pub use lexer::SourceReader;
@@ -7,7 +8,7 @@ pub mod lexer;
 pub mod parser;
 pub mod utils;
 
-pub fn parse_str<'src>(src: &'src str) -> (Option<TopLevelAST<'src>>, Vec<CobaltError<'src>>) {
+pub fn parse_str(src: &str) -> (Option<TopLevelAST>, Vec<CobaltError>) {
     let mut reader = SourceReader::new(src);
     let mut errors = vec![];
     let tokenize_result = reader.tokenize();

--- a/cobalt-parser/src/parser/expr/mod.rs
+++ b/cobalt-parser/src/parser/expr/mod.rs
@@ -103,7 +103,7 @@ impl<'src> Parser<'src> {
                     state |= can_be_postfixed;
                 }
             }
-            TokenKind::OpenDelimiter(p) if p == Delimiter::Paren => {
+            TokenKind::OpenDelimiter(Delimiter::Paren) => {
                 let (parsed_expr, parsed_errors) = self.parse_paren_expr();
                 errors.extend(parsed_errors);
                 working_ast = parsed_expr;
@@ -113,7 +113,7 @@ impl<'src> Parser<'src> {
                 state |= can_be_indexed;
                 state |= can_be_postfixed;
             }
-            TokenKind::OpenDelimiter(b) if b == Delimiter::Brace => {
+            TokenKind::OpenDelimiter(Delimiter::Brace) => {
                 let (parsed_expr, parsed_errors) = self.parse_block_expr();
                 errors.extend(parsed_errors);
                 working_ast = parsed_expr;
@@ -400,7 +400,7 @@ impl<'src> Parser<'src> {
                     );
                 }
             },
-            TokenKind::Keyword(kw) if kw == Keyword::Mut => "mut",
+            TokenKind::Keyword(Keyword::Mut) => "mut",
             _ => {
                 errors.push(CobaltError::ExpectedFound {
                     ex: "unary operator",


### PR DESCRIPTION
All Clippy lints have been fixed, and this branch has been merged from `main` to fix the deprecation of `os_str_bytes` methods without the `conversions` feature (brought about in 6.6?)