### PR TITLE
Use better parameters for CLI

### DIFF
--- a/cobalt-cli/Cargo.toml
+++ b/cobalt-cli/Cargo.toml
@@ -27,8 +27,8 @@ const_format = "0.2.32"
 human-repr = "1.1.0"
 object = { version = "0.32.1", features = ["write"] }
 ar = "0.9.0"
-ambassador = "0.3.5"
 os_str_bytes = { version = "6.6.1", features = ["conversions"] }
+clio = { version = "0.3.4", features = ["clap-parse"] }
 
 [[bin]]
 name = "co"

--- a/cobalt-cli/Cargo.toml
+++ b/cobalt-cli/Cargo.toml
@@ -33,3 +33,6 @@ clio = { version = "0.3.4", features = ["clap-parse"] }
 [[bin]]
 name = "co"
 path = "src/main.rs"
+
+[features]
+http = ["clio/http-ureq"]


### PR DESCRIPTION
The CLI takes multiple parameters, which were previously required to be strings. Now, `clio` is used to parse them more nicely, and give clearer errors about missing files.