### PR TITLE
Add symbols

### DIFF
--- a/cobalt-ast/src/ast/misc.rs
+++ b/cobalt-ast/src/ast/misc.rs
@@ -321,3 +321,33 @@ impl<'src> AST<'src> for ParenAST<'src> {
         self.base.print_impl(f, pre, file)
     }
 }
+#[derive(Debug, Clone)]
+pub struct SymbolAST<'src> {
+    pub loc: SourceSpan,
+    pub val: Cow<'src, [u8]>,
+}
+impl<'src> SymbolAST<'src> {
+    pub fn new(loc: SourceSpan, val: Cow<'src, [u8]>) -> Self {
+        SymbolAST { loc, val }
+    }
+}
+impl<'src> AST<'src> for SymbolAST<'src> {
+    fn loc(&self) -> SourceSpan {
+        self.loc
+    }
+    fn codegen_impl<'ctx>(
+        &self,
+        _ctx: &CompCtx<'src, 'ctx>,
+        _errs: &mut Vec<CobaltError<'src>>,
+    ) -> Value<'src, 'ctx> {
+        Value::new(None, None, types::Symbol::new_ref(&self.val))
+    }
+    fn print_impl(
+        &self,
+        f: &mut std::fmt::Formatter,
+        _pre: &mut TreePrefix,
+        _file: Option<CobaltFile>,
+    ) -> std::fmt::Result {
+        write!(f, "symbol: {:?}", bstr::BStr::new(&self.val))
+    }
+}

--- a/cobalt-ast/src/ast/misc.rs
+++ b/cobalt-ast/src/ast/misc.rs
@@ -348,6 +348,6 @@ impl<'src> AST<'src> for SymbolAST<'src> {
         _pre: &mut TreePrefix,
         _file: Option<CobaltFile>,
     ) -> std::fmt::Result {
-        write!(f, "symbol: {:?}", bstr::BStr::new(&self.val))
+        writeln!(f, "symbol: {:?}", bstr::BStr::new(&self.val))
     }
 }

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![allow(unused_variables, ambiguous_glob_reexports)]
 use crate::*;
 use inkwell::types::{BasicType, BasicTypeEnum};
 use inkwell::values::{BasicValueEnum, FunctionValue};

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -776,6 +776,6 @@ pub use func::*;
 pub use int::*;
 pub use intrinsic::*;
 pub use mem::*;
-pub use meta::*;
+pub use meta::{Symbol, *};
 
 use ref_cast::*;

--- a/cobalt-parser/src/lexer/tokens.rs
+++ b/cobalt-parser/src/lexer/tokens.rs
@@ -199,6 +199,8 @@ pub enum LiteralToken<'src> {
     Str(&'src str),
     /// The slice includes the single quotes.
     Char(&'src str),
+    /// The slice included the `$` and possibly the quotes.
+    Symbol(&'src str),
 }
 impl<'src> LiteralToken<'src> {
     pub fn as_str(self) -> &'src str {
@@ -206,7 +208,8 @@ impl<'src> LiteralToken<'src> {
             LiteralToken::Int(s)
             | LiteralToken::Float(s)
             | LiteralToken::Str(s)
-            | LiteralToken::Char(s) => s,
+            | LiteralToken::Char(s)
+            | LiteralToken::Symbol(s) => s,
         }
     }
 }

--- a/cobalt-parser/src/parser/expr/literal.rs
+++ b/cobalt-parser/src/parser/expr/literal.rs
@@ -598,6 +598,8 @@ impl<'src> Parser<'src> {
 
         let bytes = Self::parse_string_bytes(s, span, errors)?;
 
+        self.next();
+
         Some(StringLiteralAST::new(span, bytes, None))
     }
 }

--- a/cobalt-parser/src/parser/expr/literal.rs
+++ b/cobalt-parser/src/parser/expr/literal.rs
@@ -146,6 +146,21 @@ impl<'src> Parser<'src> {
                 return Box::new(ast);
             }
 
+            TokenKind::Literal(LiteralToken::Symbol(s)) => {
+                let s = s[1..].trim_start();
+                let val = if s.as_bytes()[0] == b'"' {
+                    if let Some(bytes) = Self::parse_string_bytes(s, span, errors) {
+                        Cow::Owned(bytes)
+                    } else {
+                        return Box::new(ErrorAST::new(span));
+                    }
+                } else {
+                    Cow::Borrowed(s.as_bytes())
+                };
+                self.next();
+                return Box::new(SymbolAST::new(span, val));
+            }
+
             _ => {}
         }
 
@@ -469,27 +484,12 @@ impl<'src> Parser<'src> {
         Some(CharLiteralAST::new(span, val, None))
     }
 
-    /// Going into this function, expect current token to be 'LiteralToken::Str'.
-    pub(crate) fn parse_string_literal(
-        &mut self,
+    pub(crate) fn parse_string_bytes(
+        s: &'src str,
+        span: SourceSpan,
         errors: &mut Vec<CobaltError<'src>>,
-    ) -> Option<StringLiteralAST<'src>> {
-        let current = self.current_token.unwrap();
-
-        let span = current.span;
-
-        let TokenKind::Literal(LiteralToken::Str(s)) = current.kind else {
-            self.next();
-            errors.push(CobaltError::ExpectedFound {
-                ex: "string literal",
-                found: Some(self.current_token.unwrap().kind.as_str().into()),
-                loc: span,
-            });
-            return None;
-        };
+    ) -> Option<Vec<u8>> {
         let mut char_indices = s[1..(s.len() - 1)].char_indices().peekable();
-
-        self.next();
 
         // ---
         let mut bytes = vec![];
@@ -573,6 +573,30 @@ impl<'src> Parser<'src> {
             };
             bytes.extend(cbi);
         }
+
+        Some(bytes)
+    }
+
+    /// Going into this function, expect current token to be 'LiteralToken::Str'.
+    pub(crate) fn parse_string_literal(
+        &mut self,
+        errors: &mut Vec<CobaltError<'src>>,
+    ) -> Option<StringLiteralAST<'src>> {
+        let current = self.current_token.unwrap();
+
+        let span = current.span;
+
+        let TokenKind::Literal(LiteralToken::Str(s)) = current.kind else {
+            self.next();
+            errors.push(CobaltError::ExpectedFound {
+                ex: "string literal",
+                found: Some(self.current_token.unwrap().kind.as_str().into()),
+                loc: span,
+            });
+            return None;
+        };
+
+        let bytes = Self::parse_string_bytes(s, span, errors)?;
 
         Some(StringLiteralAST::new(span, bytes, None))
     }

--- a/cobalt-parser/src/tests/parser/expr/literals.rs
+++ b/cobalt-parser/src/tests/parser/expr/literals.rs
@@ -57,3 +57,14 @@ fn test_parse_char_literal() {
         parser.parse_char_literal(errors)
     });
 }
+
+#[test]
+fn test_symbol_literal() {
+    test_parser_fn(r#"$abc"#, true, |parser, errors| {
+        parser.parse_literal(errors)
+    });
+
+    test_parser_fn(r#"$"abc\ndef""#, true, |parser, errors| {
+        parser.parse_literal(errors)
+    });
+}


### PR DESCRIPTION
Symbol types are ZSTs that encode a string into their type information. They will have more metaprogramming applications once generics and traits are implemented.