### PR TITLE
Add alternate bases for integer literals

### DIFF
--- a/cobalt-errors/src/error.rs
+++ b/cobalt-errors/src/error.rs
@@ -49,8 +49,14 @@ pub enum CobaltError<'src> {
         #[label("previously defined here")]
         prev: SourceSpan,
     },
-
-    #[error("unexpected character {ch}")]
+    #[error("invalid character {ch:?} in base-{base} literal")]
+    InvalidCharInLiteral {
+        ch: char,
+        base: u8,
+        #[label]
+        loc: SourceSpan,
+    },
+    #[error("unexpected character {ch:?}")]
     UnexpectedChar {
         #[label]
         loc: SourceSpan,

--- a/cobalt-parser/src/lexer/tokenizer.rs
+++ b/cobalt-parser/src/lexer/tokenizer.rs
@@ -488,13 +488,13 @@ impl<'src> SourceReader<'src> {
                 // alt. base int. literals
                 '0' => {
                     let start = self.index;
-                    
+
                     self.next_char();
                     let (base, alt) = match self.peek() {
                         Some(&'x') => (16, true),
                         Some(&'o') => (8, true),
                         Some(&'b') => (2, true),
-                        _ => (10, false)
+                        _ => (10, false),
                     };
                     if alt {
                         self.next_char();
@@ -511,7 +511,7 @@ impl<'src> SourceReader<'src> {
                                 errors.push(CobaltError::InvalidCharInLiteral {
                                     ch,
                                     base,
-                                    loc: (self.index, 1).into()
+                                    loc: (self.index, 1).into(),
                                 });
                                 while self.peek().map_or(false, char::is_ascii_digit) {
                                     self.next_char();
@@ -529,9 +529,7 @@ impl<'src> SourceReader<'src> {
                     } else {
                         // Not a float.
                         tokens.push(Token {
-                            kind: TokenKind::Literal(LiteralToken::Int(
-                                &self.source[start..end],
-                            )),
+                            kind: TokenKind::Literal(LiteralToken::Int(&self.source[start..end])),
                             span: (start..end).into(),
                         });
                         continue;

--- a/cobalt-parser/src/parser/expr/literal.rs
+++ b/cobalt-parser/src/parser/expr/literal.rs
@@ -1,6 +1,6 @@
-use std::iter::Peekable;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::iter::Peekable;
 use std::str::CharIndices;
 
 use cobalt_ast::ast::*;
@@ -46,7 +46,7 @@ impl<'src> Parser<'src> {
                     Some(&b'x') => i128::from_str_radix(&s[2..], 16),
                     Some(&b'o') => i128::from_str_radix(&s[2..], 8),
                     Some(&b'b') => i128::from_str_radix(&s[2..], 2),
-                    _ => s.parse::<i128>()
+                    _ => s.parse::<i128>(),
                 };
 
                 let parsed_int = parsed_int.unwrap_or_else(|_| {
@@ -84,11 +84,7 @@ impl<'src> Parser<'src> {
                     0.0
                 });
 
-                return Box::new(FloatLiteralAST::new(
-                    span,
-                    parsed_float,
-                    suffix,
-                ));
+                return Box::new(FloatLiteralAST::new(span, parsed_float, suffix));
             }
 
             TokenKind::Literal(LiteralToken::Char(_)) => {


### PR DESCRIPTION
Fixes #129.
`0x`, `0o`, and `0b` can be used as integer literal prefixes now.
