### PR TITLE
Merge intrinsic/annotation tokens into one

### DIFF
--- a/cobalt-parser/src/lexer/tokenizer.rs
+++ b/cobalt-parser/src/lexer/tokenizer.rs
@@ -74,7 +74,12 @@ impl<'src> TokenStream<'src> {
     }
 }
 impl<'src> SourceReader<'src> {
-    pub fn eat_tokens(&mut self, tokens: &mut Vec<Token<'src>>, errors: &mut Vec<CobaltError<'src>>, max_idx: usize) -> usize {
+    pub fn eat_tokens(
+        &mut self,
+        tokens: &mut Vec<Token<'src>>,
+        errors: &mut Vec<CobaltError<'src>>,
+        max_idx: usize,
+    ) -> usize {
         let starting_len = tokens.len();
         while let Some(c) = self.peek() {
             if self.index >= max_idx {
@@ -741,7 +746,7 @@ impl<'src> SourceReader<'src> {
                         });
                         continue;
                     }
-                    
+
                     let idx0 = self.index;
 
                     // Eat the '('.
@@ -769,7 +774,7 @@ impl<'src> SourceReader<'src> {
                     self.next_char();
 
                     let arg = &self.source[arg_span_start..arg_span_end];
-                    
+
                     let idx1 = std::mem::replace(&mut self.index, idx0);
 
                     let len = self.eat_tokens(tokens, errors, idx1);
@@ -844,7 +849,6 @@ impl<'src> SourceReader<'src> {
                 }
             }
         }
-        
 
         tokens.len() - starting_len
     }

--- a/cobalt-parser/src/lexer/tokenizer.rs
+++ b/cobalt-parser/src/lexer/tokenizer.rs
@@ -75,6 +75,12 @@ impl<'src> TokenStream<'src> {
     }
 }
 impl<'src> SourceReader<'src> {
+    /// Advance self by reading tokens, stopping at the source index of `max_idx`
+    /// Tokens and errors are stored in the given lists, and the number of tokens consumed is
+    /// returned.
+    ///
+    /// You generally shouldn't have to call this in a public API, but it might be useful if you
+    /// already have token and error vectors and want to be efficient with allocations.
     pub fn eat_tokens(
         &mut self,
         tokens: &mut Vec<Token<'src>>,
@@ -863,6 +869,8 @@ impl<'src> SourceReader<'src> {
         tokens.len() - starting_len
     }
 
+    /// Tokenize the input, returning a token stream and the given input.
+    /// This is most commonly the entry point for the lexer.
     pub fn tokenize(&mut self) -> (TokenStream<'src>, Vec<CobaltError<'src>>) {
         let mut tokens = Vec::new();
         let mut errors = Vec::new();

--- a/cobalt-parser/src/lexer/tokens.rs
+++ b/cobalt-parser/src/lexer/tokens.rs
@@ -228,8 +228,7 @@ pub enum TokenKind<'src> {
     BinOp(BinOpToken),
     UnOrBinOp(UnOrBinOpToken),
     Literal(LiteralToken<'src>),
-    Intrinsic(&'src str),
-    Annotation((&'src str, Option<&'src str>)),
+    IntrinOrAnn((&'src str, Option<&'src str>, usize)),
     Dot,
 }
 
@@ -298,8 +297,7 @@ impl<'src> TokenKind<'src> {
             BinOp(op) => op.as_str(),
             UnOrBinOp(op) => op.as_str(),
             Literal(lit) => lit.as_str(),
-            Intrinsic(name) => name,
-            Annotation(..) => "annotation",
+            IntrinOrAnn(..) => "intrinsic/annotation",
             Dot => ".",
         }
     }

--- a/cobalt-parser/src/parser/annotations.rs
+++ b/cobalt-parser/src/parser/annotations.rs
@@ -7,16 +7,16 @@ impl<'src> Parser<'src> {
         assert!(matches!(
             self.current_token,
             Some(Token {
-                kind: TokenKind::Annotation(..),
+                kind: TokenKind::IntrinOrAnn(..),
                 ..
             })
         ));
 
         let span = self.current_token.unwrap().span;
-        let TokenKind::Annotation((name_src, option_arg_src)) = self.current_token.unwrap().kind
-        else {
+        let TokenKind::IntrinOrAnn((name_src, option_arg_src, skip)) = self.current_token.unwrap().kind else {
             unreachable!()
         };
+        self.cursor.index += skip;
         self.next();
 
         let name = Cow::Borrowed(name_src);
@@ -32,7 +32,7 @@ impl<'src> Parser<'src> {
     /// the last annotation in the collection.
     pub fn eat_annotations(&mut self) {
         while let Some(Token {
-            kind: TokenKind::Annotation(..),
+            kind: TokenKind::IntrinOrAnn(..),
             ..
         }) = self.current_token
         {
@@ -53,7 +53,7 @@ impl<'src> Parser<'src> {
         while matches!(
             self.current_token,
             Some(Token {
-                kind: TokenKind::Annotation(..),
+                kind: TokenKind::IntrinOrAnn(..),
                 ..
             })
         ) {

--- a/cobalt-parser/src/parser/annotations.rs
+++ b/cobalt-parser/src/parser/annotations.rs
@@ -13,7 +13,9 @@ impl<'src> Parser<'src> {
         ));
 
         let span = self.current_token.unwrap().span;
-        let TokenKind::IntrinOrAnn((name_src, option_arg_src, skip)) = self.current_token.unwrap().kind else {
+        let TokenKind::IntrinOrAnn((name_src, option_arg_src, skip)) =
+            self.current_token.unwrap().kind
+        else {
             unreachable!()
         };
         self.cursor.index += skip;

--- a/cobalt-parser/src/parser/decl.rs
+++ b/cobalt-parser/src/parser/decl.rs
@@ -150,7 +150,7 @@ impl<'src> Parser<'src> {
                     break;
                 }
                 Some(Token {
-                    kind: TokenKind::Annotation(..),
+                    kind: TokenKind::IntrinOrAnn(..),
                     ..
                 }) => {
                     let _ = self.parse_annotation();

--- a/cobalt-parser/src/parser/expr/mod.rs
+++ b/cobalt-parser/src/parser/expr/mod.rs
@@ -126,7 +126,7 @@ impl<'src> Parser<'src> {
 
                 parsed_something = true;
             }
-            TokenKind::Intrinsic(..) => {
+            TokenKind::IntrinOrAnn(..) => {
                 working_ast = self.parse_intrinsic();
 
                 parsed_something = true;
@@ -304,7 +304,7 @@ impl<'src> Parser<'src> {
                 self.next();
                 Box::new(DotAST::new(target, (ident.into(), span)))
             }
-            TokenKind::Intrinsic(name) => {
+            TokenKind::IntrinOrAnn((name, _, _)) => {
                 let iloc = current.span;
                 self.next();
                 Box::new(CallAST::new(
@@ -943,7 +943,7 @@ impl<'src> Parser<'src> {
     /// ```
     pub(crate) fn parse_intrinsic(&mut self) -> BoxedAST<'src> {
         let Some(Token {
-            kind: TokenKind::Intrinsic(name_src),
+            kind: TokenKind::IntrinOrAnn((name_src, _, _)),
             span,
         }) = self.current_token
         else {

--- a/cobalt-parser/src/parser/mod.rs
+++ b/cobalt-parser/src/parser/mod.rs
@@ -34,6 +34,7 @@ pub use decl::DeclLoc;
 
 /// This is what the parser uses to iterate over the tokens. Since the `TokenStream`
 /// is immutable, we need to keep track of the index of the next token to be returned.
+#[derive(Debug, Clone)]
 pub struct TokenStreamCursor<'src> {
     stream: TokenStream<'src>,
     /// The index of the next token to be returned.
@@ -68,6 +69,7 @@ impl<'src> TokenStreamCursor<'src> {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Parser<'src> {
     cursor: TokenStreamCursor<'src>,
     current_token: Option<Token<'src>>,

--- a/cobalt-parser/src/parser/top_level.rs
+++ b/cobalt-parser/src/parser/top_level.rs
@@ -39,7 +39,7 @@ impl<'src> Parser<'src> {
                     break;
                 }
                 Some(Token {
-                    kind: TokenKind::Annotation(..),
+                    kind: TokenKind::IntrinOrAnn(..),
                     ..
                 }) => {
                     let _ = self.parse_annotation();


### PR DESCRIPTION
This fixes #137, read about the issue and change there.

#137 descrition:
> As of right now, there are separate `TokenKind`s for intrinsics and annotations, despite being difficult to tell apart at the lexing phase. As a workaround, the intrinsics registry is checked, but this has a problem: it assumes that anything not recognized is an annotation.
> 
> While this could be manageable on its own, the error doesn't print correctly for some reason. This makes it difficult to tell what went wrong or where the error is, which could easily detract from Cobalt's usability.
> 
> To fix this, I propose merging the `Intrinsic` and `Annotation` variants into `IntrinOrAnn(&'src str, &'src str, usize)`. When lexing, the tokenizer will lex the annotation arguments, roll back to the start, lex it as _tokens_, then store the token count. In the case of an annotation, the following tokens can be skipped, and for an intrinsic, the extra fields can be ignored.